### PR TITLE
Simplifying implementation of BCE loss using binary_map

### DIFF
--- a/src/losses.rs
+++ b/src/losses.rs
@@ -98,7 +98,7 @@ pub fn kl_div_with_logits_loss<T: Tensor<Dtype = f32>>(
 ///
 /// # Numerically Stable Derivation
 ///
-/// See https://www.tensorflow.org/api_docs/python/tf/nn/sigmoid_cross_entropy_with_logits
+/// See <https://www.tensorflow.org/api_docs/python/tf/nn/sigmoid_cross_entropy_with_logits>
 /// for more information on this.
 pub fn binary_cross_entropy_with_logits_loss<T: Tensor<Dtype = f32>>(
     logits: T,

--- a/src/tensor_ops/binary_map.rs
+++ b/src/tensor_ops/binary_map.rs
@@ -78,7 +78,7 @@ pub(super) mod minimum {
 /// to a pair of [Tensor]s `lhs` and `rhs.
 ///
 /// This is primarily used to implement [add()], [sub()], [mul()], and [div()].
-pub(super) fn binary_map<T: Tensor<Dtype = f32>>(
+pub(crate) fn binary_map<T: Tensor<Dtype = f32>>(
     mut lhs: T,
     rhs: &T::NoTape,
     f: fn(&f32, &f32) -> f32,


### PR DESCRIPTION
This implementation is much easier to understand, and also *allocates nothing*! The old implementation allocated an extra tensor for storing the max value. This also moves to using the tensorflow derivation of f(x) with `max(x, 0)` and `-abs(x)`