### PR TITLE
Fixing ModuleMut impls for containers of sub modules

### DIFF
--- a/src/nn/repeated.rs
+++ b/src/nn/repeated.rs
@@ -95,13 +95,15 @@ impl<Input, T: Module<Input, Output = Input>, const N: usize> Module<Input> for 
     }
 }
 
-impl<Input, T, const N: usize> ModuleMut<Input> for Repeated<T, N>
-where
-    Self: Module<Input>,
+impl<Input, T: ModuleMut<Input, Output = Input>, const N: usize> ModuleMut<Input>
+    for Repeated<T, N>
 {
-    type Output = <Self as Module<Input>>::Output;
-    fn forward_mut(&mut self, input: Input) -> Self::Output {
-        self.forward(input)
+    type Output = T::Output;
+    fn forward_mut(&mut self, mut x: Input) -> Self::Output {
+        for i in 0..N {
+            x = self.modules[i].forward_mut(x);
+        }
+        x
     }
 }
 

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -36,20 +36,17 @@ impl<F: ResetParams> ResetParams for Residual<F> {
 
 impl<T: Tensor<Dtype = f32>, F: Module<T, Output = T>> Module<T> for Residual<F> {
     type Output = F::Output;
-    /// Calls forward on `F` and then adds `x` to the result: `F(x) + x`
     fn forward(&self, x: T) -> Self::Output {
         let (x, tape) = x.split_tape();
         add(self.0.forward(x.duplicate().put_tape(tape)), &x)
     }
 }
 
-impl<T, F> ModuleMut<T> for Residual<F>
-where
-    Self: Module<T>,
-{
-    type Output = <Self as Module<T>>::Output;
-    fn forward_mut(&mut self, input: T) -> Self::Output {
-        self.forward(input)
+impl<T: Tensor<Dtype = f32>, F: ModuleMut<T, Output = T>> ModuleMut<T> for Residual<F> {
+    type Output = F::Output;
+    fn forward_mut(&mut self, x: T) -> Self::Output {
+        let (x, tape) = x.split_tape();
+        add(self.0.forward_mut(x.duplicate().put_tape(tape)), &x)
     }
 }
 


### PR DESCRIPTION
Anything that has sub modules must use that sub modules ModuleMut implementation. Previously these all just used sub modules Module implementation, which was a bug.