### PR TITLE
Add `trait ModuleMut`

### DIFF
--- a/src/nn/activations.rs
+++ b/src/nn/activations.rs
@@ -26,6 +26,16 @@ macro_rules! activation_impls {
                 $func_name(input)
             }
         }
+
+        impl<T> ModuleMut<T> for $struct_name
+        where
+            Self: Module<T>,
+        {
+            type Output = <Self as Module<T>>::Output;
+            fn forward_mut(&mut self, input: T) -> Self::Output {
+                self.forward(input)
+            }
+        }
     };
 }
 
@@ -61,6 +71,16 @@ impl<T: Reduce1<-1>> Module<T> for Softmax {
     type Output = T;
     fn forward(&self, input: T) -> Self::Output {
         softmax(input)
+    }
+}
+
+impl<T> ModuleMut<T> for Softmax
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
     }
 }
 

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -176,6 +176,24 @@ where
     }
 }
 
+impl<
+        T,
+        const IN_CHAN: usize,
+        const OUT_CHAN: usize,
+        const KERNEL_SIZE: usize,
+        const STRIDE: usize,
+        const PADDING: usize,
+    > ModuleMut<T> for Conv2D<IN_CHAN, OUT_CHAN, KERNEL_SIZE, STRIDE, PADDING>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/nn/dropout.rs
+++ b/src/nn/dropout.rs
@@ -1,18 +1,19 @@
 use crate::prelude::*;
 use rand::{prelude::StdRng, Rng, SeedableRng};
 
-/// A [Module<Tensor>] that calls [dropout()] in [Module::forward()] with probability `1.0 / N`.
-/// Note that [dropout()] does not do anything for tensors with [NoneTape].
+/// A [Module<Tensor>] that calls [dropout()] in [ModuleMut::forward_mut()] with probability `1.0 / N`.
+/// It is the identity function in [Module::forward()]. Note that [dropout()] does not do anything
+/// for tensors with [NoneTape], even in [ModuleMut].
 ///
-/// # Generics
+/// Generics
 /// - `N`: p is set as `1.0 / N`
 ///
-/// # Examples
+/// Examples
 /// ```rust
 /// # use dfdx::prelude::*;
-/// let dropout: DropoutOneIn<2> = Default::default();
+/// let mut dropout: DropoutOneIn<2> = Default::default();
 /// let t: Tensor2D<2, 5> = Tensor2D::ones();
-/// let r = dropout.forward(t.trace());
+/// let r = dropout.forward_mut(t.trace());
 /// assert_eq!(r.data(), &[[2.0, 2.0, 2.0, 0.0, 0.0], [2.0, 2.0, 0.0, 0.0, 2.0]]);
 /// ```
 #[derive(Clone, Debug)]
@@ -61,16 +62,13 @@ impl<const N: usize, T: Tensor<Dtype = f32, OwnedTape = T>> ModuleMut<T> for Dro
     }
 }
 
-/// A [Module<Tensor>] that calls [dropout()] in [Module::forward()] with probability `self.p`.
+/// A [Module<Tensor>] that calls [dropout()] in [ModuleMut::forward_mut()] with probability `self.p`.
+/// It is the identity function in [Module::forward()].
 ///
 /// This also implements [Module<(Tensor, Rng)>] if you want to pass in an [Rng] externally, though
 /// this may be harder to use and infect other modules.
 ///
 /// [Default] is implemented as `p=0.5` and seeds.
-///
-/// Implementation details:
-/// This stores the [Rng] in a [RefCell] to maintain compatibility with forward taking
-/// a non-mutable reference to self.
 ///
 /// Example:
 ///

