### PR TITLE
Adding `trait ModuleMut` and blanket impls that call `Module`

### DIFF
--- a/src/nn/activations.rs
+++ b/src/nn/activations.rs
@@ -28,6 +28,16 @@ macro_rules! activation_impls {
                 $func_name(input)
             }
         }
+
+        impl<T> ModuleMut<T> for $struct_name
+        where
+            Self: Module<T>,
+        {
+            type Output = <Self as Module<T>>::Output;
+            fn forward_mut(&mut self, input: T) -> Self::Output {
+                self.forward(input)
+            }
+        }
     };
 }
 
@@ -69,6 +79,16 @@ where
     }
 }
 
+impl<T> ModuleMut<T> for Softmax
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,7 +96,7 @@ mod tests {
     #[test]
     fn test_relu() {
         let t = tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
-        let r1 = ReLU.forward(t.clone());
+        let r1 = ReLU.forward_mut(t.clone());
         let r2 = relu(t);
         assert_eq!(r1.data(), r2.data());
     }
@@ -84,28 +104,28 @@ mod tests {
     #[test]
     fn test_sin() {
         let t = tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
-        let r1 = Sin.forward(t.clone());
+        let r1 = Sin.forward_mut(t.clone());
         let r2 = sin(t);
         assert_eq!(r1.data(), r2.data());
     }
     #[test]
     fn test_cos() {
         let t = tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
-        let r1 = Cos.forward(t.clone());
+        let r1 = Cos.forward_mut(t.clone());
         let r2 = cos(t);
         assert_eq!(r1.data(), r2.data());
     }
     #[test]
     fn test_ln() {
         let t = tensor([0.0, 1.0, 2.0, 3.0, 4.0]);
-        let r1 = Ln.forward(t.clone());
+        let r1 = Ln.forward_mut(t.clone());
         let r2 = ln(t);
         assert_eq!(r1.data(), r2.data());
     }
     #[test]
     fn test_exp() {
         let t = tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
-        let r1 = Exp.forward(t.clone());
+        let r1 = Exp.forward_mut(t.clone());
         let r2 = exp(t);
         assert_eq!(r1.data(), r2.data());
     }
@@ -113,14 +133,14 @@ mod tests {
     #[test]
     fn test_sigmoid() {
         let t = tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
-        let r1 = Sigmoid.forward(t.clone());
+        let r1 = Sigmoid.forward_mut(t.clone());
         let r2 = sigmoid(t);
         assert_eq!(r1.data(), r2.data());
     }
     #[test]
     fn test_tanh() {
         let t = tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
-        let r1 = Tanh.forward(t.clone());
+        let r1 = Tanh.forward_mut(t.clone());
         let r2 = tanh(t);
         assert_eq!(r1.data(), r2.data());
     }
@@ -128,7 +148,7 @@ mod tests {
     #[test]
     fn test_square() {
         let t = tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
-        let r1 = Square.forward(t.clone());
+        let r1 = Square.forward_mut(t.clone());
         let r2 = square(t);
         assert_eq!(r1.data(), r2.data());
     }
@@ -136,7 +156,7 @@ mod tests {
     #[test]
     fn test_sqrt() {
         let t = tensor([0.0, 1.0, 2.0, 3.0, 4.0]);
-        let r1 = Sqrt.forward(t.clone());
+        let r1 = Sqrt.forward_mut(t.clone());
         let r2 = sqrt(t);
         assert_eq!(r1.data(), r2.data());
     }
@@ -144,7 +164,7 @@ mod tests {
     #[test]
     fn test_abs() {
         let t = tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
-        let r1 = Abs.forward(t.clone());
+        let r1 = Abs.forward_mut(t.clone());
         let r2 = abs(t);
         assert_eq!(r1.data(), r2.data());
     }
@@ -152,17 +172,17 @@ mod tests {
     #[test]
     fn test_softmax() {
         let t = Tensor0D::new(0.0);
-        let r1 = Softmax.forward(t.clone());
+        let r1 = Softmax.forward_mut(t.clone());
         let r2 = t.softmax();
         assert_eq!(r1.data(), r2.data());
 
         let t = tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
-        let r1 = Softmax.forward(t.clone());
+        let r1 = Softmax.forward_mut(t.clone());
         let r2 = t.softmax();
         assert_eq!(r1.data(), r2.data());
 
         let t = Tensor2D::new([[-2.0, -1.0, 0.0], [1.0, 2.0, 3.0]]);
-        let r1 = Softmax.forward(t.clone());
+        let r1 = Softmax.forward_mut(t.clone());
         let r2 = t.softmax::<crate::arrays::Axis<1>>();
         assert_eq!(r1.data(), r2.data());
     }

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -124,6 +124,17 @@ where
     }
 }
 
+impl<const I: usize, const O: usize, const K: usize, const S: usize, const P: usize, T> ModuleMut<T>
+    for Conv2D<I, O, K, S, P>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -173,7 +184,7 @@ mod tests {
         type C = Conv2D<4, 1, 1, 1, 1>;
 
         type Img = Tensor3D<1, 10, 10>;
-        let _: Tensor3D<1, 8, 8> = <(A, B, C)>::default().forward(Img::zeros());
+        let _: Tensor3D<1, 8, 8> = <(A, B, C)>::default().forward_mut(Img::zeros());
     }
 
     #[test]

--- a/src/nn/dropout.rs
+++ b/src/nn/dropout.rs
@@ -57,6 +57,16 @@ impl<const N: usize, T: Tensor<Dtype = f32>> Module<T> for DropoutOneIn<N> {
     }
 }
 
+impl<T, const N: usize> ModuleMut<T> for DropoutOneIn<N>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 /// A [Module<Tensor>] that calls [dropout()] in [Module::forward()] with probability `self.p`.
 ///
 /// This also implements [Module<(Tensor, Rng)>] if you want to pass in an [Rng] externally, though
@@ -150,6 +160,16 @@ impl<R: Rng + SeedableRng, T: Tensor<Dtype = f32>> Module<(T, R)> for Dropout {
         let (t, mut rng) = input;
         let t = dropout(t, self.p, &mut rng);
         (t, rng)
+    }
+}
+
+impl<T> ModuleMut<T> for Dropout
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
     }
 }
 

--- a/src/nn/flatten.rs
+++ b/src/nn/flatten.rs
@@ -48,13 +48,23 @@ where
     }
 }
 
