### PR TITLE
Add Batched Select for devices and tensor_ops

### DIFF
--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -20,12 +20,7 @@ pub use reduce_all::*;
 pub use reduce_axis::*;
 pub use select::*;
 
-use std::marker::PhantomData;
 use std::ops::*;
-
-pub struct Index;
-pub struct Recurse<M>(PhantomData<*const M>);
-pub struct Broadcast<M>(PhantomData<*const M>);
 
 /// The CPU device
 pub struct Cpu;

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -20,7 +20,12 @@ pub use reduce_all::*;
 pub use reduce_axis::*;
 pub use select::*;
 
+use std::marker::PhantomData;
 use std::ops::*;
+
+pub struct Index;
+pub struct Recurse<M>(PhantomData<*const M>);
+pub struct Broadcast<M>(PhantomData<*const M>);
 
 /// The CPU device
 pub struct Cpu;

--- a/src/devices/select.rs
+++ b/src/devices/select.rs
@@ -19,16 +19,16 @@
 use super::{Cpu, ForEachElement};
 use crate::arrays::CountElements;
 
-pub mod modes {
+pub mod select_modes {
     pub struct Index;
     pub struct Recurse<const N: usize>;
     pub struct Broadcast<const N: usize>;
 }
 
-use modes::*;
+use select_modes::*;
 
 pub trait DeviceSelect<T, R, Mode> {
-    type Indices;
+    type Indices: Clone;
 
     /// Equivalent to psuedocode `out = inp[indices]`
     fn select_axis(inp: &T, indices: &Self::Indices, out: &mut R);

--- a/src/devices/select.rs
+++ b/src/devices/select.rs
@@ -47,6 +47,7 @@ pub(crate) type SelectAx2 = select_modes::Recurse<SelectAx1>;
 pub(crate) type SelectAx3 = select_modes::Recurse<SelectAx2>;
 pub(crate) type BSelectAx1 = select_modes::Broadcast<SelectAx0>;
 
+/// Select values from `T` using indices `I`. `Mode` is used to disambiguate the impl.
 pub trait DeviceSelect<T, I, Mode> {
     type Result;
 
@@ -57,6 +58,7 @@ pub trait DeviceSelect<T, I, Mode> {
     fn select_add(inp: &mut T, indices: &I, out: &Self::Result);
 }
 
+// Select 1 element from 0th axis.
 impl<T, const M: usize> DeviceSelect<[T; M], usize, Index> for Cpu
 where
     Self: ForEachElement<T>,
@@ -74,6 +76,7 @@ where
     }
 }
 
+// Select Z elements from 0th axis.
 impl<T, const M: usize, const Z: usize> DeviceSelect<[T; M], [usize; Z], Index> for Cpu
 where
     Self: ForEachElement<T>,
@@ -94,6 +97,7 @@ where
     }
 }
 
+// Select elements from non-zero axis
 impl<T, I, const M: usize, SubMode> DeviceSelect<[T; M], [I; M], Recurse<SubMode>> for Cpu
 where
     Self: DeviceSelect<T, I, SubMode>,
@@ -113,6 +117,7 @@ where
     }
 }
 
+// Broadcast select elements from non-zero axis.
 impl<T, I, const M: usize, SubMode> DeviceSelect<T, [I; M], Broadcast<SubMode>> for Cpu
 where
     Self: DeviceSelect<T, I, SubMode>,

--- a/src/devices/select.rs
+++ b/src/devices/select.rs
@@ -19,61 +19,74 @@
 use super::{Cpu, ForEachElement};
 use crate::arrays::CountElements;
 
