### PR TITLE
add macOS support

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-Wl,-rpath,/opt/intel/oneapi/compiler/latest/mac/compiler/lib"]


### PR DESCRIPTION
Closes https://github.com/coreylowman/dfdx/issues/66

Tested on macOS 12.4 with MBP 14 Intel with all features (`mkl-static-iomp`, `mkl-static-seq`, `mkl-dynamic-iomp`, `mkl-dynamic-seq`) and without any of them.