+impl<T> ModuleMut<T> for FlattenImage
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_flattens() {
-        let _: Tensor1D<{ 15 * 10 * 5 }> = FlattenImage.forward(Tensor3D::<15, 10, 5>::zeros());
-        let _: Tensor2D<5, 24> = FlattenImage.forward(Tensor4D::<5, 4, 3, 2>::zeros());
+        let _: Tensor1D<{ 15 * 10 * 5 }> = FlattenImage.forward_mut(Tensor3D::<15, 10, 5>::zeros());
+        let _: Tensor2D<5, 24> = FlattenImage.forward_mut(Tensor4D::<5, 4, 3, 2>::zeros());
     }
 }

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -81,6 +81,16 @@ impl<F: LoadFromNpz, R: LoadFromNpz> LoadFromNpz for GeneralizedResidual<F, R> {
     }
 }
 
+impl<T, F, R> ModuleMut<T> for GeneralizedResidual<F, R>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -112,7 +122,7 @@ mod tests {
         model.reset_params(&mut rng);
 
         let x: Tensor2D<4, 2> = TensorCreator::randn(&mut rng);
-        let y = model.forward(x.trace());
+        let y = model.forward_mut(x.trace());
 
         #[rustfmt::skip]
         assert_close(y.data(), &[[-0.81360567, -1.1473482], [1.0925694, 0.17383915], [-0.32519114, 0.49806428], [0.08259219, -0.7277866]]);

--- a/src/nn/impl_module_for_tuples.rs
+++ b/src/nn/impl_module_for_tuples.rs
@@ -81,6 +81,21 @@ macro_rules! tuple_impls {
                 x
             }
         }
+
+        impl<
+            Input: Tensor,
+            $last:
+            $(ModuleMut::<$rev_tail ::Output>, $rev_tail: )+
+            ModuleMut<Input>
+        > ModuleMut<Input> for ($($name,)+) {
+            type Output = $last ::Output;
+
+            /// Calls forward sequentially on each module in the tuple.
+            fn forward_mut(&mut self, x: Input) -> Self::Output {
+                $(let x = self.$idx.forward_mut(x);)+
+                x
+            }
+        }
     };
 }
 