--- a/src/nn/dropout.rs
+++ b/src/nn/dropout.rs
@@ -43,7 +43,7 @@ impl<const N: usize> ResetParams for DropoutOneIn<N> {
 impl<const N: usize> SaveToNpz for DropoutOneIn<N> {}
 impl<const N: usize> LoadFromNpz for DropoutOneIn<N> {}
 
-impl<const N: usize, T: Tensor<Dtype = f32, Tape = NoneTape>> Module<T> for DropoutOneIn<N> {
+impl<const N: usize, T: Tensor<Dtype = f32, NoTape = T>> Module<T> for DropoutOneIn<N> {
     type Output = T;
 
     /// Identity function
@@ -52,7 +52,7 @@ impl<const N: usize, T: Tensor<Dtype = f32, Tape = NoneTape>> Module<T> for Drop
     }
 }
 
-impl<const N: usize, T: Tensor<Dtype = f32, Tape = OwnedTape>> ModuleMut<T> for DropoutOneIn<N> {
+impl<const N: usize, T: Tensor<Dtype = f32, OwnedTape = T>> ModuleMut<T> for DropoutOneIn<N> {
     type Output = T;
 
     /// Calls [dropout()] with `p=1/N` using `self.rng`.
@@ -136,7 +136,7 @@ impl ResetParams for Dropout {
 impl SaveToNpz for Dropout {}
 impl LoadFromNpz for Dropout {}
 
-impl<T: Tensor<Dtype = f32, Tape = NoneTape>> Module<T> for Dropout {
+impl<T: Tensor<Dtype = f32, NoTape = T>> Module<T> for Dropout {
     type Output = T;
 
     /// Identity function
@@ -144,7 +144,7 @@ impl<T: Tensor<Dtype = f32, Tape = NoneTape>> Module<T> for Dropout {
         input
     }
 }
-impl<T: Tensor<Dtype = f32, Tape = OwnedTape>> ModuleMut<T> for Dropout {
+impl<T: Tensor<Dtype = f32, OwnedTape = T>> ModuleMut<T> for Dropout {
     type Output = T;
 
     /// Identity function
@@ -153,7 +153,7 @@ impl<T: Tensor<Dtype = f32, Tape = OwnedTape>> ModuleMut<T> for Dropout {
     }
 }
 
-impl<R: Rng, T: Tensor<Dtype = f32, Tape = NoneTape>> Module<(T, R)> for Dropout {
+impl<R: Rng, T: Tensor<Dtype = f32, NoTape = T>> Module<(T, R)> for Dropout {
     type Output = (T, R);
 
     /// Identity function
@@ -162,7 +162,7 @@ impl<R: Rng, T: Tensor<Dtype = f32, Tape = NoneTape>> Module<(T, R)> for Dropout
     }
 }
 
-impl<R: Rng, T: Tensor<Dtype = f32, Tape = OwnedTape>> ModuleMut<(T, R)> for Dropout {
+impl<R: Rng, T: Tensor<Dtype = f32, OwnedTape = T>> ModuleMut<(T, R)> for Dropout {
     type Output = (T, R);
 
     /// Calls [dropout()] using `input.1`.

--- a/src/nn/flatten.rs
+++ b/src/nn/flatten.rs
@@ -46,6 +46,17 @@ where
     }
 }
 
+impl<T> ModuleMut<T> for FlattenImage
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+
+    fn forward_mut(&mut self, t: T) -> Self::Output {
+        self.forward(t)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -59,34 +59,36 @@ where
     }
 }
 
+impl<T, F, R> ModuleMut<T> for GeneralizedResidual<F, R>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, t: T) -> Self::Output {
+        self.forward(t)
+    }
+}
+
 impl<F: SaveToNpz, R: SaveToNpz> SaveToNpz for GeneralizedResidual<F, R> {
     /// Pass through to `F`/`R`'s [SaveToNpz].
-    fn write<W>(
-        &self,
-        filename_prefix: &str,
-        w: &mut zip::ZipWriter<W>,
-    ) -> zip::result::ZipResult<()>
+    fn write<W>(&self, pre: &str, w: &mut zip::ZipWriter<W>) -> zip::result::ZipResult<()>
     where
         W: std::io::Write + std::io::Seek,
     {
-        self.0.write(&format!("{}_main", filename_prefix), w)?;
-        self.1.write(&format!("{}_residual", filename_prefix), w)?;
+        self.0.write(&format!("{}_main", pre), w)?;
+        self.1.write(&format!("{}_residual", pre), w)?;
         Ok(())
     }
 }
 
 impl<F: LoadFromNpz, R: LoadFromNpz> LoadFromNpz for GeneralizedResidual<F, R> {
     /// Pass through to `F`/`R`'s [LoadFromNpz].
-    fn read<READ>(
-        &mut self,
-        filename_prefix: &str,
-        r: &mut zip::ZipArchive<READ>,
-    ) -> Result<(), NpzError>
+    fn read<READ>(&mut self, pre: &str, r: &mut zip::ZipArchive<READ>) -> Result<(), NpzError>
     where
         READ: std::io::Read + std::io::Seek,
     {
-        self.0.read(&format!("{}_main", filename_prefix), r)?;
-        self.1.read(&format!("{}_residual", filename_prefix), r)?;
+        self.0.read(&format!("{}_main", pre), r)?;
+        self.1.read(&format!("{}_residual", pre), r)?;
         Ok(())
     }
 }

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -101,6 +101,16 @@ impl<H: Tape, const B: usize, const S: usize, const M: usize> Module<Tensor3D<B,
     }
 }
 
+impl<T, const M: usize> ModuleMut<T> for LayerNorm1D<M>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 impl<const M: usize> SaveToNpz for LayerNorm1D<M> {
     /// Saves [Self::gamma] to `{pre}gamma.npy` and [Self::beta] to `{pre}beta.npy`
     /// using [npz_fwrite()].

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -110,6 +110,16 @@ impl<const B: usize, const S: usize, const I: usize, const O: usize, H: Tape>
     }
 }
 
