### PR TITLE
[Breaking] `softmax`, `log_softmax`, and `logsumexp` along any axis

### DIFF
--- a/examples/classification.rs
+++ b/examples/classification.rs
@@ -13,7 +13,7 @@ fn main() {
 
     // initialize target data
     let x: Tensor2D<64, 10> = Tensor2D::randn(&mut rng);
-    let y: Tensor2D<64, 2> = Tensor2D::randn(&mut rng).softmax();
+    let y: Tensor2D<64, 2> = Tensor2D::randn(&mut rng).softmax::<-1>();
 
     // initialize model - all weights are 0s
     let mut mlp: Mlp = Default::default();

--- a/examples/ppo.rs
+++ b/examples/ppo.rs
@@ -37,11 +37,11 @@ fn main() {
 
         // old_log_prob_a = log(P(action | state, target_pi_net))
         let old_logits = target_pi_net.forward(state.clone());
-        let old_log_prob_a: Tensor1D<64> = old_logits.log_softmax().select(&action);
+        let old_log_prob_a: Tensor1D<64> = old_logits.log_softmax::<-1>().select(&action);
 
         // log_prob_a = log(P(action | state, pi_net))
         let logits = pi_net.forward(state.trace());
-        let log_prob_a: Tensor1D<64, OwnedTape> = logits.log_softmax().select(&action);
+        let log_prob_a: Tensor1D<64, OwnedTape> = logits.log_softmax::<-1>().select(&action);
 
         // ratio = P(action | state, pi_net) / P(action | state, target_pi_net)
         // but compute in log space and then do .exp() to bring it back out of log space

--- a/src/losses.rs
+++ b/src/losses.rs
@@ -121,7 +121,7 @@ pub fn cross_entropy_with_logits_loss<T: Reduce1<-1>>(
     logits: T,
     target_probs: &T::NoTape,
 ) -> Tensor0D<T::Tape> {
-    -mean(sum_axis::<T, -1>(mul(log_softmax(logits), target_probs)))
+    -mean(sum_axis(mul(log_softmax(logits), target_probs)))
 }
 
 /// [KL Divergence loss](https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence).
@@ -146,7 +146,7 @@ pub fn kl_div_with_logits_loss<T: Reduce1<-1>>(
     logits: T,
     target_probs: &T::NoTape,
 ) -> Tensor0D<T::Tape> {
-    -mean(sum_axis::<T, -1>(mul(
+    -mean(sum_axis(mul(
         sub(log_softmax(logits), &ln(target_probs.duplicate())),
         target_probs,
     )))

--- a/src/nn/activations.rs
+++ b/src/nn/activations.rs
@@ -148,17 +148,17 @@ mod tests {
     fn test_softmax() {
         let t = Tensor0D::new(0.0);
         let r1 = Softmax.forward(t.clone());
-        let r2 = softmax(t);
+        let r2 = t.softmax::<-1>();
         assert_eq!(r1.data(), r2.data());
 
         let t = tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
         let r1 = Softmax.forward(t.clone());
-        let r2 = softmax(t);
+        let r2 = t.softmax::<-1>();
         assert_eq!(r1.data(), r2.data());
 
         let t = Tensor2D::new([[-2.0, -1.0, 0.0], [1.0, 2.0, 3.0]]);
         let r1 = Softmax.forward(t.clone());
-        let r2 = softmax(t);
+        let r2 = t.softmax::<-1>();
         assert_eq!(r1.data(), r2.data());
     }
 }

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -123,9 +123,7 @@ where
         // Get weights
         let scalar: f32 = 1.0 / ((K / H) as f32).sqrt();
         let weights: Tensor3D<H, S1, S2, _> = matmul_transpose(q, &k) * scalar;
-
-        // Softmax on last dimension
-        let weights: Tensor3D<H, S1, S2, _> = softmax(weights);
+        let weights: Tensor3D<H, S1, S2, _> = weights.softmax::<-1>();
 
         // Get new tokens
         let tokens: Tensor3D<H, S1, { V / H }, _> = matmul(weights, &v);
@@ -187,9 +185,7 @@ where
         // Get weights
         let scalar: f32 = 1.0 / ((K / H) as f32).sqrt();
         let weights: Tensor4D<B, H, S1, S2, _> = matmul_transpose(q, &k) * scalar;
-
-        // Softmax on last dimension
-        let weights: Tensor4D<B, H, S1, S2, _> = softmax(weights);
+        let weights: Tensor4D<B, H, S1, S2, _> = weights.softmax::<-1>();
 
         // Get new tokens
         let tokens: Tensor4D<B, H, S1, { V / H }, _> = matmul(weights, &v);


### PR DESCRIPTION
This is one of the only operations that hard codes the axis. This makes it more consistent, and also a bit easier to swap to not using `-1`.

Related to #188 