-/// Select values from `T` using `Indices` and producing `R` along a single `AXIS`.
-pub trait SelectAlongAxis<T: CountElements, Indices, R: CountElements, const AXIS: isize> {
-    /// Equivalent to psuedocode `out = inp[indices]`
-    fn select_axis(inp: &T, indices: &Indices, out: &mut R);
-
-    /// `inp[indices] += out`
-    fn select_add(inp: &mut T, indices: &Indices, out: &R);
+pub mod modes {
+    pub struct Index;
+    pub struct Recurse<const N: usize>;
+    pub struct Broadcast<const N: usize>;
 }
 
-impl<T, const M: usize> SelectAlongAxis<[T; M], usize, T, 0> for Cpu
+use modes::*;
+
+pub trait DeviceSelect<T, I, Mode> {
+    type Result;
+
+    /// Equivalent to psuedocode `out = inp[indices]`
+    fn select_axis(inp: &T, indices: &I, out: &mut Self::Result);
+
+    /// `inp[indices] += out`
+    fn select_add(inp: &mut T, indices: &I, out: &Self::Result);
+}
+
+impl<T, const M: usize> DeviceSelect<[T; M], usize, Index> for Cpu
 where
     Self: ForEachElement<T>,
     T: Copy + CountElements,
     T::Dtype: for<'a> std::ops::AddAssign<&'a T::Dtype>,
 {
-    fn select_axis(inp: &[T; M], indices: &usize, out: &mut T) {
+    type Result = T;
+
+    fn select_axis(inp: &[T; M], indices: &usize, out: &mut Self::Result) {
         *out = inp[*indices];
     }
-    fn select_add(inp: &mut [T; M], indices: &usize, out: &T) {
+    fn select_add(inp: &mut [T; M], indices: &usize, out: &Self::Result) {
         Self::foreach_mr(&mut inp[*indices], out, &mut |a, b| *a += b);
     }
 }
 
-impl<T, const M: usize, const Z: usize> SelectAlongAxis<[T; M], [usize; Z], [T; Z], 0> for Cpu
+impl<T, const M: usize, const Z: usize> DeviceSelect<[T; M], [usize; Z], Index> for Cpu
 where
     Self: ForEachElement<T>,
     T: Copy + CountElements,
     T::Dtype: for<'a> std::ops::AddAssign<&'a T::Dtype>,
 {
-    fn select_axis(inp: &[T; M], indices: &[usize; Z], out: &mut [T; Z]) {
+    type Result = [T; Z];
+    fn select_axis(inp: &[T; M], indices: &[usize; Z], out: &mut Self::Result) {
         for z in 0..Z {
             out[z] = inp[indices[z]];
         }
     }
-    fn select_add(inp: &mut [T; M], indices: &[usize; Z], out: &[T; Z]) {
+
+    fn select_add(inp: &mut [T; M], indices: &[usize; Z], out: &Self::Result) {
         for z in 0..Z {
             Self::foreach_mr(&mut inp[indices[z]], &out[z], &mut |a, b| *a += b);
         }
     }
 }
 
-macro_rules! select_nz {
-    ($Axis:expr, $SubAxis:expr) => {
-        impl<T, I, R, const M: usize> SelectAlongAxis<[T; M], [I; M], [R; M], $Axis> for Cpu
+macro_rules! nd_recurse {
+    ($Mode:ty, $SubMode:ty) => {
+        impl<T, I, const M: usize> DeviceSelect<[T; M], [I; M], $Mode> for Cpu
         where
-            Self: SelectAlongAxis<T, I, R, $SubAxis>,
-            T: CountElements,
-            R: CountElements,
+            Self: DeviceSelect<T, I, $SubMode>,
         {
-            fn select_axis(inp: &[T; M], indices: &[I; M], out: &mut [R; M]) {
+            type Result = [<Self as DeviceSelect<T, I, $SubMode>>::Result; M];
+
+            fn select_axis(inp: &[T; M], indices: &[I; M], out: &mut Self::Result) {
                 for m in 0..M {
                     Self::select_axis(&inp[m], &indices[m], &mut out[m]);
                 }
             }
-            fn select_add(inp: &mut [T; M], indices: &[I; M], out: &[R; M]) {
+            fn select_add(inp: &mut [T; M], indices: &[I; M], out: &Self::Result) {
                 for m in 0..M {
                     Self::select_add(&mut inp[m], &indices[m], &out[m]);
                 }
@@ -82,9 +95,28 @@ macro_rules! select_nz {
     };
 }
 
-select_nz!(1, 0);
-select_nz!(2, 1);
-select_nz!(3, 2);
+nd_recurse!(Recurse<0>, Index);
+nd_recurse!(Recurse<1>, Recurse<0>);
+nd_recurse!(Recurse<2>, Recurse<1>);
+nd_recurse!(Recurse<3>, Recurse<2>);
+
+impl<T, I, const M: usize> DeviceSelect<T, [I; M], Broadcast<0>> for Cpu
+where
+    Self: DeviceSelect<T, I, Index>,
+{
+    type Result = [<Self as DeviceSelect<T, I, Index>>::Result; M];
+
+    fn select_axis(inp: &T, indices: &[I; M], out: &mut Self::Result) {
+        for m in 0..M {
+            Self::select_axis(inp, &indices[m], &mut out[m]);
+        }
+    }
+    fn select_add(inp: &mut T, indices: &[I; M], out: &Self::Result) {
+        for m in 0..M {
+            Self::select_add(inp, &indices[m], &out[m]);
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -101,9 +133,9 @@ mod tests {
 
     #[test]
     fn test_select_1d_0z() {
-        let a = [1.0, 2.0, 3.0];
+        let a = [1.0f32, 2.0, 3.0];
         let mut b = ZeroElements::ZEROS;
-        Cpu::select_axis(&a, &[0, 1, 2, 2, 1, 0], &mut b);
+        <Cpu as DeviceSelect<_, _, Index>>::select_axis(&a, &[0, 1, 2, 2, 1, 0], &mut b);
         assert_eq!(b, [1.0, 2.0, 3.0, 3.0, 2.0, 1.0]);
     }
 
@@ -121,7 +153,7 @@ mod tests {
     fn test_select_2d_0z() {
         let a = A_2D;
         let mut b = ZeroElements::ZEROS;
-        Cpu::select_axis(&a, &[0, 0, 1], &mut b);
+        <Cpu as DeviceSelect<_, _, Index>>::select_axis(&a, &[0, 0, 1], &mut b);
         assert_eq!(b, [a[0], a[0], a[1]]);
     }
 
@@ -129,7 +161,7 @@ mod tests {
     fn test_select_2d_1() {
         let a = A_2D;
         let mut b = ZeroElements::ZEROS;
-        <Cpu as SelectAlongAxis<_, _, _, 1>>::select_axis(&a, &[0, 1], &mut b);
+        <Cpu as DeviceSelect<_, _, Recurse<0>>>::select_axis(&a, &[0, 1], &mut b);
         assert_eq!(b, [1.0, 5.0]);
     }
 
@@ -137,8 +169,18 @@ mod tests {
     fn test_select_2d_1z() {
         let a = A_2D;
         let mut b = ZeroElements::ZEROS;
-        Cpu::select_axis(&a, &[[0, 2], [1, 1]], &mut b);
+        <Cpu as DeviceSelect<_, _, Recurse<0>>>::select_axis(&a, &[[0, 2], [1, 1]], &mut b);
         assert_eq!(b, [[1.0, 3.0], [5.0, 5.0]]);
+    }
+
+    #[test]
+    fn test_select_broadcast_2d() {
+        let a = [[1.0], [2.0]];
+        let i = [[0, 1, 0], [1, 1, 1], [0, 0, 0], [1, 0, 1]];
+        let mut b = ZeroElements::ZEROS;
+        <Cpu as DeviceSelect<_, _, Broadcast<0>>>::select_axis(&a, &i, &mut b);
+        #[rustfmt::skip]
+        assert_eq!(b, [[[1.], [2.], [1.]], [[2.], [2.], [2.]], [[1.], [1.], [1.]], [[2.], [1.], [2.]]]);
     }
 
     #[test]
@@ -146,7 +188,7 @@ mod tests {
         let mut a = [[0.0; 3]; 2];
         let b = [[1.0, 3.0], [5.0, 5.0]];
         let i = [[0, 2], [1, 1]];
-        Cpu::select_add(&mut a, &i, &b);
+        <Cpu as DeviceSelect<_, _, Recurse<0>>>::select_add(&mut a, &i, &b);
         assert_eq!(a, [[1.0, 0.0, 3.0], [0.0, 10.0, 0.0]]);
     }
 
@@ -169,7 +211,7 @@ mod tests {
     fn test_select_3d_0z() {
         let a = A_3D;
         let mut b = ZeroElements::ZEROS;
-        Cpu::select_axis(&a, &[0, 0, 1, 2, 3, 3], &mut b);
+        <Cpu as DeviceSelect<_, _, Index>>::select_axis(&a, &[0, 0, 1, 2, 3, 3], &mut b);
         assert_eq!(b, [A_3D[0], A_3D[0], A_3D[1], A_3D[2], A_3D[3], A_3D[3]]);
     }
 
@@ -177,7 +219,7 @@ mod tests {
     fn test_select_3d_1() {
         let a = A_3D;
         let mut b = ZeroElements::ZEROS;
-        <Cpu as SelectAlongAxis<_, _, _, 1>>::select_axis(&a, &[0, 0, 1, 1], &mut b);
+        <Cpu as DeviceSelect<_, _, Recurse<0>>>::select_axis(&a, &[0, 0, 1, 1], &mut b);
         assert_eq!(b, [A_3D[0][0], A_3D[1][0], A_3D[2][1], A_3D[3][1]]);
     }
 
@@ -185,7 +227,7 @@ mod tests {
     fn test_select_3d_1z() {
         let a = A_3D;
         let mut b = ZeroElements::ZEROS;
-        <Cpu as SelectAlongAxis<_, _, _, 1>>::select_axis(&a, &[[0], [0], [1], [1]], &mut b);
+        <Cpu as DeviceSelect<_, _, Recurse<0>>>::select_axis(&a, &[[0], [0], [1], [1]], &mut b);
         assert_eq!(b, [[A_3D[0][0]], [A_3D[1][0]], [A_3D[2][1]], [A_3D[3][1]]]);
     }
 
@@ -193,7 +235,7 @@ mod tests {
     fn test_select_3d_2() {
         let a = A_3D;
         let mut b = ZeroElements::ZEROS;
-        <Cpu as SelectAlongAxis<_, _, _, 2>>::select_axis(
+        <Cpu as DeviceSelect<_, _, Recurse<1>>>::select_axis(
             &a,
             &[[1, 0], [0, 1], [0, 0], [1, 1]],
             &mut b,
@@ -213,7 +255,7 @@ mod tests {
     fn test_select_3d_2z() {
         let a = A_3D;
         let mut b: [[[f32; 1]; 2]; 4] = ZeroElements::ZEROS;
-        <Cpu as SelectAlongAxis<_, _, _, 2>>::select_axis(
+        <Cpu as DeviceSelect<_, _, Recurse<1>>>::select_axis(
             &a,
             &[[[1], [0]], [[0], [1]], [[0], [0]], [[1], [1]]],
             &mut b,

--- a/src/devices/select.rs
+++ b/src/devices/select.rs
@@ -16,8 +16,19 @@
 //! Then all three arrays with have the same dimension as the 0th axis.
 //! Do a for loop over the 0th axis and recurse!
 
-use super::{Broadcast, Cpu, ForEachElement, Index, Recurse};
+use super::{Cpu, ForEachElement};
 use crate::arrays::CountElements;
+use std::marker::PhantomData;
+
+pub(crate) struct Idx;
+pub(crate) struct Rec<M>(PhantomData<*const M>);
+pub(crate) struct Bcst<M>(PhantomData<*const M>);
+
+pub(crate) type SelectAx0 = Idx;
+pub(crate) type SelectAx1 = Rec<SelectAx0>;
+pub(crate) type SelectAx2 = Rec<SelectAx1>;
+pub(crate) type SelectAx3 = Rec<SelectAx2>;
+pub(crate) type BSelectAx0 = Bcst<Idx>;
 
 pub trait DeviceSelect<T, I, Mode> {
     type Result;
@@ -29,7 +40,7 @@ pub trait DeviceSelect<T, I, Mode> {
     fn select_add(inp: &mut T, indices: &I, out: &Self::Result);
 }
 
-impl<T, const M: usize> DeviceSelect<[T; M], usize, Index> for Cpu
+impl<T, const M: usize> DeviceSelect<[T; M], usize, Idx> for Cpu
 where
     Self: ForEachElement<T>,
     T: Copy + CountElements,
@@ -46,7 +57,7 @@ where
     }
 }
 
-impl<T, const M: usize, const Z: usize> DeviceSelect<[T; M], [usize; Z], Index> for Cpu
+impl<T, const M: usize, const Z: usize> DeviceSelect<[T; M], [usize; Z], Idx> for Cpu
 where
     Self: ForEachElement<T>,
     T: Copy + CountElements,
@@ -66,7 +77,7 @@ where
     }
 }
 
-impl<T, I, const M: usize, SubMode> DeviceSelect<[T; M], [I; M], Recurse<SubMode>> for Cpu
+impl<T, I, const M: usize, SubMode> DeviceSelect<[T; M], [I; M], Rec<SubMode>> for Cpu
 where
     Self: DeviceSelect<T, I, SubMode>,
 {
@@ -85,7 +96,7 @@ where
     }
 }
 
-impl<T, I, const M: usize, SubMode> DeviceSelect<T, [I; M], Broadcast<SubMode>> for Cpu
+impl<T, I, const M: usize, SubMode> DeviceSelect<T, [I; M], Bcst<SubMode>> for Cpu
 where
     Self: DeviceSelect<T, I, SubMode>,
 {
@@ -120,7 +131,7 @@ mod tests {
     fn test_select_1d_0z() {
         let a: [f32; 3] = [1.0f32, 2.0, 3.0];
         let mut b: [f32; 6] = ZeroElements::ZEROS;
-        <Cpu as DeviceSelect<_, _, Index>>::select_axis(&a, &[0, 1, 2, 2, 1, 0], &mut b);
+        <Cpu as DeviceSelect<_, _, Idx>>::select_axis(&a, &[0, 1, 2, 2, 1, 0], &mut b);
         assert_eq!(b, [1.0, 2.0, 3.0, 3.0, 2.0, 1.0]);
     }
 
@@ -138,7 +149,7 @@ mod tests {
     fn test_select_2d_0z() {
         let a = A_2D;
         let mut b: [[f32; 3]; 3] = ZeroElements::ZEROS;
-        <Cpu as DeviceSelect<_, _, Index>>::select_axis(&a, &[0, 0, 1], &mut b);
+        <Cpu as DeviceSelect<_, _, Idx>>::select_axis(&a, &[0, 0, 1], &mut b);
         assert_eq!(b, [a[0], a[0], a[1]]);
     }
 
@@ -146,7 +157,7 @@ mod tests {
     fn test_select_2d_1() {
         let a = A_2D;
         let mut b: [f32; 2] = ZeroElements::ZEROS;
-        <Cpu as DeviceSelect<_, _, Recurse<Index>>>::select_axis(&a, &[0, 1], &mut b);
+        <Cpu as DeviceSelect<_, _, Rec<Idx>>>::select_axis(&a, &[0, 1], &mut b);
         assert_eq!(b, [1.0, 5.0]);
     }
 
@@ -154,7 +165,7 @@ mod tests {
     fn test_select_2d_1z() {
         let a = A_2D;
         let mut b: [[f32; 2]; 2] = ZeroElements::ZEROS;
-        <Cpu as DeviceSelect<_, _, Recurse<Index>>>::select_axis(&a, &[[0, 2], [1, 1]], &mut b);
+        <Cpu as DeviceSelect<_, _, Rec<Idx>>>::select_axis(&a, &[[0, 2], [1, 1]], &mut b);
         assert_eq!(b, [[1.0, 3.0], [5.0, 5.0]]);
     }
 
@@ -163,7 +174,7 @@ mod tests {
         let a = [[1.0], [2.0]];
         let i: [[usize; 3]; 4] = [[0, 1, 0], [1, 1, 1], [0, 0, 0], [1, 0, 1]];
         let mut b: [[[f32; 1]; 3]; 4] = ZeroElements::ZEROS;
-        <Cpu as DeviceSelect<_, _, Broadcast<Index>>>::select_axis(&a, &i, &mut b);
+        <Cpu as DeviceSelect<_, _, Bcst<Idx>>>::select_axis(&a, &i, &mut b);
         #[rustfmt::skip]
         assert_eq!(b, [[[1.], [2.], [1.]], [[2.], [2.], [2.]], [[1.], [1.], [1.]], [[2.], [1.], [2.]]]);
     }
@@ -173,7 +184,7 @@ mod tests {
         let mut a = [[0.0; 3]; 2];
         let b = [[1.0, 3.0], [5.0, 5.0]];
         let i = [[0, 2], [1, 1]];
-        <Cpu as DeviceSelect<_, _, Recurse<Index>>>::select_add(&mut a, &i, &b);
+        <Cpu as DeviceSelect<_, _, Rec<Idx>>>::select_add(&mut a, &i, &b);
         assert_eq!(a, [[1.0, 0.0, 3.0], [0.0, 10.0, 0.0]]);
     }
 
@@ -196,7 +207,7 @@ mod tests {
     fn test_select_3d_0z() {
         let a = A_3D;
         let mut b: [[[f32; 3]; 2]; 6] = ZeroElements::ZEROS;
-        <Cpu as DeviceSelect<_, _, Index>>::select_axis(&a, &[0, 0, 1, 2, 3, 3], &mut b);
+        <Cpu as DeviceSelect<_, _, Idx>>::select_axis(&a, &[0, 0, 1, 2, 3, 3], &mut b);
         assert_eq!(b, [A_3D[0], A_3D[0], A_3D[1], A_3D[2], A_3D[3], A_3D[3]]);
     }
 
@@ -204,7 +215,7 @@ mod tests {
     fn test_select_3d_1() {
         let a = A_3D;
         let mut b: [[f32; 3]; 4] = ZeroElements::ZEROS;
-        <Cpu as DeviceSelect<_, _, Recurse<Index>>>::select_axis(&a, &[0, 0, 1, 1], &mut b);
+        <Cpu as DeviceSelect<_, _, Rec<Idx>>>::select_axis(&a, &[0, 0, 1, 1], &mut b);
         assert_eq!(b, [A_3D[0][0], A_3D[1][0], A_3D[2][1], A_3D[3][1]]);
     }
 
@@ -212,7 +223,7 @@ mod tests {
     fn test_select_3d_1z() {
         let a = A_3D;
         let mut b: [[[f32; 3]; 1]; 4] = ZeroElements::ZEROS;
-        <Cpu as DeviceSelect<_, _, Recurse<Index>>>::select_axis(&a, &[[0], [0], [1], [1]], &mut b);
+        <Cpu as DeviceSelect<_, _, Rec<Idx>>>::select_axis(&a, &[[0], [0], [1], [1]], &mut b);
         assert_eq!(b, [[A_3D[0][0]], [A_3D[1][0]], [A_3D[2][1]], [A_3D[3][1]]]);
     }
 
@@ -220,7 +231,7 @@ mod tests {
     fn test_select_3d_2() {
         let a = A_3D;
         let mut b: [[f32; 2]; 4] = ZeroElements::ZEROS;
-        <Cpu as DeviceSelect<_, _, Recurse<Recurse<Index>>>>::select_axis(
+        <Cpu as DeviceSelect<_, _, Rec<Rec<Idx>>>>::select_axis(
             &a,
             &[[1, 0], [0, 1], [0, 0], [1, 1]],
             &mut b,
@@ -240,7 +251,7 @@ mod tests {
     fn test_select_3d_2z() {
         let a = A_3D;
         let mut b: [[[f32; 1]; 2]; 4] = ZeroElements::ZEROS;
-        <Cpu as DeviceSelect<_, _, Recurse<Recurse<Index>>>>::select_axis(
+        <Cpu as DeviceSelect<_, _, Rec<Rec<Idx>>>>::select_axis(
             &a,
             &[[[1], [0]], [[0], [1]], [[0], [0]], [[1], [1]]],
             &mut b,

--- a/src/tensor_ops/select.rs
+++ b/src/tensor_ops/select.rs
@@ -10,94 +10,88 @@ use crate::prelude::*;
 /// 2. Select multiple values from an axis, which keeps the number
 /// of dimensions the same. You can select the same element multiple
 /// number of times.
-pub trait Select1<T, const I: isize> {
-    type Indices: Clone;
+///
+/// Select sub elements using [Self::Indices].
+/// The same element can be selected multiple times depending
+/// on [Self::Indices].
+///
+/// Selecting single value from 2d tensors:
+/// ```rust
+/// # use dfdx::prelude::*;
+/// // select a single element from the 0th axis
+/// let _: Tensor1D<5> = Tensor2D::<3, 5>::zeros().select(&0);
+///
+/// // select a single element from the 1st axis - number of elements is equal
+/// // to the size of the 0th axis, and the usize values can be 0..5
+/// let _: Tensor1D<3> = Tensor2D::<3, 5>::zeros().select(&[0, 2, 4]);
+///```
+///
+/// Selecting multiple values from 2d tensors:
+/// ```rust
+/// # use dfdx::prelude::*;
+/// // select a multiple elements from the 0th axis.
+/// // the number of indices is the new size of the 0th axis.
+/// let _: Tensor2D<6, 5> = Tensor2D::<3, 5>::zeros().select(&[0, 1, 2, 0, 1, 2]);
+///
+/// // select a multiple elements from the 1st axis.
+/// // must have same number of elements as the 0th axis, and the number of indices
+/// // is the new size of the 1st axis.
+/// let _: Tensor2D<3, 2> = Tensor2D::<3, 5>::zeros().select(&[[0, 4], [1, 3], [2, 2]]);
+/// ```
+pub fn select<T, R, Mode>(
+    t: T,
+    indices: &<<T as HasDevice>::Device as DeviceSelect<T::Array, R::Array, Mode>>::Indices,
+) -> R
+where
+    T: Tensor<Dtype = f32>,
+    R: Tensor<Dtype = f32, Tape = T::Tape>,
+    <T as HasDevice>::Device: DeviceSelect<T::Array, R::Array, Mode>,
+    <<T as HasDevice>::Device as DeviceSelect<T::Array, R::Array, Mode>>::Indices: 'static,
+{
+    let mut result: <R as Tensor>::NoTape = TensorCreator::zeros();
+    <T as HasDevice>::Device::select_axis(t.data(), indices, result.mut_data());
 
-    /// Select sub elements using [Self::Indices].
-    /// The same element can be selected multiple times depending
-    /// on [Self::Indices].
-    ///
-    /// Selecting single value from 2d tensors:
-    /// ```rust
-    /// # use dfdx::prelude::*;
-    /// // select a single element from the 0th axis
-    /// let _: Tensor1D<5> = Tensor2D::<3, 5>::zeros().select(&0);
-    ///
-    /// // select a single element from the 1st axis - number of elements is equal
-    /// // to the size of the 0th axis, and the usize values can be 0..5
-    /// let _: Tensor1D<3> = Tensor2D::<3, 5>::zeros().select(&[0, 2, 4]);
-    ///```
-    ///
-    /// Selecting multiple values from 2d tensors:
-    /// ```rust
-    /// # use dfdx::prelude::*;
-    /// // select a multiple elements from the 0th axis.
-    /// // the number of indices is the new size of the 0th axis.
-    /// let _: Tensor2D<6, 5> = Tensor2D::<3, 5>::zeros().select(&[0, 1, 2, 0, 1, 2]);
-    ///
-    /// // select a multiple elements from the 1st axis.
-    /// // must have same number of elements as the 0th axis, and the number of indices
-    /// // is the new size of the 1st axis.
-    /// let _: Tensor2D<3, 2> = Tensor2D::<3, 5>::zeros().select(&[[0, 4], [1, 3], [2, 2]]);
-    /// ```
-    fn select(self, indices: &Self::Indices) -> T;
+    #[allow(clippy::clone_on_copy)]
+    let i = indices.clone();
+
+    move_tape_and_add_backward_op(t, result, move |mut t, result, grads| {
+        let (t_grad, result_grad) = grads.mut_and_ref(&t, &result);
+        <T as HasDevice>::Device::fill(t.mut_data(), &mut |v| *v = 0.0);
+        <T as HasDevice>::Device::select_add(t.mut_data(), &i, result_grad);
+        <T as HasDevice>::Device::add(t_grad, t.data());
+    })
 }
 
-macro_rules! impl_select {
-    ($Axis:expr, $SrcTy:ty, $IndTy:tt, $DstTy:ty, {$($Dims:tt),*}) => {
-impl<$(const $Dims: usize, )* H: Tape> Select1<$DstTy, $Axis> for $SrcTy {
-    type Indices = $IndTy;
-    fn select(self, indices: &Self::Indices) -> $DstTy {
-        let mut result: <$DstTy as Tensor>::NoTape = TensorCreator::zeros();
-        Cpu::select_axis(self.data(), indices, result.mut_data());
-
-        #[allow(clippy::clone_on_copy)]
-        let i = indices.clone();
-
-        move_tape_and_add_backward_op(self, result, move |mut t, result, grads| {
-            let (t_grad, result_grad) = grads.mut_and_ref(&t, &result);
-            Cpu::fill(t.mut_data(), &mut |v| *v = 0.0);
-            Cpu::select_add(t.mut_data(), &i, result_grad);
-            Cpu::add(t_grad, t.data());
-        })
+macro_rules! tensor_impl {
+    ($typename:ident, [$($Vs:tt),*]) => {
+impl<$(const $Vs: usize, )* H: Tape> $typename<$($Vs, )* H> {
+    /// Calls [select()] on `self`.
+    pub fn select<R, Mode>(
+        self,
+        indices: &<<Self as HasDevice>::Device as DeviceSelect<<Self as HasArrayType>::Array, R::Array, Mode>>::Indices
+    ) -> R
+    where
+        Self: Tensor<Dtype = f32>,
+        R: Tensor<Dtype = f32, Tape = <Self as Tensor>::Tape>,
+        <Self as HasDevice>::Device: DeviceSelect<<Self as HasArrayType>::Array, R::Array, Mode>,
+        <<Self as HasDevice>::Device as DeviceSelect<<Self as HasArrayType>::Array, R::Array, Mode>>::Indices: 'static,
+    {
+        select(self, indices)
     }
 }
     };
 }
 
-// 1d
-impl_select!(-1, Tensor1D<M, H>, usize, Tensor0D<H>, {M});
-impl_select!(-1, Tensor1D<M, H>, [usize; Z], Tensor1D<Z, H>, {M, Z});
-
-// 2d
-impl_select!(0, Tensor2D<M, N, H>, usize, Tensor1D<N, H>, {M, N});
-impl_select!(0, Tensor2D<M, N, H>, [usize; Z], Tensor2D<Z, N, H>, {M, N, Z});
-impl_select!(-1, Tensor2D<M, N, H>, [usize; M], Tensor1D<M, H>, {M, N});
-impl_select!(-1, Tensor2D<M, N, H>, [[usize; Z]; M], Tensor2D<M, Z, H>, {M, N, Z});
-
-// 3d
-impl_select!(0, Tensor3D<M, N, O, H>, usize, Tensor2D<N, O, H>, {M, N, O});
-impl_select!(0, Tensor3D<M, N, O, H>, [usize; Z], Tensor3D<Z, N, O, H>, {M, N, O, Z});
-impl_select!(1, Tensor3D<M, N, O, H>, [usize; M], Tensor2D<M, O, H>, {M, N, O});
-impl_select!(1, Tensor3D<M, N, O, H>, [[usize; Z]; M], Tensor3D<M, Z, O, H>, {M, N, O, Z});
-impl_select!(-1, Tensor3D<M, N, O, H>, [[usize; N]; M], Tensor2D<M, N, H>, {M, N, O});
-impl_select!(-1, Tensor3D<M, N, O, H>, [[[usize; Z]; N]; M], Tensor3D<M, N, Z, H>, {M, N, O, Z});
-
-// 4d
-impl_select!(0, Tensor4D<M, N, O, P, H>, usize, Tensor3D<N, O, P, H>, {M, N, O, P});
-impl_select!(0, Tensor4D<M, N, O, P, H>, [usize; Z], Tensor4D<Z, N, O, P, H>, {M, N, O, P, Z});
-impl_select!(1, Tensor4D<M, N, O, P, H>, [usize; M], Tensor3D<M, O, P, H>, {M, N, O, P});
-impl_select!(1, Tensor4D<M, N, O, P, H>, [[usize; Z]; M], Tensor4D<M, Z, O, P, H>, {M, N, O, P, Z});
-impl_select!(2, Tensor4D<M, N, O, P, H>, [[usize; N]; M], Tensor3D<M, N, P, H>, {M, N, O, P});
-impl_select!(2, Tensor4D<M, N, O, P, H>, [[[usize; Z]; N]; M], Tensor4D<M, N, Z, P, H>, {M, N, O, P, Z});
-impl_select!(-1, Tensor4D<M, N, O, P, H>, [[[usize; O]; N]; M], Tensor3D<M, N, O, H>, {M, N, O, P});
-impl_select!(-1, Tensor4D<M, N, O, P, H>, [[[[usize; Z]; O]; N]; M], Tensor4D<M, N, O, Z, H>, {M, N, O, P, Z});
+tensor_impl!(Tensor0D, []);
+tensor_impl!(Tensor1D, [M]);
+tensor_impl!(Tensor2D, [M, N]);
+tensor_impl!(Tensor3D, [M, N, O]);
+tensor_impl!(Tensor4D, [M, N, O, P]);
 
 #[cfg(test)]
 mod tests {
-    use rand::thread_rng;
-
     use super::*;
+    use rand::thread_rng;
 
     #[test]
     fn test_valid_selects_1d() {
@@ -120,7 +114,7 @@ mod tests {
     fn test_select_1d_less_backward() {
         let mut rng = thread_rng();
         let t: Tensor1D<5> = TensorCreator::randn(&mut rng);
-        let r: Tensor1D<2, OwnedTape> = t.trace().select(&[0, 3]);
+        let r: Tensor1D<2, OwnedTape> = t.trace().select::<_, select_modes::Index>(&[0, 3]);
         assert_eq!(r.data(), &[t.data()[0], t.data()[3]]);
         let g = r.mean().backward();
         assert_eq!(g.ref_gradient(&t), &[0.5, 0.0, 0.0, 0.5, 0.0]);

--- a/src/tensor_ops/select.rs
+++ b/src/tensor_ops/select.rs
@@ -112,7 +112,7 @@ macro_rules! impl_select_batch {
 impl<$(const $Dims: usize, )* H: Tape> SelectBatchAx0<$DstTy> for $SrcTy {
     type Indices = $IndTy;
     fn select_batch(self, indices: &Self::Indices) -> $DstTy {
-        select::<_, _, _, BSelectAx0>(self, indices)
+        select::<_, _, _, BSelectAx1>(self, indices)
     }
 }
     };

--- a/src/tensor_ops/select.rs
+++ b/src/tensor_ops/select.rs
@@ -102,7 +102,7 @@ pub trait SelectBatchAx0<T> {
     /// Selecting batch of values from a 2d tensor:
     /// ```rust
     /// # use dfdx::prelude::*;
-    /// let _: Tensor3D<2, 1, 5> = Tensor2D::<3, 5>::zeros().select_batch(&[[[0], [1]], [[2], [3]]]);
+    /// let _: Tensor3D<2, 1, 5> = Tensor2D::<3, 5>::zeros().select_batch(&[[0], [1]]);
     ///```
     fn select_batch(self, indices: &Self::Indices) -> T;
 }

--- a/src/tensor_ops/select.rs
+++ b/src/tensor_ops/select.rs
@@ -160,7 +160,7 @@ mod tests {
     fn test_valid_select_batches() {
         let _: Tensor2D<2, 1> = Tensor1D::<5>::zeros().select_batch(&[[0], [1]]);
         let _: Tensor3D<2, 1, 5> = Tensor2D::<3, 5>::zeros().select_batch(&[[0], [1]]);
-        let _: Tensor4D<2, 1, 3, 5> = Tensor3D::<1, 3, 5>::zeros().select_batch(&[[0], [1]]);
+        let _: Tensor4D<2, 1, 3, 5> = Tensor3D::<1, 3, 5>::zeros().select_batch(&[[0], [0]]);
     }
 
     #[test]

--- a/src/tensor_ops/select.rs
+++ b/src/tensor_ops/select.rs
@@ -10,35 +10,40 @@ use crate::prelude::*;
 /// 2. Select multiple values from an axis, which keeps the number
 /// of dimensions the same. You can select the same element multiple
 /// number of times.
-///
-/// Select sub elements using [Self::Indices].
-/// The same element can be selected multiple times depending
-/// on [Self::Indices].
-///
-/// Selecting single value from 2d tensors:
-/// ```rust
-/// # use dfdx::prelude::*;
-/// // select a single element from the 0th axis
-/// let _: Tensor1D<5> = Tensor2D::<3, 5>::zeros().select(&0);
-///
-/// // select a single element from the 1st axis - number of elements is equal
-/// // to the size of the 0th axis, and the usize values can be 0..5
-/// let _: Tensor1D<3> = Tensor2D::<3, 5>::zeros().select(&[0, 2, 4]);
-///```
-///
-/// Selecting multiple values from 2d tensors:
-/// ```rust
-/// # use dfdx::prelude::*;
-/// // select a multiple elements from the 0th axis.
-/// // the number of indices is the new size of the 0th axis.
-/// let _: Tensor2D<6, 5> = Tensor2D::<3, 5>::zeros().select(&[0, 1, 2, 0, 1, 2]);
-///
-/// // select a multiple elements from the 1st axis.
-/// // must have same number of elements as the 0th axis, and the number of indices
-/// // is the new size of the 1st axis.
-/// let _: Tensor2D<3, 2> = Tensor2D::<3, 5>::zeros().select(&[[0, 4], [1, 3], [2, 2]]);
-/// ```
-pub fn select<T, I, R, Mode>(t: T, indices: &I) -> R
+pub trait Select1<T, const I: isize> {
+    type Indices: Clone;
+
+    /// Select sub elements using [Self::Indices].
+    /// The same element can be selected multiple times depending
+    /// on [Self::Indices].
+    ///
+    /// Selecting single value from 2d tensors:
+    /// ```rust
+    /// # use dfdx::prelude::*;
+    /// // select a single element from the 0th axis
+    /// let _: Tensor1D<5> = Tensor2D::<3, 5>::zeros().select(&0);
+    ///
+    /// // select a single element from the 1st axis - number of elements is equal
+    /// // to the size of the 0th axis, and the usize values can be 0..5
+    /// let _: Tensor1D<3> = Tensor2D::<3, 5>::zeros().select(&[0, 2, 4]);
+    ///```
+    ///
+    /// Selecting multiple values from 2d tensors:
+    /// ```rust
+    /// # use dfdx::prelude::*;
+    /// // select a multiple elements from the 0th axis.
+    /// // the number of indices is the new size of the 0th axis.
+    /// let _: Tensor2D<6, 5> = Tensor2D::<3, 5>::zeros().select(&[0, 1, 2, 0, 1, 2]);
+    ///
+    /// // select a multiple elements from the 1st axis.
+    /// // must have same number of elements as the 0th axis, and the number of indices
+    /// // is the new size of the 1st axis.
+    /// let _: Tensor2D<3, 2> = Tensor2D::<3, 5>::zeros().select(&[[0, 4], [1, 3], [2, 2]]);
+    /// ```
+    fn select(self, indices: &Self::Indices) -> T;
+}
+
+fn select<T, I, R, Mode>(t: T, indices: &I) -> R
 where
     T: Tensor<Dtype = f32>,
     I: 'static + Clone,
@@ -59,28 +64,44 @@ where
     })
 }
 
-macro_rules! tensor_impl {
-    ($typename:ident, [$($Vs:tt),*]) => {
-impl<$(const $Vs: usize, )* H: Tape> $typename<$($Vs, )* H> {
-    /// Calls [select()] on `self`.
-    pub fn select<I, R, Mode>(self, indices: &I) -> R
-    where
-        Self: Tensor<Dtype = f32>,
-        I: 'static + Clone,
-        R: Tensor<Dtype = f32, Tape = <Self as Tensor>::Tape>,
-        <Self as HasDevice>::Device: DeviceSelect<<Self as HasArrayType>::Array, I, Mode, Result = R::Array>,
-    {
-        select(self, indices)
+macro_rules! impl_select {
+    ($Axis:expr, $Mode:ty, $SrcTy:ty, $IndTy:tt, $DstTy:ty, {$($Dims:tt),*}) => {
+impl<$(const $Dims: usize, )* H: Tape> Select1<$DstTy, $Axis> for $SrcTy {
+    type Indices = $IndTy;
+    fn select(self, indices: &Self::Indices) -> $DstTy {
+        select::<_, _, _, $Mode>(self, indices)
     }
 }
     };
 }
 
-tensor_impl!(Tensor0D, []);
-tensor_impl!(Tensor1D, [M]);
-tensor_impl!(Tensor2D, [M, N]);
-tensor_impl!(Tensor3D, [M, N, O]);
-tensor_impl!(Tensor4D, [M, N, O, P]);
+// 1d
+impl_select!(-1, SelectAx0, Tensor1D<M, H>, usize, Tensor0D<H>, {M});
+impl_select!(-1, SelectAx0, Tensor1D<M, H>, [usize; Z], Tensor1D<Z, H>, {M, Z});
+
+// 2d
+impl_select!(0, SelectAx0, Tensor2D<M, N, H>, usize, Tensor1D<N, H>, {M, N});
+impl_select!(0, SelectAx0, Tensor2D<M, N, H>, [usize; Z], Tensor2D<Z, N, H>, {M, N, Z});
+impl_select!(-1, SelectAx1, Tensor2D<M, N, H>, [usize; M], Tensor1D<M, H>, {M, N});
+impl_select!(-1, SelectAx1, Tensor2D<M, N, H>, [[usize; Z]; M], Tensor2D<M, Z, H>, {M, N, Z});
+
+// 3d
+impl_select!(0, SelectAx0, Tensor3D<M, N, O, H>, usize, Tensor2D<N, O, H>, {M, N, O});
+impl_select!(0, SelectAx0, Tensor3D<M, N, O, H>, [usize; Z], Tensor3D<Z, N, O, H>, {M, N, O, Z});
+impl_select!(1, SelectAx1, Tensor3D<M, N, O, H>, [usize; M], Tensor2D<M, O, H>, {M, N, O});
+impl_select!(1, SelectAx1, Tensor3D<M, N, O, H>, [[usize; Z]; M], Tensor3D<M, Z, O, H>, {M, N, O, Z});
+impl_select!(-1, SelectAx2, Tensor3D<M, N, O, H>, [[usize; N]; M], Tensor2D<M, N, H>, {M, N, O});
+impl_select!(-1, SelectAx2, Tensor3D<M, N, O, H>, [[[usize; Z]; N]; M], Tensor3D<M, N, Z, H>, {M, N, O, Z});
+
+// 4d
+impl_select!(0, SelectAx0, Tensor4D<M, N, O, P, H>, usize, Tensor3D<N, O, P, H>, {M, N, O, P});
+impl_select!(0, SelectAx0, Tensor4D<M, N, O, P, H>, [usize; Z], Tensor4D<Z, N, O, P, H>, {M, N, O, P, Z});
+impl_select!(1, SelectAx1, Tensor4D<M, N, O, P, H>, [usize; M], Tensor3D<M, O, P, H>, {M, N, O, P});
+impl_select!(1, SelectAx1, Tensor4D<M, N, O, P, H>, [[usize; Z]; M], Tensor4D<M, Z, O, P, H>, {M, N, O, P, Z});
+impl_select!(2, SelectAx2, Tensor4D<M, N, O, P, H>, [[usize; N]; M], Tensor3D<M, N, P, H>, {M, N, O, P});
+impl_select!(2, SelectAx2, Tensor4D<M, N, O, P, H>, [[[usize; Z]; N]; M], Tensor4D<M, N, Z, P, H>, {M, N, O, P, Z});
+impl_select!(-1, SelectAx3, Tensor4D<M, N, O, P, H>, [[[usize; O]; N]; M], Tensor3D<M, N, O, H>, {M, N, O, P});
+impl_select!(-1, SelectAx3, Tensor4D<M, N, O, P, H>, [[[[usize; Z]; O]; N]; M], Tensor4D<M, N, O, Z, H>, {M, N, O, P, Z});
 
 #[cfg(test)]
 mod tests {
@@ -90,9 +111,8 @@ mod tests {
     #[test]
     fn test_valid_selects_1d() {
         let _: Tensor0D = Tensor1D::<5>::zeros().select(&0);
-        let _: Tensor1D<3> = Tensor1D::<5>::zeros().select::<_, _, Index>(&[1, 2, 3]);
-        let _: Tensor1D<10> =
-            Tensor1D::<5>::zeros().select::<_, _, Index>(&[0, 1, 2, 3, 4, 0, 1, 2, 3, 4]);
+        let _: Tensor1D<3> = Tensor1D::<5>::zeros().select(&[1, 2, 3]);
+        let _: Tensor1D<10> = Tensor1D::<5>::zeros().select(&[0, 1, 2, 3, 4, 0, 1, 2, 3, 4]);
     }
 
     #[test]
@@ -109,7 +129,7 @@ mod tests {
     fn test_select_1d_less_backward() {
         let mut rng = thread_rng();
         let t: Tensor1D<5> = TensorCreator::randn(&mut rng);
-        let r: Tensor1D<2, OwnedTape> = t.trace().select::<_, _, Index>(&[0, 3]);
+        let r: Tensor1D<2, OwnedTape> = t.trace().select(&[0, 3]);
         assert_eq!(r.data(), &[t.data()[0], t.data()[3]]);
         let g = r.mean().backward();
         assert_eq!(g.ref_gradient(&t), &[0.5, 0.0, 0.0, 0.5, 0.0]);
@@ -120,7 +140,7 @@ mod tests {
         let mut rng = thread_rng();
         let t: Tensor1D<5> = TensorCreator::randn(&mut rng);
         let _t = *t.data();
-        let r: Tensor1D<8, OwnedTape> = t.trace().select::<_, _, Index>(&[0, 1, 2, 3, 4, 2, 4, 4]);
+        let r: Tensor1D<8, OwnedTape> = t.trace().select(&[0, 1, 2, 3, 4, 2, 4, 4]);
         assert_eq!(
             r.data(),
             &[_t[0], _t[1], _t[2], _t[3], _t[4], _t[2], _t[4], _t[4]]
@@ -145,7 +165,7 @@ mod tests {
     #[test]
     fn test_select_last_2d() {
         let t: Tensor2D<2, 3> = Tensor2D::new([[1.0, 2.0, 3.0], [-1.0, -2.0, -3.0]]);
-        let r: Tensor1D<2, OwnedTape> = t.trace().select::<_, _, Recurse<Index>>(&[1, 2]);
+        let r: Tensor1D<2, OwnedTape> = t.trace().select(&[1, 2]);
         assert_eq!(r.data(), &[2.0, -3.0]);
         let gradients = r.mean().backward();
         assert_eq!(
@@ -162,9 +182,7 @@ mod tests {
             [[-3.0, 2.0, -1.0], [-6.0, 5.0, -4.0]],
             [[1.0, -2.0, 3.0], [4.0, -5.0, 6.0]],
         ]);
-        let r: Tensor2D<4, 2, OwnedTape> =
-            t.trace()
-                .select::<_, _, Recurse<Recurse<Index>>>(&[[0, 1], [2, 2], [1, 1], [0, 0]]);
+        let r: Tensor2D<4, 2, OwnedTape> = t.trace().select(&[[0, 1], [2, 2], [1, 1], [0, 0]]);
         assert_eq!(
             r.data(),
             &[[1.0, 5.0], [-3.0, -6.0], [2.0, 5.0], [1.0, 4.0]]


### PR DESCRIPTION
Closes #177 

Unblocks #121 

Batched select needs the source type to be broadcasted one level. It was actually impossible to specify this with the macro and axis based select previously used in device. This is because broadcasted select doesn't select from an axis at first, so you can't specify a single thing for it to select from.

Summary:
- Reworks the devices implementation to use a recursive trait implementation using recursive types to deconflict implementation.
    - These are controlled via unit structs called "Modes"
- Adds (private) generic select function that uses select modes to control behavior
- Rework existing tensor impls to use modes
- Adds a SelectBatchAx0 trait with select_batch function for 1d/2d/3d tensors