+impl<T, const I: usize, const O: usize> ModuleMut<T> for Linear<I, O>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -3,9 +3,9 @@
 //!
 //! # Mutable vs Immutable forwards
 //!
-//! [Module] provides two versions of forwards:
+//! There are two versions of forwards:
 //!
-//! 1. [Module::forward_mut()] which receives `&mut self`.
+//! 1. [ModuleMut::forward_mut()] which receives `&mut self`.
 //! 2. [Module::forward()] which receives `&self`.
 //!
 //! **This has nothing to do with whether gradients are being tracked or not**.
@@ -13,14 +13,14 @@
 //! and NoneTape can still be passed to both, and all modules should conform
 //! to this expected behavior.
 //!
-//! In general, [Module::forward_mut()] should be used during training,
+//! In general, [ModuleMut::forward_mut()] should be used during training,
 //! and [Module::forward()] during evaluation/testing/inference/validation.
 //!
 //! Here is a list of existing modules that have different behavior in these
 //! two functions:
 //!
-//! - [DropoutOneIn] (soon)
-//! - [Dropout] (soon)
+//! - [DropoutOneIn]
+//! - [Dropout]
 //!
 //! # Initializing
 //!

--- a/src/nn/repeated.rs
+++ b/src/nn/repeated.rs
@@ -94,6 +94,16 @@ impl<Input, T: Module<Input, Output = Input>, const N: usize> Module<Input> for 
     }
 }
 
+impl<T, Input, const N: usize> ModuleMut<Input> for Repeated<T, N>
+where
+    Self: Module<Input>,
+{
+    type Output = <Self as Module<Input>>::Output;
+    fn forward_mut(&mut self, input: Input) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -45,6 +45,16 @@ where
     }
 }
 
+impl<T, F> ModuleMut<T> for Residual<F>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 impl<F: SaveToNpz> SaveToNpz for Residual<F> {
     /// Pass through to `F`'s [SaveToNpz].
     fn write<W>(

--- a/src/nn/transformer/decoder.rs
+++ b/src/nn/transformer/decoder.rs
@@ -52,6 +52,17 @@ where
     }
 }
 
+impl<const M: usize, const H: usize, const F: usize, const L: usize, T> ModuleMut<T>
+    for TransformerDecoder<M, H, F, L>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 impl<const M: usize, const H: usize, const F: usize, const L: usize> SaveToNpz
     for TransformerDecoder<M, H, F, L>
 {
@@ -153,6 +164,17 @@ where
         let x = self.norm2.forward(x);
         let x = self.ff.forward(x);
         self.norm3.forward(x)
+    }
+}
+
+impl<const M: usize, const H: usize, const F: usize, T> ModuleMut<T>
+    for TransformerDecoderBlock<M, H, F>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
     }
 }
 