@@ -121,7 +136,7 @@ mod tests {
         let m0 = model.clone();
 
         let loss = model
-            .forward(Tensor1D::randn(&mut rng).traced())
+            .forward_mut(Tensor1D::randn(&mut rng).traced())
             .square()
             .mean();
         let gradients = backward(loss);

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -104,6 +104,16 @@ impl<H: Tape, const B: usize, const S: usize, const M: usize> Module<Tensor3D<B,
     }
 }
 
+impl<T, const M: usize> ModuleMut<T> for LayerNorm1D<M>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 impl<const M: usize> SaveToNpz for LayerNorm1D<M> {
     /// Saves [Self::gamma] to `{pre}gamma.npy` and [Self::beta] to `{pre}beta.npy`
     /// using [npz_fwrite()].
@@ -155,9 +165,9 @@ mod tests {
     #[test]
     fn test_layer_norm_1d_forward() {
         let mut rng = StdRng::seed_from_u64(0);
-        let m: LayerNorm1D<5> = Default::default();
+        let mut m: LayerNorm1D<5> = Default::default();
         let x: Tensor1D<5> = TensorCreator::randn(&mut rng);
-        let r = m.forward(x.trace());
+        let r = m.forward_mut(x.trace());
         assert_close(
             r.data(),
             &[0.873304, 0.9879816, -1.6083492, 0.44028836, -0.6932247],

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -111,6 +111,16 @@ impl<const B: usize, const S: usize, const I: usize, const O: usize, H: Tape>
     }
 }
 
+impl<T, const I: usize, const O: usize> ModuleMut<T> for Linear<I, O>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -3,9 +3,9 @@
 //!
 //! # Mutable vs Immutable forwards
 //!
-//! [Module] provides two versions of forwards:
+//! This is provided as two separate traits
 //!
-//! 1. [Module::forward_mut()] which receives `&mut self`.
+//! 1. [ModuleMut::forward_mut()] which receives `&mut self`.
 //! 2. [Module::forward()] which receives `&self`.
 //!
 //! **This has nothing to do with whether gradients are being tracked or not**.
@@ -13,7 +13,7 @@
 //! and NoneTape can still be passed to both, and all modules should conform
 //! to this expected behavior.
 //!
-//! In general, [Module::forward_mut()] should be used during training,
+//! In general, [ModuleMut::forward_mut()] should be used during training,
 //! and [Module::forward()] during evaluation/testing/inference/validation.
 //!
 //! Here is a list of existing modules that have different behavior in these

--- a/src/nn/module.rs
+++ b/src/nn/module.rs
@@ -1,74 +1,41 @@
-/// A unit of a neural network. Acts on the generic `Input`
-/// and produces `Module::Output`.
-///
-/// * Immutable version: [Module::forward()]
-/// * Mutable version: [Module::forward_mut()]
-///
-/// Generic `Input` means you can implement module for multiple
-/// input types on the same struct. For example [super::Linear] implements
-/// [Module] for 1d inputs and 2d inputs.
-///
-/// Additionally, modules can specify different behavior based on
-/// whether it is a mutable forward ([Module::forward_mut()]) or
-/// non-mutable forward ([Module::forward()]). For example,
-/// a Dropout layer, which uses an rng under the hood, may
-/// not modify the input tensor in [Module::forward()], since
-/// it cannot modify it's underlying rng.
+/// Immutable forward of `Input` that produces [Module::Output].
+/// See [ModuleMut] for mutable forward.
 pub trait Module<Input> {
     /// The type that this unit produces given `Input`.
     type Output;
 
-    /// Pass an `Input` through the unit and produce [Self::Output].
-    /// Can be implemented for multiple `Input` types.
+    /// Forward `Input` through the module and produce [Module::Output].
     ///
-    /// This should never change `self`.
-    /// **See [Module::forward_mut()] for version that can mutate `self`.**
+    /// **See [ModuleMut] for version that can mutate `self`.**
     ///
-    /// # Example Usage
-    ///
+    /// Example Usage:
     /// ```rust
     /// # use dfdx::prelude::*;
     /// let model: Linear<7, 2> = Default::default();
     /// let y1: Tensor1D<2> = model.forward(Tensor1D::zeros());
     /// let y2: Tensor2D<10, 2> = model.forward(Tensor2D::zeros());
     /// ```
-    ///
-    /// # Example Implementation
-    ///
-    /// ```rust
-    /// # use dfdx::{prelude::*, gradients::*};
-    /// struct MyMulLayer {
-    ///     scale: Tensor1D<5, NoneTape>,
-    /// }
-    /// # impl Default for MyMulLayer { fn default() -> Self { Self { scale: Tensor1D::zeros() }}}
-    /// # impl CanUpdateWithGradients for MyMulLayer { fn update<G: GradientProvider>(&mut self, grads: &mut G, _: &mut UnusedTensors) { } }
-    /// # impl ResetParams for MyMulLayer { fn reset_params<R: rand::Rng>(&mut self, rng: &mut R) {}}
-    ///
-    /// impl Module<Tensor1D<5>> for MyMulLayer {
-    ///     type Output = Tensor1D<5>;
-    ///     fn forward(&self, input: Tensor1D<5>) -> Self::Output {
-    ///         mul(input, &self.scale)
-    ///     }
-    /// }
-    /// ```
     fn forward(&self, input: Input) -> Self::Output;
+}
 
-    /// Pass an `Input` through the unit and produce [Self::Output].
-    /// Can be implemented for multiple `Input` types.
+/// Mutable forward of `Input` that produces [ModuleMut::Output].
+/// See [Module] for immutable forward.
+pub trait ModuleMut<Input> {
+    /// The type that this unit produces given `Input`.
+    type Output;
+
+    /// Forward `Input` through the module and produce [ModuleMut::Output].
     ///
-    /// This *can* change `self`. **See [Module::forward()] for immutable version**
+    /// **See [Module::forward()] for immutable version**
     ///
-    /// # Example Usage
-    ///
+    /// Example Usage:
     /// ```rust
     /// # use dfdx::prelude::*;
     /// let mut model: Linear<7, 2> = Default::default();
     /// let y1: Tensor1D<2> = model.forward_mut(Tensor1D::zeros());
     /// let y2: Tensor2D<10, 2> = model.forward_mut(Tensor2D::zeros());
     /// ```
-    fn forward_mut(&mut self, input: Input) -> Self::Output {
-        self.forward(input)
-    }
+    fn forward_mut(&mut self, input: Input) -> Self::Output;
 }
 
 /// Something that can reset it's parameters.

--- a/src/nn/pool2d.rs
+++ b/src/nn/pool2d.rs
@@ -1,5 +1,4 @@
-use super::{LoadFromNpz, SaveToNpz};
-use super::{Module, ResetParams};
+use super::{LoadFromNpz, Module, ModuleMut, ResetParams, SaveToNpz};
 use crate::gradients::*;
 use crate::tensor::*;
 use rand::Rng;
@@ -88,6 +87,16 @@ macro_rules! impl_pools {
 
             fn forward(&self, x: Tensor4D<B, C, H, W, T>) -> Self::Output {
                 x.$Method::<K, S, P>()
+            }
+        }
+
+        impl<T, const K: usize, const S: usize, const P: usize> ModuleMut<T> for $PoolTy<K, S, P>
+        where
+            Self: Module<T>,
+        {
+            type Output = <Self as Module<T>>::Output;
+            fn forward_mut(&mut self, input: T) -> Self::Output {
+                self.forward(input)
             }
         }
     };

--- a/src/nn/pool_global.rs
+++ b/src/nn/pool_global.rs
@@ -1,4 +1,4 @@
-use super::{LoadFromNpz, Module, ResetParams, SaveToNpz};
+use super::{LoadFromNpz, Module, ModuleMut, ResetParams, SaveToNpz};
 use crate::gradients::*;
 use crate::tensor::*;
 
@@ -89,6 +89,16 @@ macro_rules! impl_pools {
             type Output = Tensor2D<B, C, T>;
             fn forward(&self, input: Tensor4D<B, C, H, W, T>) -> Self::Output {
                 input.$Method()
+            }
+        }
+
+        impl<T> ModuleMut<T> for $PoolTy
+        where
+            Self: Module<T>,
+        {
+            type Output = <Self as Module<T>>::Output;
+            fn forward_mut(&mut self, input: T) -> Self::Output {
+                self.forward(input)
             }
         }
     };

