### PR TITLE
[Breaking] Reduce things exported in prelude

### DIFF
--- a/examples/01-tensor.rs
+++ b/examples/01-tensor.rs
@@ -2,7 +2,8 @@
 
 use rand::thread_rng;
 
-use dfdx::tensor::{tensor, HasArrayData, Tensor1D, Tensor2D, Tensor3D, TensorCreator};
+use dfdx::arrays::HasArrayData;
+use dfdx::tensor::{tensor, Tensor1D, Tensor2D, Tensor3D, TensorCreator};
 
 fn main() {
     // easily create tensors using the `tensor` function

--- a/examples/02-ops.rs
+++ b/examples/02-ops.rs
@@ -2,7 +2,8 @@
 
 use rand::prelude::*;
 
-use dfdx::tensor::{HasArrayData, Tensor0D, Tensor2D, TensorCreator};
+use dfdx::arrays::HasArrayData;
+use dfdx::tensor::{Tensor0D, Tensor2D, TensorCreator};
 use dfdx::tensor_ops::add;
 
 fn main() {

--- a/examples/05-optim.rs
+++ b/examples/05-optim.rs
@@ -2,11 +2,12 @@
 
 use rand::prelude::*;
 
+use dfdx::arrays::HasArrayData;
 use dfdx::gradients::{Gradients, OwnedTape};
 use dfdx::losses::mse_loss;
 use dfdx::nn::{Linear, Module, ReLU, ResetParams, Tanh};
 use dfdx::optim::{Momentum, Optimizer, Sgd, SgdConfig};
-use dfdx::tensor::{HasArrayData, Tensor2D, TensorCreator};
+use dfdx::tensor::{Tensor2D, TensorCreator};
 
 // first let's declare our neural network to optimze
 type Mlp = (

--- a/examples/06-mnist.rs
+++ b/examples/06-mnist.rs
@@ -2,6 +2,7 @@
 //! to build a neural network that learns to recognize
 //! the MNIST digits.
 
+use dfdx::data::SubsetIterator;
 use dfdx::prelude::*;
 use indicatif::ProgressBar;
 use mnist::*;

--- a/examples/08-tensor-broadcast-reduce.rs
+++ b/examples/08-tensor-broadcast-reduce.rs
@@ -1,8 +1,8 @@
 //! Demonstrates broadcasting tensors to different sizes, and axis reductions
 //! with BroadcastTo and ReduceTo
 
-use dfdx::arrays::Axis;
-use dfdx::tensor::{tensor, HasArrayData, Tensor1D, Tensor2D, Tensor4D};
+use dfdx::arrays::{Axis, HasArrayData};
+use dfdx::tensor::{tensor, Tensor1D, Tensor2D, Tensor4D};
 use dfdx::tensor_ops::BroadcastTo;
 
 fn main() {

--- a/examples/10-tensor-index.rs
+++ b/examples/10-tensor-index.rs
@@ -1,6 +1,7 @@
 //! Demonstrates how to select sub tensors (index) from tensors
 
-use dfdx::tensor::{tensor, HasArrayData, Tensor2D, Tensor3D};
+use dfdx::arrays::HasArrayData;
+use dfdx::tensor::{tensor, Tensor2D, Tensor3D};
 use dfdx::tensor_ops::Select1;
 
 fn main() {

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -180,6 +180,12 @@ pub trait HasArrayType {
         + HasLastAxis;
 }
 
+/// Something that has [HasArrayType], and also can return a reference to or mutate `Self::Array`.
+pub trait HasArrayData: HasArrayType {
+    fn data(&self) -> &Self::Array;
+    fn mut_data(&mut self) -> &mut Self::Array;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,7 +1,8 @@
 //! A collection of data utility classes such as [one_hot_encode()] and [SubsetIterator].
 
-use crate::prelude::*;
 use rand::prelude::SliceRandom;
+
+use crate::tensor::{HasArrayData, Tensor1D, Tensor2D, TensorCreator};
 
 /// Generates a tensor with ordered data from 0 to `N`.
 ///

--- a/src/data.rs
+++ b/src/data.rs
@@ -9,13 +9,13 @@ use crate::tensor::{Tensor1D, Tensor2D, TensorCreator};
 ///
 /// Examples:
 /// ```rust
-/// # use dfdx::prelude::*;
+/// # use dfdx::{prelude::*, data::arange};
 /// let t = arange::<5>();
 /// assert_eq!(t.data(), &[0.0, 1.0, 2.0, 3.0, 4.0]);
 /// ```
 ///
 /// ```rust
-/// # use dfdx::prelude::*;
+/// # use dfdx::{prelude::*, data::arange};
 /// let t: Tensor1D<10> = arange();
 /// assert_eq!(t.data(), &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
 /// ```
@@ -41,8 +41,7 @@ pub fn arange<const N: usize>() -> Tensor1D<N> {
 ///
 /// Examples:
 /// ```rust
-/// # use dfdx::prelude::*;
-///
+/// # use dfdx::{prelude::*, data::one_hot_encode};
 /// let class_labels = [0, 1, 2, 1, 1];
 /// // NOTE: 5 is the batch size, 3 is the number of classes
 /// let probs = one_hot_encode::<5, 3>(&class_labels);
@@ -70,14 +69,14 @@ pub fn one_hot_encode<const B: usize, const N: usize>(class_labels: &[usize; B])
 ///
 /// Iterating a dataset in order:
 /// ```rust
-/// # use dfdx::prelude::*;
+/// # use dfdx::{prelude::*, data::SubsetIterator};
 /// let mut subsets = SubsetIterator::<5>::in_order(100);
 /// assert_eq!(subsets.next(), Some([0, 1, 2, 3, 4]));
 /// ```
 ///
 /// Iterating a dataset in random order:
 /// ```rust
-/// # use dfdx::prelude::*;
+/// # use dfdx::{prelude::*, data::SubsetIterator};
 /// # use rand::prelude::*;
 /// let mut rng = StdRng::seed_from_u64(0);
 /// let mut subsets = SubsetIterator::<5>::shuffled(100, &mut rng);

--- a/src/data.rs
+++ b/src/data.rs
@@ -2,7 +2,8 @@
 
 use rand::prelude::SliceRandom;
 
-use crate::tensor::{HasArrayData, Tensor1D, Tensor2D, TensorCreator};
+use crate::arrays::HasArrayData;
+use crate::tensor::{Tensor1D, Tensor2D, TensorCreator};
 
 /// Generates a tensor with ordered data from 0 to `N`.
 ///

--- a/src/devices/fill.rs
+++ b/src/devices/fill.rs
@@ -32,7 +32,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::ZeroElements;
+    use crate::arrays::ZeroElements;
     use rand::{thread_rng, Rng};
 
     #[test]

--- a/src/devices/foreach.rs
+++ b/src/devices/foreach.rs
@@ -12,7 +12,7 @@ use crate::arrays::CountElements;
 ///
 /// Examples:
 /// ```rust
-/// # use dfdx::prelude::*;
+/// # use dfdx::devices::{Cpu, ForEachElement};
 /// let mut a = [[0.0; 3]; 2];
 /// let b = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
 /// Cpu::foreach_mr(&mut a, &b, &mut |x, y| {

--- a/src/devices/permute.rs
+++ b/src/devices/permute.rs
@@ -217,7 +217,7 @@ permutations!([0, 1, 2, 3]);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::FillElements;
+    use crate::devices::FillElements;
     use rand::{thread_rng, Rng};
 
     #[test]

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -132,7 +132,7 @@ impl Gradients {
     ///
     /// Examples:
     /// ```rust
-    /// # use dfdx::prelude::*;
+    /// # use dfdx::{prelude::*, gradients::*};
     /// let a = Tensor1D::new([1.0, 2.0, 3.0]);
     /// let b: Tensor1D<5> = Tensor1D::zeros();
     /// let mut gradients: Gradients = Default::default();
@@ -186,7 +186,7 @@ impl Gradients {
     ///
     /// Example usage:
     /// ```
-    /// # use dfdx::prelude::*;
+    /// # use dfdx::{prelude::*, gradients::*};
     /// let t = Tensor1D::new([1.0, 2.0, 3.0]);
     /// let mut gradients: Gradients = Default::default();
     /// *gradients.mut_gradient(&t) = [-4.0, 5.0, -6.0];
@@ -205,7 +205,7 @@ impl Gradients {
     ///
     /// Example usage:
     /// ```
-    /// # use dfdx::prelude::*;
+    /// # use dfdx::{prelude::*, gradients::*};
     /// let t = Tensor1D::new([1.0, 2.0, 3.0]);
     /// let mut gradients: Gradients = Default::default();
     /// let g: &mut [f32; 3] = gradients.mut_gradient(&t);
@@ -234,7 +234,7 @@ impl Gradients {
     ///
     /// # Example usage:
     /// ```
-    /// # use dfdx::prelude::*;
+    /// # use dfdx::{prelude::*, gradients::*};
     /// let t = Tensor1D::new([1.0, 2.0, 3.0]);
     /// let mut gradients: Gradients = Default::default();
     /// gradients.mut_gradient(&t);

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -1,7 +1,10 @@
 //! Implementations of [GradientTape] and generic Nd array containers via [Gradients].
 
-use crate::prelude::*;
 use std::collections::HashMap;
+
+use crate::arrays::HasArrayType;
+use crate::devices::{AllocateZeros, HasDevice};
+use crate::unique_id::{HasUniqueId, UniqueId};
 
 /// Records gradient computations to execute later.
 ///
@@ -303,6 +306,8 @@ impl UnusedTensors {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::devices::Cpu;
+    use crate::unique_id::unique_id;
 
     struct Tensor {
         id: UniqueId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,17 +109,13 @@ pub mod unique_id;
 /// Contains all public exports.
 pub mod prelude {
     pub use crate::arrays::*;
-    pub use crate::data::*;
-    pub use crate::devices::*;
+    pub use crate::devices::HasDevice;
     pub use crate::gradients::*;
     pub use crate::losses::*;
     pub use crate::nn::*;
     pub use crate::optim::*;
     pub use crate::tensor::*;
     pub use crate::tensor_ops::*;
-    pub use crate::unique_id::*;
-
-    pub use crate::{Assert, ConstTrue};
 }
 
 #[cfg(not(any(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub mod unique_id;
 pub mod prelude {
     pub use crate::arrays::{AllAxes, Axes2, Axes3, Axes4, Axis, HasArrayData};
     pub use crate::devices::HasDevice;
-    pub use crate::gradients::*;
+    pub use crate::gradients::{NoneTape, OwnedTape};
     pub use crate::losses::*;
     pub use crate::nn::*;
     pub use crate::optim::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ pub mod unique_id;
 
 /// Contains all public exports.
 pub mod prelude {
-    pub use crate::arrays::*;
+    pub use crate::arrays::{AllAxes, Axes2, Axes3, Axes4, Axis, HasArrayData};
     pub use crate::devices::HasDevice;
     pub use crate::gradients::*;
     pub use crate::losses::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //!
 //! 6. Compute gradients with [crate::tensor_ops::backward()]. See [crate::tensor_ops].
 //! ```rust
-//! # use dfdx::prelude::*;
+//! # use dfdx::{prelude::*, gradients::Gradients};
 //! # let mut rng = rand::thread_rng();
 //! # let model: Linear<10, 5> = Default::default();
 //! # let y_true: Tensor1D<5> = Tensor1D::randn(&mut rng).softmax();
@@ -76,7 +76,7 @@
 //! ```
 //! 7. Use an optimizer from [crate::optim] to optimize your network!
 //! ```rust
-//! # use dfdx::prelude::*;
+//! # use dfdx::{prelude::*, gradients::Gradients};
 //! # let mut rng = rand::thread_rng();
 //! # let mut model: Linear<10, 5> = Default::default();
 //! # let x: Tensor1D<10> = Tensor1D::zeros();

--- a/src/losses.rs
+++ b/src/losses.rs
@@ -1,6 +1,10 @@
 //! Standard loss functions such as [mse_loss()], [cross_entropy_with_logits_loss()], and more.
 
-use crate::prelude::*;
+use crate::arrays::{AllAxes, HasArrayType, HasLastAxis};
+use crate::tensor::Tensor;
+use crate::tensor_ops::{
+    abs, div_scalar, ln, log_softmax, mean, mul, mul_scalar, negate, sqrt, square, sub, Reduce,
+};
 
 /// [Mean Squared Error](https://en.wikipedia.org/wiki/Mean_squared_error).
 /// This computes `(&targ - pred).square().mean()`.
@@ -190,9 +194,9 @@ pub fn binary_cross_entropy_with_logits_loss<T: Reduce<AllAxes>>(
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::assert_close;
-
     use super::*;
+    use crate::prelude::*;
+    use crate::tests::assert_close;
 
     #[test]
     fn test_mse() {

--- a/src/nn/activations.rs
+++ b/src/nn/activations.rs
@@ -1,3 +1,4 @@
+use crate::arrays::{HasArrayType, HasLastAxis};
 use crate::prelude::*;
 use rand::Rng;
 
@@ -161,7 +162,7 @@ mod tests {
 
         let t = Tensor2D::new([[-2.0, -1.0, 0.0], [1.0, 2.0, 3.0]]);
         let r1 = Softmax.forward(t.clone());
-        let r2 = t.softmax::<Axis<1>>();
+        let r2 = t.softmax::<crate::arrays::Axis<1>>();
         assert_eq!(r1.data(), r2.data());
     }
 }

--- a/src/nn/activations.rs
+++ b/src/nn/activations.rs
@@ -1,4 +1,5 @@
 use crate::arrays::{HasArrayType, HasLastAxis};
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use rand::Rng;
 

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -1,3 +1,4 @@
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, Tape, UnusedTensors};
 use crate::prelude::*;
 use rand::Rng;
 use rand_distr::Uniform;

--- a/src/nn/dropout.rs
+++ b/src/nn/dropout.rs
@@ -1,3 +1,4 @@
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use crate::unique_id::unique_id;
 use rand::{prelude::StdRng, Rng, SeedableRng};

--- a/src/nn/dropout.rs
+++ b/src/nn/dropout.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::unique_id::unique_id;
 use rand::{prelude::StdRng, Rng, SeedableRng};
 use std::{cell::RefCell, ops::DerefMut};
 

--- a/src/nn/flatten.rs
+++ b/src/nn/flatten.rs
@@ -1,4 +1,6 @@
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, Tape, UnusedTensors};
 use crate::prelude::*;
+use crate::{Assert, ConstTrue};
 
 /// **Requires Nightly** Flattens 3d tensors to 1d, and 4d tensors to 2d.
 ///

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -1,3 +1,4 @@
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 
 /// A residual connection `R` around `F`: `F(x) + R(x)`,

--- a/src/nn/impl_module_for_tuples.rs
+++ b/src/nn/impl_module_for_tuples.rs
@@ -93,6 +93,7 @@ tuple_impls!([A, B, C, D, E, F] [0, 1, 2, 3, 4, 5], F, [E, D, C, B, A]);
 mod tests {
     use super::*;
     use crate::nn::tests::SimpleGradients;
+    use crate::unique_id::HasUniqueId;
     use rand::{prelude::StdRng, SeedableRng};
     use std::fs::File;
     use tempfile::NamedTempFile;

--- a/src/nn/impl_module_for_tuples.rs
+++ b/src/nn/impl_module_for_tuples.rs
@@ -1,3 +1,4 @@
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use rand::prelude::Rng;
 use std::io::{Read, Seek, Write};

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -1,5 +1,6 @@
 use crate::arrays::Axis;
 use crate::devices::{Cpu, FillElements};
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, Tape, UnusedTensors};
 use crate::prelude::*;
 use std::io::{Read, Seek, Write};
 use zip::{result::ZipResult, ZipArchive};
@@ -23,8 +24,8 @@ use zip::{result::ZipResult, ZipArchive};
 /// ```
 #[derive(Debug, Clone)]
 pub struct LayerNorm1D<const M: usize> {
-    pub gamma: Tensor1D<M, NoneTape>,
-    pub beta: Tensor1D<M, NoneTape>,
+    pub gamma: Tensor1D<M>,
+    pub beta: Tensor1D<M>,
     pub epsilon: f32,
 }
 

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -1,3 +1,4 @@
+use crate::arrays::Axis;
 use crate::devices::{Cpu, FillElements};
 use crate::prelude::*;
 use std::io::{Read, Seek, Write};

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -1,3 +1,4 @@
+use crate::devices::{Cpu, FillElements};
 use crate::prelude::*;
 use std::io::{Read, Seek, Write};
 use zip::{result::ZipResult, ZipArchive};
@@ -125,6 +126,7 @@ impl<const M: usize> LoadFromNpz for LayerNorm1D<M> {
 mod tests {
     use super::*;
     use crate::nn::tests::SimpleGradients;
+    use crate::unique_id::HasUniqueId;
     use rand::{prelude::StdRng, SeedableRng};
     use rand_distr::Standard;
     use std::fs::File;

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -113,6 +113,7 @@ impl<const B: usize, const S: usize, const I: usize, const O: usize, H: Tape>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::unique_id::HasUniqueId;
     use crate::{nn::tests::SimpleGradients, tests::assert_close};
     use rand::{prelude::StdRng, SeedableRng};
     use std::fs::File;

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -1,3 +1,4 @@
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, Tape, UnusedTensors};
 use crate::prelude::*;
 use rand::Rng;
 use rand_distr::Uniform;
@@ -25,10 +26,10 @@ use zip::{result::ZipResult, ZipArchive, ZipWriter};
 #[derive(Default, Debug, Clone)]
 pub struct Linear<const I: usize, const O: usize> {
     /// Transposed weight matrix, shape (O, I)
-    pub weight: Tensor2D<O, I, NoneTape>,
+    pub weight: Tensor2D<O, I>,
 
     /// Bias vector, shape (O, )
-    pub bias: Tensor1D<O, NoneTape>,
+    pub bias: Tensor1D<O>,
 }
 
 impl<const I: usize, const O: usize> CanUpdateWithGradients for Linear<I, O> {

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -119,6 +119,7 @@ pub use conv::*;
 #[cfg(test)]
 mod tests {
     use crate::prelude::{GradientProvider, Gradients};
+    use crate::unique_id::HasUniqueId;
 
     #[derive(Default)]
     pub struct SimpleGradients(pub Gradients);
@@ -126,9 +127,7 @@ mod tests {
     impl GradientProvider for SimpleGradients {
         fn gradient<P>(&mut self, p: &P) -> Option<Box<P::Array>>
         where
-            P: crate::prelude::HasUniqueId
-                + crate::prelude::HasArrayType<Dtype = f32>
-                + crate::prelude::HasDevice,
+            P: HasUniqueId + crate::prelude::HasArrayType<Dtype = f32> + crate::prelude::HasDevice,
         {
             self.0.remove(p)
         }

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -118,7 +118,7 @@ pub use conv::*;
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::{GradientProvider, Gradients};
+    use crate::gradients::{GradientProvider, Gradients};
     use crate::unique_id::HasUniqueId;
 
     #[derive(Default)]
@@ -127,7 +127,7 @@ mod tests {
     impl GradientProvider for SimpleGradients {
         fn gradient<P>(&mut self, p: &P) -> Option<Box<P::Array>>
         where
-            P: HasUniqueId + crate::prelude::HasArrayType<Dtype = f32> + crate::prelude::HasDevice,
+            P: HasUniqueId + crate::arrays::HasArrayType<Dtype = f32> + crate::devices::HasDevice,
         {
             self.0.remove(p)
         }

--- a/src/nn/module.rs
+++ b/src/nn/module.rs
@@ -38,7 +38,7 @@ pub trait Module<Input>: ResetParams + CanUpdateWithGradients {
     /// # Example Implementation
     ///
     /// ```rust
-    /// # use dfdx::prelude::*;
+    /// # use dfdx::{prelude::*, gradients::*};
     /// struct MyMulLayer {
     ///     scale: Tensor1D<5, NoneTape>,
     /// }

--- a/src/nn/module.rs
+++ b/src/nn/module.rs
@@ -1,4 +1,4 @@
-use crate::prelude::CanUpdateWithGradients;
+use crate::gradients::CanUpdateWithGradients;
 
 /// A unit of a neural network. Acts on the generic `Input`
 /// and produces `Module::Output`.

--- a/src/nn/repeated.rs
+++ b/src/nn/repeated.rs
@@ -98,6 +98,7 @@ impl<Input, T: Module<Input, Output = Input>, const N: usize> Module<Input> for 
 mod tests {
     use super::*;
     use crate::nn::tests::SimpleGradients;
+    use crate::unique_id::HasUniqueId;
     use rand::{prelude::StdRng, SeedableRng};
     use std::fs::File;
     use tempfile::NamedTempFile;

--- a/src/nn/repeated.rs
+++ b/src/nn/repeated.rs
@@ -1,3 +1,4 @@
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use std::io::{Read, Seek, Write};
 use zip::{result::ZipResult, ZipArchive, ZipWriter};

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -74,7 +74,7 @@ impl<F: LoadFromNpz> LoadFromNpz for Residual<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{nn::tests::SimpleGradients, tests::assert_close};
+    use crate::{nn::tests::SimpleGradients, tests::assert_close, unique_id::HasUniqueId};
     use rand::{prelude::StdRng, SeedableRng};
     use std::fs::File;
     use tempfile::NamedTempFile;

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -1,3 +1,4 @@
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 
 /// A residual connection around `F`: `F(x) + x`,

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -1,3 +1,4 @@
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 
 /// Splits input into multiple heads. `T` should be a tuple,

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -88,7 +88,7 @@ tuple_impls!([A, B, C, D, E] F);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::nn::tests::SimpleGradients;
+    use crate::{nn::tests::SimpleGradients, unique_id::HasUniqueId};
 
     #[test]
     fn test_split_into_2() {

--- a/src/nn/transformer/decoder.rs
+++ b/src/nn/transformer/decoder.rs
@@ -1,3 +1,4 @@
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use rand::Rng;
 use std::io::{Read, Seek, Write};

--- a/src/nn/transformer/encoder.rs
+++ b/src/nn/transformer/encoder.rs
@@ -1,3 +1,4 @@
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use std::io::{Read, Seek, Write};
 use zip::{result::ZipResult, ZipArchive, ZipWriter};

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -1,4 +1,6 @@
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, Tape, UnusedTensors};
 use crate::prelude::*;
+use crate::{Assert, ConstTrue};
 use rand::Rng;
 
 /// **Requires Nightly** A multi-head attention layer.

--- a/src/nn/transformer/transformer.rs
+++ b/src/nn/transformer/transformer.rs
@@ -1,3 +1,4 @@
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use std::io::{Read, Seek, Write};
 use zip::{result::ZipResult, ZipArchive, ZipWriter};

--- a/src/optim/adam.rs
+++ b/src/optim/adam.rs
@@ -1,7 +1,8 @@
+use crate::arrays::HasArrayType;
+use crate::devices::ForEachElement;
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, Gradients};
 use crate::prelude::*;
 use crate::unique_id::HasUniqueId;
-use crate::devices::ForEachElement;
-use crate::arrays::HasArrayType;
 use std::marker::PhantomData;
 
 /// An implementation of the Adam optimizer from

--- a/src/optim/adam.rs
+++ b/src/optim/adam.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use crate::unique_id::HasUniqueId;
 use crate::devices::ForEachElement;
+use crate::arrays::HasArrayType;
 use std::marker::PhantomData;
 
 /// An implementation of the Adam optimizer from

--- a/src/optim/adam.rs
+++ b/src/optim/adam.rs
@@ -1,4 +1,6 @@
 use crate::prelude::*;
+use crate::unique_id::HasUniqueId;
+use crate::devices::ForEachElement;
 use std::marker::PhantomData;
 
 /// An implementation of the Adam optimizer from

--- a/src/optim/mod.rs
+++ b/src/optim/mod.rs
@@ -14,7 +14,7 @@
 //! the [crate::gradients::Gradients]:
 //!
 //! ```rust
-//! # use dfdx::prelude::*;
+//! # use dfdx::{prelude::*, gradients::*};
 //! # type MyModel = Linear<5, 2>;
 //! let mut model: MyModel = Default::default();
 //! let mut opt: Sgd<MyModel> = Default::default();

--- a/src/optim/optimizer.rs
+++ b/src/optim/optimizer.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{CanUpdateWithGradients, Gradients, UnusedTensors};
+use crate::gradients::{CanUpdateWithGradients, Gradients, UnusedTensors};
 
 /// All optimizers must implement the update function, which takes an object
 /// that implements [CanUpdateWithGradients], and calls [CanUpdateWithGradients::update].

--- a/src/optim/rmsprop.rs
+++ b/src/optim/rmsprop.rs
@@ -1,6 +1,7 @@
-use crate::devices::{FillElements, ForEachElement};
-use crate::prelude::*;
 use crate::arrays::HasArrayType;
+use crate::devices::{FillElements, ForEachElement};
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, Gradients};
+use crate::prelude::*;
 use crate::unique_id::HasUniqueId;
 use std::marker::PhantomData;
 

--- a/src/optim/rmsprop.rs
+++ b/src/optim/rmsprop.rs
@@ -1,4 +1,6 @@
+use crate::devices::{FillElements, ForEachElement};
 use crate::prelude::*;
+use crate::unique_id::HasUniqueId;
 use std::marker::PhantomData;
 
 /// RMSprop As described in [Hinton, 2012](http://www.cs.toronto.edu/%7Etijmen/csc321/slides/lecture_slides_lec6.pdf).

--- a/src/optim/rmsprop.rs
+++ b/src/optim/rmsprop.rs
@@ -1,5 +1,6 @@
 use crate::devices::{FillElements, ForEachElement};
 use crate::prelude::*;
+use crate::arrays::HasArrayType;
 use crate::unique_id::HasUniqueId;
 use std::marker::PhantomData;
 

--- a/src/optim/sgd.rs
+++ b/src/optim/sgd.rs
@@ -1,3 +1,4 @@
+use crate::arrays::HasArrayType;
 use crate::devices::ForEachElement;
 use crate::prelude::*;
 use crate::unique_id::HasUniqueId;

--- a/src/optim/sgd.rs
+++ b/src/optim/sgd.rs
@@ -1,5 +1,6 @@
 use crate::arrays::HasArrayType;
 use crate::devices::ForEachElement;
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, Gradients};
 use crate::prelude::*;
 use crate::unique_id::HasUniqueId;
 use std::marker::PhantomData;

--- a/src/optim/sgd.rs
+++ b/src/optim/sgd.rs
@@ -1,4 +1,6 @@
+use crate::devices::ForEachElement;
 use crate::prelude::*;
+use crate::unique_id::HasUniqueId;
 use std::marker::PhantomData;
 
 /// Implementation of Stochastic Gradient Descent. Based on [pytorch's implementation](https://pytorch.org/docs/stable/generated/torch.optim.SGD.html)

--- a/src/tensor/impl_has_array.rs
+++ b/src/tensor/impl_has_array.rs
@@ -1,11 +1,5 @@
 use super::*;
-use crate::prelude::*;
-
-/// Something that has [HasArrayType], and also can return a reference to or mutate `Self::Array`.
-pub trait HasArrayData: HasArrayType {
-    fn data(&self) -> &Self::Array;
-    fn mut_data(&mut self) -> &mut Self::Array;
-}
+use crate::arrays::{HasArrayData, HasArrayType};
 
 macro_rules! tensor_impl {
     ($typename:ident, [$($Vs:tt),*], $arr:ty) => {

--- a/src/tensor/impl_phantom.rs
+++ b/src/tensor/impl_phantom.rs
@@ -1,6 +1,6 @@
+use crate::arrays::HasArrayType;
 use crate::prelude::*;
 use crate::unique_id::{HasUniqueId, UniqueId};
-use crate::arrays::HasArrayType;
 use std::marker::PhantomData;
 
 /// A fake tensor that holds a [UniqueId] and a type `T` that is [HasArrayType].

--- a/src/tensor/impl_phantom.rs
+++ b/src/tensor/impl_phantom.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use crate::unique_id::{HasUniqueId, UniqueId};
+use crate::arrays::HasArrayType;
 use std::marker::PhantomData;
 
 /// A fake tensor that holds a [UniqueId] and a type `T` that is [HasArrayType].

--- a/src/tensor/impl_phantom.rs
+++ b/src/tensor/impl_phantom.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::unique_id::{HasUniqueId, UniqueId};
 use std::marker::PhantomData;
 
 /// A fake tensor that holds a [UniqueId] and a type `T` that is [HasArrayType].

--- a/src/tensor/impl_randomize.rs
+++ b/src/tensor/impl_randomize.rs
@@ -1,3 +1,4 @@
+use crate::devices::FillElements;
 use crate::prelude::*;
 use rand::{distributions::Distribution, Rng};
 

--- a/src/tensor/impl_tensor.rs
+++ b/src/tensor/impl_tensor.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::unique_id::{unique_id, HasUniqueId};
 
 /// The main tensor trait. A tensor consists of mainly 1. an array, 2. a device, 3. a unique id.
 pub trait Tensor:

--- a/src/tensor/impl_tensor.rs
+++ b/src/tensor/impl_tensor.rs
@@ -1,3 +1,4 @@
+use crate::arrays::HasArrayType;
 use crate::prelude::*;
 use crate::unique_id::{unique_id, HasUniqueId};
 

--- a/src/tensor/impl_tensor.rs
+++ b/src/tensor/impl_tensor.rs
@@ -1,4 +1,5 @@
 use crate::arrays::HasArrayType;
+use crate::gradients::{CanUpdateWithGradients, NoneTape, Tape};
 use crate::prelude::*;
 use crate::unique_id::{unique_id, HasUniqueId};
 

--- a/src/tensor/impl_tensor_creator.rs
+++ b/src/tensor/impl_tensor_creator.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::devices::{AllocateZeros, FillElements};
+use crate::gradients::NoneTape;
 use crate::prelude::*;
 use crate::unique_id::unique_id;
 use rand::prelude::Distribution;

--- a/src/tensor/impl_tensor_creator.rs
+++ b/src/tensor/impl_tensor_creator.rs
@@ -1,5 +1,7 @@
 use super::*;
+use crate::devices::{AllocateZeros, FillElements};
 use crate::prelude::*;
+use crate::unique_id::unique_id;
 use rand::prelude::Distribution;
 use rand_distr::{num_traits::One, Standard, StandardNormal};
 
@@ -68,11 +70,10 @@ tensor_impl!(Tensor4D, [M, N, O, P]);
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use super::*;
-    use crate::unique_id::unique_id;
+    use crate::unique_id::UniqueId;
     use rand::thread_rng;
+    use std::collections::HashSet;
 
     #[test]
     fn test_id() {

--- a/src/tensor/impl_update_with_grads.rs
+++ b/src/tensor/impl_update_with_grads.rs
@@ -1,4 +1,5 @@
 use crate::devices::Device;
+use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 
 impl<T: Tensor<Dtype = f32>> CanUpdateWithGradients for T {

--- a/src/tensor/impl_update_with_grads.rs
+++ b/src/tensor/impl_update_with_grads.rs
@@ -1,3 +1,4 @@
+use crate::devices::Device;
 use crate::prelude::*;
 
 impl<T: Tensor<Dtype = f32>> CanUpdateWithGradients for T {

--- a/src/tensor_ops/arith_scalar.rs
+++ b/src/tensor_ops/arith_scalar.rs
@@ -1,5 +1,9 @@
 use super::utils::move_tape_and_add_backward_op;
-use crate::{devices::{Device, ForEachElement}, prelude::*};
+use crate::gradients::Tape;
+use crate::{
+    devices::{Device, ForEachElement},
+    prelude::*,
+};
 use std::ops::{Add, Div, Mul, Sub};
 
 /// `t + val`. `val` is used for all elements of `t`.

--- a/src/tensor_ops/arith_scalar.rs
+++ b/src/tensor_ops/arith_scalar.rs
@@ -1,5 +1,5 @@
 use super::utils::move_tape_and_add_backward_op;
-use crate::prelude::*;
+use crate::{devices::{Device, ForEachElement}, prelude::*};
 use std::ops::{Add, Div, Mul, Sub};
 
 /// `t + val`. `val` is used for all elements of `t`.

--- a/src/tensor_ops/conv.rs
+++ b/src/tensor_ops/conv.rs
@@ -1,3 +1,4 @@
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// **Requires Nightly** Perform a 2d convolution.

--- a/src/tensor_ops/impl_add.rs
+++ b/src/tensor_ops/impl_add.rs
@@ -1,4 +1,5 @@
 use super::utils::binary_map;
+use crate::gradients::{NoneTape, Tape};
 use crate::prelude::*;
 
 /// Element wise addition.

--- a/src/tensor_ops/impl_backward.rs
+++ b/src/tensor_ops/impl_backward.rs
@@ -1,3 +1,4 @@
+use crate::devices::{Cpu, FillElements};
 use crate::prelude::*;
 
 /// Runs backprop algorithm with all operations contained in the tape that `t` has.

--- a/src/tensor_ops/impl_backward.rs
+++ b/src/tensor_ops/impl_backward.rs
@@ -1,4 +1,5 @@
 use crate::devices::{Cpu, FillElements};
+use crate::gradients::{Gradients, Tape};
 use crate::prelude::*;
 
 /// Runs backprop algorithm with all operations contained in the tape that `t` has.

--- a/src/tensor_ops/impl_broadcast_reduce.rs
+++ b/src/tensor_ops/impl_broadcast_reduce.rs
@@ -1,6 +1,7 @@
 use super::utils::move_tape_and_add_backward_op;
 use crate::arrays::{AllAxes, Axes2, Axes3, Axis, HasArrayType};
 use crate::devices::{AddAccum, CopyAccum, Cpu, DeviceReduce};
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Broadcast self into `T` along `Axes`. Opposite of [Reduce].

--- a/src/tensor_ops/impl_broadcast_reduce.rs
+++ b/src/tensor_ops/impl_broadcast_reduce.rs
@@ -1,6 +1,6 @@
 use super::utils::move_tape_and_add_backward_op;
 use crate::arrays::{AllAxes, Axes2, Axes3, Axis};
-use crate::devices::{AddAccum, CopyAccum, DeviceReduce};
+use crate::devices::{AddAccum, CopyAccum, Cpu, DeviceReduce};
 use crate::prelude::*;
 
 /// Broadcast self into `T` along `Axes`. Opposite of [Reduce].

--- a/src/tensor_ops/impl_broadcast_reduce.rs
+++ b/src/tensor_ops/impl_broadcast_reduce.rs
@@ -1,5 +1,5 @@
 use super::utils::move_tape_and_add_backward_op;
-use crate::arrays::{AllAxes, Axes2, Axes3, Axis};
+use crate::arrays::{AllAxes, Axes2, Axes3, Axis, HasArrayType};
 use crate::devices::{AddAccum, CopyAccum, Cpu, DeviceReduce};
 use crate::prelude::*;
 

--- a/src/tensor_ops/impl_clamp.rs
+++ b/src/tensor_ops/impl_clamp.rs
@@ -1,3 +1,4 @@
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Clamp all elements between the provided min and max values.

--- a/src/tensor_ops/impl_div.rs
+++ b/src/tensor_ops/impl_div.rs
@@ -1,4 +1,5 @@
 use super::utils::binary_map;
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Element wise division.

--- a/src/tensor_ops/impl_dropout.rs
+++ b/src/tensor_ops/impl_dropout.rs
@@ -1,3 +1,4 @@
+use crate::gradients::Tape;
 use crate::prelude::*;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use rand_distr::Standard;

--- a/src/tensor_ops/impl_mask.rs
+++ b/src/tensor_ops/impl_mask.rs
@@ -1,5 +1,6 @@
 use super::utils::move_tape_and_add_backward_op;
 use crate::devices::{Device, ForEachElement};
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Sets `t` to `value` anywhere `mask` equals value

--- a/src/tensor_ops/impl_mask.rs
+++ b/src/tensor_ops/impl_mask.rs
@@ -1,4 +1,5 @@
 use super::utils::move_tape_and_add_backward_op;
+use crate::devices::{Device, ForEachElement};
 use crate::prelude::*;
 
 /// Sets `t` to `value` anywhere `mask` equals value

--- a/src/tensor_ops/impl_max.rs
+++ b/src/tensor_ops/impl_max.rs
@@ -1,5 +1,5 @@
 use super::utils::move_tape_and_add_backward_op;
-use crate::devices::{DeviceReduce, EqAccum, MaxAccum, MulAccum};
+use crate::devices::{Device, DeviceReduce, EqAccum, MaxAccum, MulAccum};
 use crate::prelude::*;
 
 /// Reduces `Axes` of the tensor by gathering the maximum value from that dimension.

--- a/src/tensor_ops/impl_max.rs
+++ b/src/tensor_ops/impl_max.rs
@@ -1,5 +1,6 @@
 use super::utils::move_tape_and_add_backward_op;
 use crate::devices::{Device, DeviceReduce, EqAccum, MaxAccum, MulAccum};
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Reduces `Axes` of the tensor by gathering the maximum value from that dimension.

--- a/src/tensor_ops/impl_maximum.rs
+++ b/src/tensor_ops/impl_maximum.rs
@@ -1,4 +1,5 @@
 use super::utils::binary_map;
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Element wise maximum.

--- a/src/tensor_ops/impl_mean.rs
+++ b/src/tensor_ops/impl_mean.rs
@@ -1,3 +1,4 @@
+use crate::arrays::{HasArrayType, HasAxes};
 use crate::prelude::*;
 
 /// Average the values along `Axes` of `T`.

--- a/src/tensor_ops/impl_mean.rs
+++ b/src/tensor_ops/impl_mean.rs
@@ -1,4 +1,5 @@
 use crate::arrays::{HasArrayType, HasAxes};
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Average the values along `Axes` of `T`.

--- a/src/tensor_ops/impl_min.rs
+++ b/src/tensor_ops/impl_min.rs
@@ -1,5 +1,6 @@
 use super::utils::move_tape_and_add_backward_op;
 use crate::devices::{Device, DeviceReduce, EqAccum, MinAccum, MulAccum};
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Reduces `Axes` of the tensor by gathering the minimum value from the axes.

--- a/src/tensor_ops/impl_min.rs
+++ b/src/tensor_ops/impl_min.rs
@@ -1,5 +1,5 @@
 use super::utils::move_tape_and_add_backward_op;
-use crate::devices::{DeviceReduce, EqAccum, MinAccum, MulAccum};
+use crate::devices::{Device, DeviceReduce, EqAccum, MinAccum, MulAccum};
 use crate::prelude::*;
 
 /// Reduces `Axes` of the tensor by gathering the minimum value from the axes.

--- a/src/tensor_ops/impl_minimum.rs
+++ b/src/tensor_ops/impl_minimum.rs
@@ -1,4 +1,5 @@
 use super::utils::binary_map;
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Element wise minimum.

--- a/src/tensor_ops/impl_mul.rs
+++ b/src/tensor_ops/impl_mul.rs
@@ -1,4 +1,5 @@
 use super::utils::binary_map;
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Element wise multiplication.

--- a/src/tensor_ops/impl_nans.rs
+++ b/src/tensor_ops/impl_nans.rs
@@ -1,3 +1,4 @@
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Replaces any [std::f32::NAN] with `value`.

--- a/src/tensor_ops/impl_normalize.rs
+++ b/src/tensor_ops/impl_normalize.rs
@@ -1,3 +1,4 @@
+use crate::arrays::{HasArrayType, HasAxes};
 use crate::prelude::*;
 
 /// Normalizes `t` to have mean `0.0` and stddev `1.0` along `Axes` of `T`. `epsilon` is passed to [stddev()].

--- a/src/tensor_ops/impl_normalize.rs
+++ b/src/tensor_ops/impl_normalize.rs
@@ -1,4 +1,5 @@
 use crate::arrays::{HasArrayType, HasAxes};
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Normalizes `t` to have mean `0.0` and stddev `1.0` along `Axes` of `T`. `epsilon` is passed to [stddev()].

--- a/src/tensor_ops/impl_pow.rs
+++ b/src/tensor_ops/impl_pow.rs
@@ -1,4 +1,5 @@
 use super::utils::map;
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Raises to a float power. `t^i`.

--- a/src/tensor_ops/impl_reshape.rs
+++ b/src/tensor_ops/impl_reshape.rs
@@ -1,5 +1,9 @@
 use super::utils::move_tape_and_add_backward_op;
+use crate::arrays::CountElements;
+use crate::devices::Device;
+use crate::gradients::Tape;
 use crate::prelude::*;
+use crate::{Assert, ConstTrue};
 
 /// **Requires Nightly** Reshape `Self` into `T`.
 pub trait Reshape<T> {

--- a/src/tensor_ops/impl_softmax.rs
+++ b/src/tensor_ops/impl_softmax.rs
@@ -1,4 +1,4 @@
-use crate::devices::{DeviceReduce, MaxAccum, SubAccum};
+use crate::devices::{Device, DeviceReduce, MaxAccum, SubAccum};
 use crate::prelude::*;
 
 /// Computes the [LogSumExp](https://en.wikipedia.org/wiki/LogSumExp) function across

--- a/src/tensor_ops/impl_softmax.rs
+++ b/src/tensor_ops/impl_softmax.rs
@@ -1,4 +1,5 @@
 use crate::devices::{Device, DeviceReduce, MaxAccum, SubAccum};
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Computes the [LogSumExp](https://en.wikipedia.org/wiki/LogSumExp) function across

--- a/src/tensor_ops/impl_stddev.rs
+++ b/src/tensor_ops/impl_stddev.rs
@@ -1,3 +1,4 @@
+use crate::arrays::{HasArrayType, HasAxes};
 use crate::prelude::*;
 
 /// Reduces `Axes` of `T` by computing std deviation of all values in those axes.

--- a/src/tensor_ops/impl_stddev.rs
+++ b/src/tensor_ops/impl_stddev.rs
@@ -1,4 +1,5 @@
 use crate::arrays::{HasArrayType, HasAxes};
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Reduces `Axes` of `T` by computing std deviation of all values in those axes.

--- a/src/tensor_ops/impl_sub.rs
+++ b/src/tensor_ops/impl_sub.rs
@@ -1,4 +1,5 @@
 use super::utils::binary_map;
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Element wise subtraction.

--- a/src/tensor_ops/impl_sum.rs
+++ b/src/tensor_ops/impl_sum.rs
@@ -1,5 +1,6 @@
 use super::utils::move_tape_and_add_backward_op;
 use crate::devices::{AddAccum, DeviceReduce};
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Sum values along axes `Axes` of `T`.

--- a/src/tensor_ops/map.rs
+++ b/src/tensor_ops/map.rs
@@ -1,4 +1,5 @@
 use super::utils::{map, map_df_uses_fx};
+use crate::gradients::Tape;
 use crate::prelude::*;
 use std::ops::Neg;
 

--- a/src/tensor_ops/matmul.rs
+++ b/src/tensor_ops/matmul.rs
@@ -249,6 +249,7 @@ pub fn vecmat_mul_transpose<const K: usize, const N: usize, TAPE: Tape>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::arrays::ZeroElements;
     use crate::{devices::Device, tests::assert_close};
     use rand::thread_rng;
 

--- a/src/tensor_ops/matmul.rs
+++ b/src/tensor_ops/matmul.rs
@@ -1,5 +1,6 @@
 use super::utils::move_tape_and_add_backward_binop;
 use crate::devices::{Cpu, MatMul, MatMulOp, Transpose};
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Matrix multiplication. This also supports batched matrix multiplication,

--- a/src/tensor_ops/matmul.rs
+++ b/src/tensor_ops/matmul.rs
@@ -1,4 +1,5 @@
 use super::utils::move_tape_and_add_backward_binop;
+use crate::devices::{Cpu, MatMul, MatMulOp, Transpose};
 use crate::prelude::*;
 
 /// Matrix multiplication. This also supports batched matrix multiplication,
@@ -248,7 +249,7 @@ pub fn vecmat_mul_transpose<const K: usize, const N: usize, TAPE: Tape>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::assert_close;
+    use crate::{devices::Device, tests::assert_close};
     use rand::thread_rng;
 
     #[test]

--- a/src/tensor_ops/permute.rs
+++ b/src/tensor_ops/permute.rs
@@ -1,5 +1,6 @@
 use super::utils::move_tape_and_add_backward_op;
 use crate::devices::{Cpu, Device, DevicePermute};
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Permutes self into `T` with the new order of axes specified via `Axes`.

--- a/src/tensor_ops/permute.rs
+++ b/src/tensor_ops/permute.rs
@@ -1,4 +1,5 @@
 use super::utils::move_tape_and_add_backward_op;
+use crate::devices::{Cpu, Device, DevicePermute};
 use crate::prelude::*;
 
 /// Permutes self into `T` with the new order of axes specified via `Axes`.

--- a/src/tensor_ops/select.rs
+++ b/src/tensor_ops/select.rs
@@ -2,6 +2,7 @@ use super::utils::move_tape_and_add_backward_op;
 use crate::devices::{
     BSelectAx1, Device, DeviceSelect, FillElements, SelectAx0, SelectAx1, SelectAx2, SelectAx3,
 };
+use crate::gradients::Tape;
 use crate::prelude::*;
 
 /// Select values along a single axis `I` resulting in `T`. Equivalent

--- a/src/tensor_ops/select.rs
+++ b/src/tensor_ops/select.rs
@@ -1,4 +1,7 @@
 use super::utils::move_tape_and_add_backward_op;
+use crate::devices::{
+    BSelectAx1, Device, DeviceSelect, FillElements, SelectAx0, SelectAx1, SelectAx2, SelectAx3,
+};
 use crate::prelude::*;
 
 /// Select values along a single axis `I` resulting in `T`. Equivalent

--- a/src/tensor_ops/utils.rs
+++ b/src/tensor_ops/utils.rs
@@ -8,6 +8,7 @@
 //!    sense to have a single unit for doing it.
 
 use crate::devices::{AllocateZeros, Device, ForEachElement};
+use crate::gradients::{Gradients, Tape};
 use crate::prelude::*;
 
 /// `f(t)`. Applies a function `f` to every element of the [Tensor]. The derivative

--- a/src/tensor_ops/utils.rs
+++ b/src/tensor_ops/utils.rs
@@ -7,6 +7,7 @@
 //! 4. You can't really separate these operations since they are very inter-dependent. So it makes
 //!    sense to have a single unit for doing it.
 
+use crate::devices::{AllocateZeros, Device, ForEachElement};
 use crate::prelude::*;
 
 /// `f(t)`. Applies a function `f` to every element of the [Tensor]. The derivative


### PR DESCRIPTION
Closes #179 

No longer exporting:
- data
- unique_id
- Assert/ConstTrue

partially exporting:
- devices
- gradients
- arrays