--- a/src/nn/transformer/encoder.rs
+++ b/src/nn/transformer/encoder.rs
@@ -92,6 +92,17 @@ where
     }
 }
 
+impl<const M: usize, const H: usize, const F: usize, T> ModuleMut<T>
+    for TransformerEncoderBlock<M, H, F>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 impl<const M: usize, const H: usize, const F: usize> SaveToNpz
     for TransformerEncoderBlock<M, H, F>
 {

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -200,6 +200,18 @@ where
     }
 }
 
+impl<T, const M: usize, const H: usize, const K: usize, const V: usize> ModuleMut<T>
+    for MultiHeadAttention<M, H, K, V>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/nn/transformer/transformer.rs
+++ b/src/nn/transformer/transformer.rs
@@ -74,6 +74,17 @@ where
     }
 }
 
+impl<const M: usize, const H: usize, const E: usize, const D: usize, const F: usize, T> ModuleMut<T>
+    for Transformer<M, H, E, D, F>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 impl<const M: usize, const H: usize, const E: usize, const D: usize, const F: usize> SaveToNpz
     for Transformer<M, H, E, D, F>
 {


### PR DESCRIPTION
Related to #78 #153 
Closes #149 

Changes:
1. Adds `trait ModuleMut` which has `fn forward_mut(&mut self, input: Input)`.
2. Removes ResetParams and CanUpdateWithGradients from requirements of Module
3. impl ModuleMut for Dropout structs based on #149 
4. Blanket impl ModuleMut for existing modules

This approach was previously discussed in #142 as an alternative to adding forward_mut to Module. However as we've seen in #153, simply adding forward_mut to Module allows some confusing permutations that compile but probably shouldn't. Instead of allowing weird combinations of things to happen, instead dfdx should just not compile.

Thoughts:
1. Enables module developers finer control over when self is mutably borrowed and over what inputs. This is a double edge sword because obviously this requires library developers to implement a second module trait. However as shown here it is easy to do a blanket impl for anything that impls Module.
5. Enables library developers to specify module inputs as either ModuleMut for training or Module for inference:
```rust
fn training<T, M: ModuleMut<T>>(module: &mut M) {
    ...
}

fn inference<T, M: Module<T>>(module: &M) {
    ...
}
```
6. Enables straightforward compile errors. Here is an example with the new dropout where the user calls `forward()` instead of `forward_mut()`

```rust
use dfdx::prelude::*;
fn main() {
    let mut m: (Linear<3, 3>, DropoutOneIn<2>, Linear<3, 3>) = Default::default();
    let a = m.forward(Tensor1D::<3>::zeros().trace());
}
```

```bash
error[E0271]: type mismatch resolving `<dfdx::tensor::Tensor1D<3_usize, OwnedTape> as Tensor>::NoTape == dfdx::tensor::Tensor1D<3_usize, OwnedTape>`
 --> examples\mutable.rs:5:15
  |
5 |     let a = m.forward(Tensor1D::<3>::zeros().trace());
  |               ^^^^^^^ expected struct `NoneTape`, found struct `OwnedTape`
  |
  = note: expected struct `dfdx::tensor::Tensor1D<NoneTape, _>`
             found struct `dfdx::tensor::Tensor1D<OwnedTape, _>`
  = note: required because of the requirements on the impl of `dfdx::nn::Module<dfdx::tensor::Tensor1D<3_usize, OwnedTape>>` for `dfdx::nn::DropoutOneIn<2_usize>`
  = note: 1 redundant requirement hidden
  = note: required because of the requirements on the impl of `dfdx::nn::Module<dfdx::tensor::Tensor1D<3_usize, OwnedTape>>` for `(dfdx::nn::Linear<3_usize, 3_usize>, dfdx::nn::DropoutOneIn<2_usize>, dfdx::nn::Linear<3_usize, 3_usize>)`
```
