### PR TITLE
[Breaking] backwards only allows 0d tensors now

### DIFF
--- a/src/losses.rs
+++ b/src/losses.rs
@@ -196,7 +196,7 @@ mod tests {
         let y = Tensor1D::new([-0.90954804, -1.0193185, -0.39221755, 2.2524886, 1.3035554]);
         let loss = mse_loss(x.trace(), &y);
         assert_eq!(loss.data(), &1.0846305);
-        let g = loss.backward();
+        let g = backward(loss);
         assert_eq!(
             g.ref_gradient(&x),
             &[0.7128116, 0.31071725, -0.24555098, -0.43896183, 0.10037976]
@@ -209,7 +209,7 @@ mod tests {
         let y = Tensor1D::new([-0.90954804, -1.0193186, -0.39221755, 2.2524886, 1.3035554]);
         let loss = mae_loss(x.trace(), &y);
         assert_eq!(loss.data(), &0.9042107);
-        let g = loss.backward();
+        let g = backward(loss);
         assert_eq!(g.ref_gradient(&x), &[0.2, 0.2, -0.2, -0.2, 0.2]);
     }
 
@@ -219,7 +219,7 @@ mod tests {
         let y = Tensor1D::new([0.10473672, 0.24449949, 0.3266706, 0.22253996, 0.10155323]);
         let loss = cross_entropy_with_logits_loss(x.trace(), &y);
         assert_eq!(loss.data(), &1.8713832);
-        let g = loss.backward();
+        let g = backward(loss);
         assert_eq!(
             g.ref_gradient(&x),
             &[
@@ -263,7 +263,7 @@ mod tests {
         ]);
         let loss = kl_div_with_logits_loss(logits.trace(), &targ);
         assert_eq!(loss.data(), &0.40656146);
-        let gradients = loss.backward();
+        let gradients = backward(loss);
         assert_eq!(
             gradients.ref_gradient(&logits),
             &[
@@ -291,7 +291,7 @@ mod tests {
         let loss = binary_cross_entropy_with_logits_loss(logit.trace(), &prob);
         assert_eq!(loss.data(), &0.70457286);
 
-        let gradients = loss.backward();
+        let gradients = backward(loss);
 
         assert_eq!(
             gradients.ref_gradient(&logit),
@@ -320,7 +320,7 @@ mod tests {
         let loss = binary_cross_entropy_with_logits_loss(logit.trace(), &targ);
         assert_eq!(loss.data(), &33.479965);
 
-        let gradients = loss.backward();
+        let gradients = backward(loss);
 
         assert_eq!(
             gradients.ref_gradient(&logit),
@@ -357,7 +357,7 @@ mod tests {
         let loss = huber_loss(x.trace(), &y, 0.5);
         assert_eq!(loss.data(), &0.24506615);
 
-        let gradients = loss.backward();
+        let gradients = backward(loss);
         assert_eq!(
             gradients.ref_gradient(&x),
             &[
@@ -392,7 +392,7 @@ mod tests {
         let loss = smooth_l1_loss(x.trace(), &y, 0.5);
         assert_eq!(loss.data(), &0.4901323);
 
-        let gradients = loss.backward();
+        let gradients = backward(loss);
         assert_eq!(
             gradients.ref_gradient(&x),
             &[

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -281,7 +281,7 @@ mod tests {
 
         let mut opt: Sgd<_> = Default::default();
         let out = m.forward(Tensor4D::<8, 2, 28, 28>::randn(&mut rng).trace());
-        let gradients = out.square().mean().backward();
+        let gradients = backward(out.square().mean());
 
         assert_ne!(gradients.ref_gradient(&m.weight), &[[[[0.0; 3]; 3]; 2]; 4]);
         assert_ne!(gradients.ref_gradient(&m.bias), &[0.0; 4]);

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -192,7 +192,7 @@ mod tests {
             add(Tensor2D::new(Y), &(-Tensor2D::new(X)).relu()).data(),
         );
 
-        let gradients = y.mean().backward();
+        let gradients = backward(y.mean());
 
         assert_close(gradients.ref_gradient(&model.0 .0.weight), &W0G);
         assert_close(gradients.ref_gradient(&model.0 .0.bias), &B0G);
@@ -232,8 +232,8 @@ mod tests {
         let y2 = model2.forward(x2.traced());
         assert_close(y.data(), y2.data());
 
-        let gradients = y.mean().backward();
-        let gradients2 = y2.mean().backward();
+        let gradients = backward(y.mean());
+        let gradients2 = backward(y2.mean());
 
         assert_close(gradients.ref_gradient(&model.0 .0.weight), &W0G);
         assert_close(gradients.ref_gradient(&model.0 .0.bias), &B0G);
@@ -316,7 +316,7 @@ mod tests {
 
         assert_close(y.data(), &[[0.0], [2.0]]);
 
-        let grads = y.mean().backward();
+        let grads = backward(y.mean());
 
         // m(x) = r(x) + r(x) = 2r(x); m'(x) = 2r'(x)
         // y_mean(x_1, x_2) = (m(x_1) + m(x_2)) / 2 = (2r(x_1) + 2r(x_2)) / 2 = r(x_1) + r(x_2)

--- a/src/nn/impl_module_for_tuples.rs
+++ b/src/nn/impl_module_for_tuples.rs
@@ -122,7 +122,7 @@ mod tests {
             .forward(Tensor1D::randn(&mut rng).traced())
             .square()
             .mean();
-        let gradients = loss.backward();
+        let gradients = backward(loss);
 
         assert!(gradients.ref_gradient(&model.0.weight) != &[[0.0; 2]; 3]);
         assert!(gradients.ref_gradient(&model.0.bias) != &[0.0; 3]);

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -179,7 +179,7 @@ mod tests {
                 1.6307268
             ]
         );
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(
             gradients.ref_gradient(&m.gamma),
             &[
@@ -204,7 +204,7 @@ mod tests {
         let m: LayerNorm1D<10> = Default::default();
         let r = m.forward(x.trace());
         assert_eq!(r.data(), &Y_2);
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(
             gradients.ref_gradient(&m.gamma),
             &[

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -136,7 +136,7 @@ mod tests {
         assert_close(y.data(), &[-0.93430865, 0.08624211]);
 
         let loss = y.square().mean();
-        let gradients = loss.backward();
+        let gradients = backward(loss);
         assert_close(
             gradients.ref_gradient(&model.weight),
             &[
@@ -173,7 +173,7 @@ mod tests {
         );
 
         let loss = y.square().mean();
-        let gradients = loss.backward();
+        let gradients = backward(loss);
         assert_close(
             gradients.ref_gradient(&model.weight),
             &[
@@ -224,7 +224,7 @@ mod tests {
         );
 
         let loss = y.square().mean();
-        let gradients = loss.backward();
+        let gradients = backward(loss);
         assert_close(
             gradients.ref_gradient(&model.weight),
             &[

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -157,7 +157,7 @@ mod tests {
         let y = model.forward(x.traced());
         assert_close(y.data(), &Y);
 
-        let gradients = y.mean().backward();
+        let gradients = backward(y.mean());
 
         assert_close(gradients.ref_gradient(&model.0 .0.weight), &W0G);
         assert_close(gradients.ref_gradient(&model.0 .0.bias), &B0G);

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -306,7 +306,7 @@ mod tests {
         let v: Tensor3D<2, 4, 12> = TensorCreator::randn(&mut rng);
         let y: Tensor3D<2, 3, 12, _> = mha.forward((q.trace(), k, v));
 
-        let mut g = SimpleGradients(y.mean().backward());
+        let mut g = SimpleGradients(backward(y.mean()));
         let mut unused = Default::default();
         mha.update(&mut g, &mut unused);
         assert!(unused.is_empty());

--- a/src/nn/transformer/transformer.rs
+++ b/src/nn/transformer/transformer.rs
@@ -127,7 +127,7 @@ mod tests {
         let src: Tensor3D<4, 12, 16> = TensorCreator::randn(&mut rng);
         let tgt: Tensor3D<4, 6, 16> = TensorCreator::randn(&mut rng);
         let out: Tensor3D<4, 6, 16, _> = t.forward((src.trace(), tgt));
-        let g = out.mean().backward();
+        let g = backward(out.mean());
 
         let mut gs = SimpleGradients(g);
         let mut unused: UnusedTensors = Default::default();

--- a/src/optim/adam.rs
+++ b/src/optim/adam.rs
@@ -146,7 +146,7 @@ mod tests {
         ];
 
         for e in expected.iter() {
-            let gradients = (t.trace() * &rate).square().mean().backward();
+            let gradients = backward((t.trace() * &rate).square().mean());
             opt.update(&mut t, gradients).expect("");
             assert_close(t.data(), e);
         }
@@ -175,7 +175,7 @@ mod tests {
         ];
 
         for e in expected.iter() {
-            let gradients = (t.trace() * &rate).square().mean().backward();
+            let gradients = backward((t.trace() * &rate).square().mean());
             opt.update(&mut t, gradients).expect("");
             assert_eq!(t.data(), e);
         }
@@ -199,7 +199,7 @@ mod tests {
 
         let py = model.forward(x.trace());
         let loss = (py - &y).square().mean();
-        let gradients = loss.backward();
+        let gradients = backward(loss);
         opt.update(&mut model, gradients).expect("");
 
         let model_1 = model.clone();
@@ -218,7 +218,7 @@ mod tests {
         let mut model: Model = Default::default();
         let mut opt: Adam<Model> = Default::default();
         let y = model.1.forward(Tensor2D::<8, 16>::zeros().trace());
-        let g = y.mean().backward();
+        let g = backward(y.mean());
         opt.update(&mut model, g).expect_err("");
     }
 }

--- a/src/optim/mod.rs
+++ b/src/optim/mod.rs
@@ -22,7 +22,7 @@
 //! # let loss = mse_loss(y, &Tensor1D::zeros());
 //! // -- snip loss computation --
 //!
-//! let gradients: Gradients = loss.backward();
+//! let gradients: Gradients = backward(loss);
 //! opt.update(&mut model, gradients);
 //! ```
 

--- a/src/optim/rmsprop.rs
+++ b/src/optim/rmsprop.rs
@@ -173,7 +173,7 @@ mod tests {
         let mut t: Tensor1D<5> = Tensor1D::ones();
         let mut opt = RMSprop::new(cfg);
         for e in expected.iter() {
-            let gradients = (t.trace() * &rate).square().sum().backward();
+            let gradients = backward((t.trace() * &rate).square().sum());
             opt.update(&mut t, gradients).expect("");
             assert_eq!(t.data(), e);
         }
@@ -280,7 +280,7 @@ mod tests {
         let mut model: Model = Default::default();
         let mut opt: RMSprop<Model> = Default::default();
         let y = model.1.forward(Tensor2D::<8, 16>::zeros().trace());
-        let g = y.mean().backward();
+        let g = backward(y.mean());
         opt.update(&mut model, g).expect_err("");
     }
 }

--- a/src/optim/sgd.rs
+++ b/src/optim/sgd.rs
@@ -164,7 +164,7 @@ mod tests {
         let targ: Tensor1D<5> = Tensor1D::ones();
         for _ in 0..5 {
             let loss = (pred.trace() - &targ).abs().mean();
-            let gradients = loss.backward();
+            let gradients = backward(loss);
             sgd.update(&mut pred, gradients).expect("");
         }
         assert_eq!(pred.data(), &[1.0; 5]);
@@ -186,7 +186,7 @@ mod tests {
         ];
 
         for e in expected.iter() {
-            let gradients = (t.trace() * &rate).mean().backward();
+            let gradients = backward((t.trace() * &rate).mean());
             sgd.update(&mut t, gradients).expect("");
             assert_eq!(t.data(), e);
         }
@@ -210,7 +210,7 @@ mod tests {
         ];
 
         for e in expected.iter() {
-            let gradients = (t.trace() * &rate).mean().backward();
+            let gradients = backward((t.trace() * &rate).mean());
             sgd.update(&mut t, gradients).expect("");
             assert_eq!(t.data(), e);
         }
@@ -234,7 +234,7 @@ mod tests {
         ];
 
         for e in expected.iter() {
-            let gradients = (t.trace() * &rate).mean().backward();
+            let gradients = backward((t.trace() * &rate).mean());
             sgd.update(&mut t, gradients).expect("");
             assert_eq!(t.data(), e);
         }
@@ -254,7 +254,7 @@ mod tests {
 
         let py = model.forward(x.trace());
         let loss = (py - &y).square().mean();
-        let gradients = loss.backward();
+        let gradients = backward(loss);
         opt.update(&mut model, gradients).expect("");
 
         let model_1 = model.clone();
@@ -273,7 +273,7 @@ mod tests {
         let mut model: Model = Default::default();
         let mut opt: Sgd<Model> = Default::default();
         let y = model.1.forward(Tensor2D::<8, 16>::zeros().trace());
-        let g = y.mean().backward();
+        let g = backward(y.mean());
         opt.update(&mut model, g).expect_err("");
     }
 }

--- a/src/tensor_ops/arith_scalar.rs
+++ b/src/tensor_ops/arith_scalar.rs
@@ -153,7 +153,7 @@ mod tests {
         let x = tensor(0.0);
         let r = x.trace() + 1.0;
         assert_eq!(r.data(), &1.0);
-        let gradients = r.exp().backward();
+        let gradients = backward(r.exp());
         assert_eq!(gradients.ref_gradient(&x), &1.0f32.exp());
     }
 
@@ -162,7 +162,7 @@ mod tests {
         let x = tensor([0.0, 1.0, 2.0]);
         let r = x.trace() + 0.5;
         assert_eq!(r.data(), &[0.5, 1.5, 2.5]);
-        let gradients = r.exp().sum().backward();
+        let gradients = backward(r.exp().sum());
         assert_eq!(
             gradients.ref_gradient(&x),
             &[1.6487212, 4.481689, 12.182494]
@@ -174,7 +174,7 @@ mod tests {
         let x = Tensor2D::zeros();
         let r = x.trace() + 0.5;
         assert_eq!(r.data(), &[[0.5; 2]; 3]);
-        let gradients = r.exp().sum().backward();
+        let gradients = backward(r.exp().sum());
         assert_eq!(gradients.ref_gradient(&x), &[[1.6487212; 2]; 3]);
     }
 
@@ -183,7 +183,7 @@ mod tests {
         let x = tensor(0.0);
         let r = x.trace() - 1.0;
         assert_eq!(r.data(), &-1.0);
-        let gradients = r.exp().sum().backward();
+        let gradients = backward(r.exp().sum());
         assert_eq!(gradients.ref_gradient(&x), &(-1.0f32).exp());
     }
 
@@ -192,7 +192,7 @@ mod tests {
         let x = tensor([0.0, 1.0, 2.0]);
         let r = x.trace() - 1.0;
         assert_eq!(r.data(), &[-1.0, 0.0, 1.0]);
-        let gradients = r.exp().sum().backward();
+        let gradients = backward(r.exp().sum());
         assert_eq!(gradients.ref_gradient(&x), &[0.36787945, 1.0, 2.7182817]);
     }
 
@@ -201,7 +201,7 @@ mod tests {
         let x = Tensor2D::zeros();
         let r = x.trace() - 1.0;
         assert_eq!(r.data(), &[[-1.0; 2]; 3]);
-        let gradients = r.exp().sum().backward();
+        let gradients = backward(r.exp().sum());
         assert_eq!(gradients.ref_gradient(&x), &[[0.36787945; 2]; 3]);
     }
 
@@ -210,7 +210,7 @@ mod tests {
         let x = tensor(1.0);
         let r = x.trace() * 0.5;
         assert_eq!(r.data(), &0.5);
-        let gradients = r.exp().sum().backward();
+        let gradients = backward(r.exp().sum());
         assert_eq!(gradients.ref_gradient(&x), &0.8243606);
     }
 
@@ -219,7 +219,7 @@ mod tests {
         let x = tensor([0.0, 1.0, 2.0]);
         let r = x.trace() * 0.5;
         assert_eq!(r.data(), &[0.0, 0.5, 1.0]);
-        let gradients = r.exp().sum().backward();
+        let gradients = backward(r.exp().sum());
         assert_eq!(gradients.ref_gradient(&x), &[0.5, 0.8243606, 1.3591409]);
     }
 
@@ -228,7 +228,7 @@ mod tests {
         let x = Tensor2D::ones();
         let r = x.trace() * 0.5;
         assert_eq!(r.data(), &[[0.5; 2]; 3]);
-        let gradients = r.exp().sum().backward();
+        let gradients = backward(r.exp().sum());
         assert_eq!(gradients.ref_gradient(&x), &[[0.8243606; 2]; 3]);
     }
 
@@ -237,7 +237,7 @@ mod tests {
         let x = tensor(1.0);
         let r = x.trace() / 2.0;
         assert_eq!(r.data(), &0.5);
-        let gradients = r.exp().sum().backward();
+        let gradients = backward(r.exp().sum());
         assert_eq!(gradients.ref_gradient(&x), &0.8243606);
     }
 
@@ -246,7 +246,7 @@ mod tests {
         let x = tensor([0.0, 1.0, 2.0]);
         let r = x.trace() / 2.0;
         assert_eq!(r.data(), &[0.0, 0.5, 1.0]);
-        let gradients = r.exp().sum().backward();
+        let gradients = backward(r.exp().sum());
         assert_eq!(gradients.ref_gradient(&x), &[0.5, 0.8243606, 1.3591409]);
     }
 
@@ -255,7 +255,7 @@ mod tests {
         let x = Tensor2D::ones();
         let r = x.trace() / 2.0;
         assert_eq!(r.data(), &[[0.5; 2]; 3]);
-        let gradients = r.exp().sum().backward();
+        let gradients = backward(r.exp().sum());
         assert_eq!(gradients.ref_gradient(&x), &[[0.8243606; 2]; 3]);
     }
 }

--- a/src/tensor_ops/conv.rs
+++ b/src/tensor_ops/conv.rs
@@ -258,7 +258,7 @@ mod tests {
             result.data(),
             &[[[0.24369538, 0.71453357]], [[-0.69169492, -0.06172103]]],
         );
-        let g = result.exp().mean().backward();
+        let g = backward(result.exp().mean());
         assert_close(
             g.ref_gradient(&x),
             &[[
@@ -295,7 +295,7 @@ mod tests {
         ]]);
         let result = conv2d::<OwnedTape, 1, 2, 2, 2, 0, 2, 3>(x.trace(), &weight, &bias);
         assert_close(result.data(), &[[[-0.29368058]], [[0.30018353]]]);
-        let g = result.exp().mean().backward();
+        let g = backward(result.exp().mean());
         assert_close(
             g.ref_gradient(&x),
             &[[[-0.03917716, 0.06006697, 0.], [0.19859464, 0.19576924, 0.]]],
@@ -346,7 +346,7 @@ mod tests {
                 ],
             ],
         );
-        let gradients = result.exp().mean().backward();
+        let gradients = backward(result.exp().mean());
         assert_close(
             gradients.ref_gradient(&x),
             &[[[0.010052743, 0.038219165]], [[0.0013861917, 0.096129306]]],
@@ -415,7 +415,7 @@ mod tests {
                 ],
             ],
         );
-        let gradients = result.exp().mean().backward();
+        let gradients = backward(result.exp().mean());
         assert_close(
             gradients.ref_gradient(&x),
             &[[
@@ -488,7 +488,7 @@ mod tests {
                 ],
             ],
         );
-        let gradients = result.exp().mean().backward();
+        let gradients = backward(result.exp().mean());
         assert_close(
             gradients.ref_gradient(&x),
             &[

--- a/src/tensor_ops/impl_add.rs
+++ b/src/tensor_ops/impl_add.rs
@@ -44,7 +44,7 @@ mod tests {
 
         let r = a.trace() + &b;
         assert_eq!(r.data(), &2.0);
-        let gradients = r.backward();
+        let gradients = backward(r);
         assert_eq!(gradients.ref_gradient(&a), &1.0);
         assert_eq!(gradients.ref_gradient(&b), &1.0);
     }
@@ -56,7 +56,7 @@ mod tests {
 
         let r = a.trace() + &b;
         assert_eq!(r.data(), &[2.0, 1.0, 3.0]);
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(gradients.ref_gradient(&a), &[1.0 / 3.0; 3]);
         assert_eq!(gradients.ref_gradient(&b), &[1.0 / 3.0; 3]);
     }
@@ -71,7 +71,7 @@ mod tests {
             r.data(),
             &[[1.1769, 0.5552, 0.5259], [1.3917, 1.0692, 0.873]]
         );
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(gradients.ref_gradient(&a), &[[1.0 / 6.0; 3]; 2]);
         assert_eq!(gradients.ref_gradient(&b), &[[1.0 / 6.0; 3]; 2]);
     }

--- a/src/tensor_ops/impl_backward.rs
+++ b/src/tensor_ops/impl_backward.rs
@@ -5,27 +5,16 @@ use crate::prelude::*;
 /// This function takes ownership of `t` and returns [Gradients].
 ///
 /// Note that `t` is required to have [OwnedTape], which means it currently owns the [crate::gradients::GradientTape].
-pub fn backward<T: Tensor<Dtype = f32, Tape = OwnedTape>>(t: T) -> Gradients {
+pub fn backward(t: Tensor0D<OwnedTape>) -> Gradients {
     let (t, mut tape) = t.split_tape();
     tape.add_backward_op(move |grads| {
-        T::Device::fill(grads.mut_gradient(&t), &mut |v| *v = 1.0);
+        Cpu::fill(grads.mut_gradient(&t), &mut |v| *v = 1.0);
     });
     tape.0.execute()
 }
 
-macro_rules! tensor_impl {
-    ($typename:ident, [$($Vs:tt),*]) => {
-impl<$(const $Vs: usize, )*> $typename<$($Vs, )* OwnedTape> {
-    /// Calls [backward()] on `self`
+impl Tensor0D<OwnedTape> {
     pub fn backward(self) -> Gradients {
         backward(self)
     }
 }
-    };
-}
-
-tensor_impl!(Tensor0D, []);
-tensor_impl!(Tensor1D, [M]);
-tensor_impl!(Tensor2D, [M, N]);
-tensor_impl!(Tensor3D, [M, N, O]);
-tensor_impl!(Tensor4D, [M, N, O, P]);

--- a/src/tensor_ops/impl_broadcast_reduce.rs
+++ b/src/tensor_ops/impl_broadcast_reduce.rs
@@ -158,7 +158,7 @@ mod tests {
         let a_up: Tensor2D<5, 3, OwnedTape> = a.trace().broadcast();
         assert_close(a_up.data(), &[*a.data(); 5]);
         let r = mul(a_up, &b);
-        let g = r.exp().mean().backward();
+        let g = backward(r.exp().mean());
         // a's gradient: (b * (b * a).exp()).sum(0) / 15
         // b's gradient: (a * (b * a).exp()) / 15
         let a_up: Tensor2D<5, 3> = a.clone().broadcast();

--- a/src/tensor_ops/impl_clamp.rs
+++ b/src/tensor_ops/impl_clamp.rs
@@ -43,7 +43,7 @@ mod tests {
         let t = tensor(1.0);
         let r = t.trace().clamp(0.0, 1.0);
         assert_eq!(r.data(), &1.0);
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(gradients.ref_gradient(&t), &1.0);
     }
 
@@ -53,7 +53,7 @@ mod tests {
         let r = t.trace().clamp(-0.5, 0.25);
         assert_eq!(r.data(), &[-0.5, -0.5, -0.25, 0.0, 0.25, 0.25, 0.25]);
         // NOTE: .exp() so we cover case where .clamp() needs to use result's grad
-        let gradients = r.exp().mean().backward();
+        let gradients = backward(r.exp().mean());
         assert_eq!(
             gradients.ref_gradient(&t),
             &[0.0, 0.08664724, 0.11125726, 0.14285715, 0.1834322, 0.0, 0.0]
@@ -65,7 +65,7 @@ mod tests {
         let t: Tensor2D<2, 3> = tensor([[-1.0, 0.0, 1.0], [-2.0, 2.0, 1.1]]);
         let r = t.trace().clamp(-1.0, 1.0);
         assert_eq!(r.data(), &[[-1.0, 0.0, 1.0], [-1.0, 1.0, 1.0]]);
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(gradients.ref_gradient(&t), &[[1.0 / 6.0; 3], [0.0; 3]]);
     }
 }

--- a/src/tensor_ops/impl_div.rs
+++ b/src/tensor_ops/impl_div.rs
@@ -47,7 +47,7 @@ mod tests {
 
         let r = b.trace() / &a;
         assert_eq!(r.data(), &2.0);
-        let gradients = r.backward();
+        let gradients = backward(r);
         assert_eq!(gradients.ref_gradient(&a), &-1.0);
         assert_eq!(gradients.ref_gradient(&b), &0.5);
     }
@@ -59,7 +59,7 @@ mod tests {
 
         let r = b.trace() / &a;
         assert_eq!(r.data(), &[1.0, -0.5, 0.0]);
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(gradients.ref_gradient(&a), &[-1.0 / 3.0, 1.0 / 12.0, 0.0]);
         assert_eq!(
             gradients.ref_gradient(&b),
@@ -80,7 +80,7 @@ mod tests {
                 [1.4597031, 0.52524966, 0.046511628]
             ]
         );
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(
             gradients.ref_gradient(&a),
             &[

--- a/src/tensor_ops/impl_dropout.rs
+++ b/src/tensor_ops/impl_dropout.rs
@@ -89,7 +89,7 @@ mod tests {
         let t: Tensor0D = Tensor0D::new(3.0);
         let r = t.trace().dropout(1.0, &mut rng);
         assert_eq!(r.data(), &0.0);
-        let gradients = r.backward();
+        let gradients = backward(r);
         assert_eq!(gradients.ref_gradient(&t), &0.0);
     }
 
@@ -99,7 +99,7 @@ mod tests {
         let t: Tensor0D = Tensor0D::new(3.0);
         let r = t.trace().dropout(0.0, &mut rng);
         assert_eq!(r.data(), &3.0);
-        let gradients = r.backward();
+        let gradients = backward(r);
         assert_eq!(gradients.ref_gradient(&t), &1.0);
     }
 
@@ -117,7 +117,7 @@ mod tests {
         let t = Tensor1D::new([0.0, 2.0, -3.0, -4.0, 0.0]);
         let r = t.trace().dropout(0.5, &mut rng);
         assert_eq!(r.data(), &[0.0, 0.0, 0.0, -8.0, 0.0]);
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(gradients.ref_gradient(&t), &[0.0, 0.0, 0.0, 0.4, 0.0]);
     }
 
@@ -128,7 +128,7 @@ mod tests {
         let r = t.trace().dropout(0.6, &mut rng);
         assert_close(r.data(), &[[0.125, 0.25, -0.5], [0.0, 0.0, 1.25]]);
         // NOTE: .exp() so we ensure result grad is used properly
-        let gradients = r.exp().mean().backward();
+        let gradients = backward(r.exp().mean());
         assert_eq!(
             gradients.ref_gradient(&t),
             &[[0.47214523, 0.5350107, 0.2527211], [0.0, 0.0, 1.4543099]]
@@ -149,7 +149,7 @@ mod tests {
                 [[1.25, 1.25, 1.25], [1.25, 1.25, 1.25]]
             ]
         );
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         const V: f32 = 0.052083336;
         assert_eq!(
             gradients.ref_gradient(&t),

--- a/src/tensor_ops/impl_mask.rs
+++ b/src/tensor_ops/impl_mask.rs
@@ -57,7 +57,7 @@ mod tests {
         let m = tensor(-1e10);
         let r = t.trace().value_mask(&m, -1e10);
         assert_eq!(r.data(), &-1e10);
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(gradients.ref_gradient(&t), &0.0);
     }
 
@@ -68,7 +68,7 @@ mod tests {
         let r = t.trace().value_mask(&m, -1e10);
         assert_eq!(r.data(), &[-1e10, 2.0, -1e10]);
         // NOTE: .exp() so we cover the case where .mask() has to use result grad
-        let gradients = r.exp().mean().backward();
+        let gradients = backward(r.exp().mean());
         assert_eq!(gradients.ref_gradient(&t), &[0.0, 2.463019, 0.0]);
     }
 
@@ -78,7 +78,7 @@ mod tests {
         let m: Tensor2D<2, 3> = tensor([[-1e10, 0.0, -1e10], [1.0, -1e10, -1e9]]);
         let r = t.trace().value_mask(&m, -1e10);
         assert_eq!(r.data(), &[[-1e10, 2.0, -1e10], [4.0, -1e10, 6.0]]);
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(
             gradients.ref_gradient(&t),
             &[[0.0, 1.0 / 6.0, 0.0], [1.0 / 6.0, 0.0, 1.0 / 6.0]]

--- a/src/tensor_ops/impl_minimum.rs
+++ b/src/tensor_ops/impl_minimum.rs
@@ -67,7 +67,7 @@ mod tests {
         let result = minimum(a.trace(), &b);
         assert_eq!(result.data(), &[[-1., 0., -1.], [3., -4., -5.]]);
 
-        let g = result.sum().backward();
+        let g = backward(result.sum());
         assert_eq!(g.ref_gradient(&a), &[[1.0, 0.5, 0.0], [0.5, 0.0, 1.0]]);
         assert_eq!(g.ref_gradient(&b), &[[0.0, 0.5, 1.0], [0.5, 1.0, 0.0]]);
     }

--- a/src/tensor_ops/impl_mul.rs
+++ b/src/tensor_ops/impl_mul.rs
@@ -55,7 +55,7 @@ mod tests {
 
         let r = a.trace() * &b;
         assert_eq!(r.data(), &[1.0, -2.0, 0.0]);
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(gradients.ref_gradient(&a), &[1.0 / 3.0, -1.0 / 3.0, 0.0]);
         assert_eq!(gradients.ref_gradient(&b), &[1.0 / 3.0, 2.0 / 3.0, 1.0]);
     }
@@ -73,7 +73,7 @@ mod tests {
                 [0.46729425, 0.2581082, 0.03236696]
             ]
         );
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(
             gradients.ref_gradient(&a),
             &[

--- a/src/tensor_ops/impl_nans.rs
+++ b/src/tensor_ops/impl_nans.rs
@@ -45,7 +45,7 @@ mod tests {
         let t = tensor(f32::NAN);
         let r = t.trace().nans_to(0.0);
         assert_eq!(r.data(), &0.0);
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(gradients.ref_gradient(&t), &0.0);
     }
 
@@ -55,7 +55,7 @@ mod tests {
         let r = t.trace().nans_to(0.0);
         assert_eq!(r.data(), &[1.0, 0.0, 0.0, 4.0]);
         // NOTE: .exp() so we cover case where nans_to() needs to use result grad
-        let gradients = r.exp().mean().backward();
+        let gradients = backward(r.exp().mean());
         assert_eq!(
             gradients.ref_gradient(&t),
             &[0.67957044, 0.0, 0.0, 13.649537]
@@ -67,7 +67,7 @@ mod tests {
         let t: Tensor2D<2, 3> = tensor([[1.0, f32::NAN, 3.0], [f32::NAN, 4.0, f32::NAN]]);
         let r = t.trace().nans_to(0.0);
         assert_eq!(r.data(), &[[1.0, 0.0, 3.0], [0.0, 4.0, 0.0]]);
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(
             gradients.ref_gradient(&t),
             &[[1.0 / 6.0, 0.0, 1.0 / 6.0], [0.0, 1.0 / 6.0, 0.0]]

--- a/src/tensor_ops/impl_pow.rs
+++ b/src/tensor_ops/impl_pow.rs
@@ -67,7 +67,7 @@ mod tests {
         assert!(r.data()[1].is_nan());
         assert_eq!(&r.data()[2..], &[0.0, 1.0, 11.313708]);
 
-        let g = r.sum().backward();
+        let g = backward(r.sum());
         let grad = g.ref_gradient(&t);
         assert!(grad[0].is_nan());
         assert!(grad[1].is_nan());
@@ -82,7 +82,7 @@ mod tests {
         assert!(r.data()[1].is_nan());
         assert_eq!(&r.data()[2..], &[f32::INFINITY, 1.0, 0.43527526]);
 
-        let g = r.sum().backward();
+        let g = backward(r.sum());
         let grad = g.ref_gradient(&t);
         assert!(grad[0].is_nan());
         assert!(grad[1].is_nan());
@@ -94,7 +94,7 @@ mod tests {
         let t = tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
         let r = t.trace().powi(3);
         assert_eq!(r.data(), &[-8., -1., 0., 1., 8.]);
-        let g = r.sum().backward();
+        let g = backward(r.sum());
         assert_eq!(g.ref_gradient(&t), &[12., 3., 0., 3., 12.]);
     }
 
@@ -103,7 +103,7 @@ mod tests {
         let t = tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
         let r = t.trace().powi(-3);
         assert_eq!(r.data(), &[-0.125, -1.0, f32::INFINITY, 1.0, 0.125]);
-        let g = r.sum().backward();
+        let g = backward(r.sum());
         assert_eq!(
             g.ref_gradient(&t),
             &[-0.1875, -3., f32::NEG_INFINITY, -3., -0.1875]

--- a/src/tensor_ops/impl_reshape.rs
+++ b/src/tensor_ops/impl_reshape.rs
@@ -98,7 +98,7 @@ mod tests {
         let a = Tensor1D::new([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]);
         let b: Tensor2D<2, 3, OwnedTape> = a.trace().reshape();
         assert_eq!(b.data(), &[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]);
-        let gradients = b.exp().mean().backward();
+        let gradients = backward(b.exp().mean());
         assert_eq!(
             gradients.ref_gradient(&a),
             &[0.18419516, 0.20356713, 0.22497648, 0.24863747, 0.2747869, 0.3036865]

--- a/src/tensor_ops/impl_sub.rs
+++ b/src/tensor_ops/impl_sub.rs
@@ -55,7 +55,7 @@ mod tests {
 
         let r = b.trace() - &a;
         assert_eq!(r.data(), &[0.0, -3.0, -3.0]);
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(gradients.ref_gradient(&a), &[-1.0 / 3.0; 3]);
         assert_eq!(gradients.ref_gradient(&b), &[1.0 / 3.0; 3]);
     }
@@ -73,7 +73,7 @@ mod tests {
                 [0.2601, -0.33279997, -0.7954]
             ]
         );
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(gradients.ref_gradient(&a), &[[-1.0 / 6.0; 3]; 2]);
         assert_eq!(gradients.ref_gradient(&b), &[[1.0 / 6.0; 3]; 2]);
     }

--- a/src/tensor_ops/matmul.rs
+++ b/src/tensor_ops/matmul.rs
@@ -288,7 +288,7 @@ mod tests {
                 [1.0546886, 1.165766],
             ],
         );
-        let gradients = r.exp().mean().backward();
+        let gradients = backward(r.exp().mean());
         assert_close(
             gradients.ref_gradient(&a),
             &[
@@ -319,8 +319,8 @@ mod tests {
         let c_tr = matmul_transpose(a.trace(), &b_t);
         assert_close(c_tr.data(), c.data());
 
-        let gs = c.exp().mean().backward();
-        let gs_tr = c_tr.exp().mean().backward();
+        let gs = backward(c.exp().mean());
+        let gs_tr = backward(c_tr.exp().mean());
         assert_close(gs_tr.ref_gradient(&a), gs.ref_gradient(&a));
         assert_close(gs_tr.ref_gradient(&b_t), &transpose(gs.ref_gradient(&b)));
     }
@@ -336,11 +336,11 @@ mod tests {
             let sub_a = Tensor2D::new(a.data()[i]);
             assert_close(&r.data()[i], matmul(sub_a, &b).data());
         }
-        let gs = r.sum().backward();
+        let gs = backward(r.sum());
         let mut sub_bs_summed = [[0.0; 2]; 3];
         for i in 0..N {
             let sub_a = Tensor2D::new(a.data()[i]);
-            let sub_gs = matmul(sub_a.trace(), &b).sum().backward();
+            let sub_gs = backward(matmul(sub_a.trace(), &b).sum());
             assert_close(&gs.ref_gradient(&a)[i], sub_gs.ref_gradient(&sub_a));
             <Cpu as Device<_>>::add(&mut sub_bs_summed, sub_gs.ref_gradient(&b));
         }
@@ -358,8 +358,8 @@ mod tests {
         let c_tr = matmul_transpose(a.trace(), &b_t);
         assert_close(c_tr.data(), c.data());
 
-        let gs = c.exp().mean().backward();
-        let gs_tr = c_tr.exp().mean().backward();
+        let gs = backward(c.exp().mean());
+        let gs_tr = backward(c_tr.exp().mean());
         assert_close(gs_tr.ref_gradient(&a), gs.ref_gradient(&a));
         assert_close(gs_tr.ref_gradient(&b_t), &transpose(gs.ref_gradient(&b)));
     }
@@ -370,7 +370,7 @@ mod tests {
         let b = tensor([[0.7804, 0.5540], [0.5378, 0.8401], [0.5042, 0.8604]]);
         let r: Tensor1D<2, OwnedTape> = vecmat_mul(a.trace(), &b);
         assert_close(r.data(), &[1.261436, 1.5543157]);
-        let g = r.exp().mean().backward();
+        let g = backward(r.exp().mean());
         assert_close(g.ref_gradient(&a), &[2.6883178, 2.9369607, 2.9256766]);
         assert_close(
             g.ref_gradient(&b),
@@ -388,7 +388,7 @@ mod tests {
         let b = tensor([[0.7804, 0.5378, 0.5042], [0.5540, 0.8401, 0.8604]]);
         let r: Tensor1D<2, OwnedTape> = vecmat_mul_transpose(a.trace(), &b);
         assert_close(r.data(), &[1.261436, 1.5543157]);
-        let g = r.exp().mean().backward();
+        let g = backward(r.exp().mean());
         assert_close(g.ref_gradient(&a), &[2.6883178, 2.9369607, 2.9256766]);
         assert_close(
             g.ref_gradient(&b),

--- a/src/tensor_ops/permute.rs
+++ b/src/tensor_ops/permute.rs
@@ -250,8 +250,8 @@ mod tests {
     fn test_permute_2d_backwards() {
         let mut rng = thread_rng();
         let t: Tensor2D<3, 6> = TensorCreator::randn(&mut rng);
-        let g1 = t.trace().permute_axes::<1, 0>().exp().sum().backward();
-        let g2 = t.trace().exp().sum().backward();
+        let g1 = backward(t.trace().permute_axes::<1, 0>().exp().sum());
+        let g2 = backward(t.trace().exp().sum());
         assert_eq!(g1.ref_gradient(&t), g2.ref_gradient(&t));
     }
 
@@ -259,8 +259,8 @@ mod tests {
     fn test_permute_3d_backwards() {
         let mut rng = thread_rng();
         let t: Tensor3D<3, 6, 9> = TensorCreator::randn(&mut rng);
-        let g1 = t.trace().permute_axes::<1, 2, 0>().exp().sum().backward();
-        let g2 = t.trace().exp().sum().backward();
+        let g1 = backward(t.trace().permute_axes::<1, 2, 0>().exp().sum());
+        let g2 = backward(t.trace().exp().sum());
         assert_eq!(g1.ref_gradient(&t), g2.ref_gradient(&t));
     }
 
@@ -268,13 +268,8 @@ mod tests {
     fn test_permute_4d_backwards() {
         let mut rng = thread_rng();
         let t: Tensor4D<3, 6, 9, 11> = TensorCreator::randn(&mut rng);
-        let g1 = t
-            .trace()
-            .permute_axes::<3, 1, 0, 2>()
-            .exp()
-            .sum()
-            .backward();
-        let g2 = t.trace().exp().sum().backward();
+        let g1 = backward(t.trace().permute_axes::<3, 1, 0, 2>().exp().sum());
+        let g2 = backward(t.trace().exp().sum());
         assert_eq!(g1.ref_gradient(&t), g2.ref_gradient(&t));
     }
 

--- a/src/tensor_ops/select.rs
+++ b/src/tensor_ops/select.rs
@@ -169,7 +169,7 @@ mod tests {
         let t: Tensor1D<5> = TensorCreator::randn(&mut rng);
         let r: Tensor0D<OwnedTape> = t.trace().select(&0);
         assert_eq!(r.data(), &t.data()[0]);
-        let g = r.exp().mean().backward();
+        let g = backward(r.exp().mean());
         assert_eq!(g.ref_gradient(&t), &[t.data()[0].exp(), 0.0, 0.0, 0.0, 0.0]);
     }
 
@@ -179,7 +179,7 @@ mod tests {
         let t: Tensor1D<5> = TensorCreator::randn(&mut rng);
         let r: Tensor1D<2, OwnedTape> = t.trace().select(&[0, 3]);
         assert_eq!(r.data(), &[t.data()[0], t.data()[3]]);
-        let g = r.mean().backward();
+        let g = backward(r.mean());
         assert_eq!(g.ref_gradient(&t), &[0.5, 0.0, 0.0, 0.5, 0.0]);
     }
 
@@ -193,7 +193,7 @@ mod tests {
             r.data(),
             &[_t[0], _t[1], _t[2], _t[3], _t[4], _t[2], _t[4], _t[4]]
         );
-        let g = r.mean().backward();
+        let g = backward(r.mean());
         assert_eq!(
             g.ref_gradient(&t),
             &[1.0 / 8.0, 1.0 / 8.0, 2.0 / 8.0, 1.0 / 8.0, 3.0 / 8.0]
@@ -206,7 +206,7 @@ mod tests {
         let r: Tensor0D<OwnedTape> = t.trace().select(&2);
         assert_eq!(r.data(), &3.0);
         // NOTE: .exp() so we make sure its using result grad properly
-        let gradients = r.exp().backward();
+        let gradients = backward(r.exp());
         assert_eq!(gradients.ref_gradient(&t), &[0.0, 0.0, 20.085537]);
     }
 
@@ -215,7 +215,7 @@ mod tests {
         let t: Tensor2D<2, 3> = Tensor2D::new([[1.0, 2.0, 3.0], [-1.0, -2.0, -3.0]]);
         let r: Tensor1D<2, OwnedTape> = t.trace().select(&[1, 2]);
         assert_eq!(r.data(), &[2.0, -3.0]);
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(
             gradients.ref_gradient(&t),
             &[[0.0, 0.5, 0.0], [0.0, 0.0, 0.5]]
@@ -235,7 +235,7 @@ mod tests {
             r.data(),
             &[[1.0, 5.0], [-3.0, -6.0], [2.0, 5.0], [1.0, 4.0]]
         );
-        let gradients = r.mean().backward();
+        let gradients = backward(r.mean());
         assert_eq!(
             gradients.ref_gradient(&t),
             &[
@@ -257,7 +257,7 @@ mod tests {
         assert_close(&r.data()[0], r0.data());
         assert_close(&r.data()[1], r1.data());
 
-        let g = r.sum().backward();
+        let g = backward(r.sum());
         assert_eq!(g.ref_gradient(&t), &[[3.; 5], [0.; 5], [1.; 5], [2.; 5]]);
     }
 }


### PR DESCRIPTION
Prepping for #194 

Doing this to:
1. Minimize bugs of doing backwards on > 0d tensors when you don't mean to
2. Move to using backwards as a function so type inference works better