--- a/src/nn/repeated.rs
+++ b/src/nn/repeated.rs
@@ -95,6 +95,16 @@ impl<Input, T: Module<Input, Output = Input>, const N: usize> Module<Input> for 
     }
 }
 
+impl<Input, T, const N: usize> ModuleMut<Input> for Repeated<T, N>
+where
+    Self: Module<Input>,
+{
+    type Output = <Self as Module<Input>>::Output;
+    fn forward_mut(&mut self, input: Input) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,7 +149,7 @@ mod tests {
         let x = m.modules[3].forward(x);
         let x = m.modules[4].forward(x);
 
-        assert_eq!(x.data(), m.forward(Tensor1D::zeros()).data());
+        assert_eq!(x.data(), m.forward_mut(Tensor1D::zeros()).data());
     }
 
     #[test]

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -43,6 +43,16 @@ impl<T: Tensor<Dtype = f32>, F: Module<T, Output = T>> Module<T> for Residual<F>
     }
 }
 
+impl<T, F> ModuleMut<T> for Residual<F>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, input: T) -> Self::Output {
+        self.forward(input)
+    }
+}
+
 impl<F: SaveToNpz> SaveToNpz for Residual<F> {
     /// Pass through to `F`'s [SaveToNpz].
     fn write<W: Write + Seek>(&self, p: &str, w: &mut ZipWriter<W>) -> ZipResult<()> {
@@ -84,7 +94,7 @@ mod tests {
         model.reset_params(&mut rng);
 
         let x: Tensor2D<4, 2> = TensorCreator::randn(&mut rng);
-        let y = model.forward(x.trace());
+        let y = model.forward_mut(x.trace());
 
         #[rustfmt::skip]
         assert_close(y.data(), &[[0.25372928, -2.4258814],[1.7892148, -2.6242268],[1.5131638, 0.23407778],[3.4201493, 1.597525]]);

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -77,6 +77,32 @@ where
         )
     }
 }
+
+impl<
+    Input: Tensor,
+    $($heads : ModuleMut<Input>,)+
+    $tail: ModuleMut<Input>
+> ModuleMut<Input> for SplitInto<($($heads,)+ $tail)>
+where
+    $($heads::Output: Tensor<Tape = Input::Tape>,)+
+{
+    type Output = (
+        $(<$heads::Output as Tensor>::NoTape, )+
+        $tail::Output
+    );
+
+    #[allow(non_snake_case)]
+    fn forward_mut(&mut self, x: Input) -> Self::Output {
+        let (x, tape) = x.split_tape();
+        let ($($heads, )+ $tail) = &mut self.0;
+        $(let ($heads, tape) = $heads.forward_mut(x.duplicate().put_tape(tape)).split_tape();)+
+        let $tail = $tail.forward_mut(x.put_tape(tape));
+        (
+            $($heads,)+
+            $tail
+        )
+    }
+}
 }
 }
 

--- a/src/nn/transformer/decoder.rs
+++ b/src/nn/transformer/decoder.rs
@@ -53,6 +53,18 @@ where
     }
 }
 
+impl<const M: usize, const H: usize, const F: usize, const L: usize, T> ModuleMut<T>
+    for TransformerDecoder<M, H, F, L>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+
+    fn forward_mut(&mut self, t: T) -> Self::Output {
+        self.forward(t)
+    }
+}
+
 impl<const M: usize, const H: usize, const F: usize, const L: usize> SaveToNpz
     for TransformerDecoder<M, H, F, L>
 {

--- a/src/nn/transformer/encoder.rs
+++ b/src/nn/transformer/encoder.rs
@@ -93,6 +93,18 @@ where
     }
 }
 
+impl<const M: usize, const H: usize, const F: usize, T> ModuleMut<T>
+    for TransformerEncoderBlock<M, H, F>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+
+    fn forward_mut(&mut self, t: T) -> Self::Output {
+        self.forward(t)
+    }
+}
+
 impl<const M: usize, const H: usize, const F: usize> SaveToNpz
     for TransformerEncoderBlock<M, H, F>
 {

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -198,6 +198,18 @@ where
     }
 }
 
+impl<const M: usize, const H: usize, const K: usize, const V: usize, T> ModuleMut<T>
+    for MultiHeadAttention<M, H, K, V>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+
+    fn forward_mut(&mut self, t: T) -> Self::Output {
+        self.forward(t)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/nn/transformer/transformer.rs
+++ b/src/nn/transformer/transformer.rs
@@ -75,6 +75,17 @@ where
     }
 }
 
+impl<const M: usize, const H: usize, const E: usize, const D: usize, const F: usize, T> ModuleMut<T>
+    for Transformer<M, H, E, D, F>
+where
+    Self: Module<T>,
+{
+    type Output = <Self as Module<T>>::Output;
+    fn forward_mut(&mut self, t: T) -> Self::Output {
+        self.forward(t)
+    }
+}
+
 impl<const M: usize, const H: usize, const E: usize, const D: usize, const F: usize> SaveToNpz
     for Transformer<M, H, E, D, F>
 {
@@ -111,12 +122,12 @@ mod tests {
         // unbatched
         let src: Tensor2D<7, 16> = TensorCreator::randn(&mut rng);
         let tgt: Tensor2D<9, 16> = TensorCreator::randn(&mut rng);
-        let _: Tensor2D<9, 16> = t.forward((src, tgt));
+        let _: Tensor2D<9, 16> = t.forward_mut((src, tgt));
 
         // batched
         let src: Tensor3D<4, 12, 16> = TensorCreator::randn(&mut rng);
         let tgt: Tensor3D<4, 6, 16> = TensorCreator::randn(&mut rng);
-        let _: Tensor3D<4, 6, 16> = t.forward((src, tgt));
+        let _: Tensor3D<4, 6, 16> = t.forward_mut((src, tgt));
     }
 
     #[test]
@@ -127,7 +138,7 @@ mod tests {
 
         let src: Tensor3D<4, 12, 16> = TensorCreator::randn(&mut rng);
         let tgt: Tensor3D<4, 6, 16> = TensorCreator::randn(&mut rng);
-        let out: Tensor3D<4, 6, 16, _> = t.forward((src.trace(), tgt));
+        let out: Tensor3D<4, 6, 16, _> = t.forward_mut((src.trace(), tgt));
         let g = backward(out.mean());
 
         let mut gs = SimpleGradients(g);
@@ -153,8 +164,8 @@ mod tests {
         let src: Tensor3D<4, 12, 16> = TensorCreator::randn(&mut rng);
         let tgt: Tensor3D<4, 6, 16> = TensorCreator::randn(&mut rng);
 
-        let y1 = saved.forward((src.clone(), tgt.clone()));
-        let y2 = loaded.forward((src.clone(), tgt.clone()));
+        let y1 = saved.forward_mut((src.clone(), tgt.clone()));
+        let y2 = loaded.forward_mut((src.clone(), tgt.clone()));
 
         assert_eq!(y1.data(), y2.data());
     }


### PR DESCRIPTION
(Previously opened in #181 )

This approach was previously discussed in https://github.com/coreylowman/dfdx/issues/142 as an alternative to adding forward_mut to Module. However as we've seen in https://github.com/coreylowman/dfdx/pull/153, simply adding forward_mut to Module allows some confusing permutations that compile but probably shouldn't. Instead of allowing weird combinations of things to happen, instead dfdx should just not compile.

Having separate traits:
1. Enables module developers finer control over when self is mutably borrowed and over what inputs. This is a double edge sword because obviously this requires library developers to implement a second module trait. However as shown here it is easy to do a blanket impl for anything that impls Module.
2. Enables library developers to specify function inputs as either ModuleMut for training or Module for inference:
```rust
fn training<T, M: ModuleMut<T>>(module: &mut M) {
    ...
}

fn inference<T, M: Module<T>>(module: &M) {
    ...
}
```