### PR TITLE
Change tensors to use Arc so they implement Send and Sync

### DIFF
--- a/src/tensor/impl_has_array.rs
+++ b/src/tensor/impl_has_array.rs
@@ -13,7 +13,7 @@ impl<$(const $Vs: usize, )* H> HasArrayData for $typename<$($Vs, )* H> {
     fn data(&self) -> &Self::Array { self.data.as_ref() }
 
     /// Returns a mutable reference to the underlying array.
-    fn mut_data(&mut self) -> &mut Self::Array { std::rc::Rc::make_mut(&mut self.data) }
+    fn mut_data(&mut self) -> &mut Self::Array { std::sync::Arc::make_mut(&mut self.data) }
 }
     };
 }

--- a/src/tensor/structs.rs
+++ b/src/tensor/structs.rs
@@ -8,7 +8,7 @@ use crate::{gradients::NoneTape, unique_id::UniqueId};
 #[derive(Debug)]
 pub struct Tensor0D<Tape = NoneTape> {
     pub(crate) id: UniqueId,
-    pub(crate) data: std::rc::Rc<f32>,
+    pub(crate) data: std::sync::Arc<f32>,
     pub(crate) tape: Tape,
 }
 
@@ -16,7 +16,7 @@ pub struct Tensor0D<Tape = NoneTape> {
 #[derive(Debug)]
 pub struct Tensor1D<const N: usize, Tape = NoneTape> {
     pub(crate) id: UniqueId,
-    pub(crate) data: std::rc::Rc<[f32; N]>,
+    pub(crate) data: std::sync::Arc<[f32; N]>,
     pub(crate) tape: Tape,
 }
 
@@ -24,7 +24,7 @@ pub struct Tensor1D<const N: usize, Tape = NoneTape> {
 #[derive(Debug)]
 pub struct Tensor2D<const M: usize, const N: usize, Tape = NoneTape> {
     pub(crate) id: UniqueId,
-    pub(crate) data: std::rc::Rc<[[f32; N]; M]>,
+    pub(crate) data: std::sync::Arc<[[f32; N]; M]>,
     pub(crate) tape: Tape,
 }
 
@@ -32,7 +32,7 @@ pub struct Tensor2D<const M: usize, const N: usize, Tape = NoneTape> {
 #[derive(Debug)]
 pub struct Tensor3D<const M: usize, const N: usize, const O: usize, Tape = NoneTape> {
     pub(crate) id: UniqueId,
-    pub(crate) data: std::rc::Rc<[[[f32; O]; N]; M]>,
+    pub(crate) data: std::sync::Arc<[[[f32; O]; N]; M]>,
     pub(crate) tape: Tape,
 }
 
@@ -41,6 +41,6 @@ pub struct Tensor3D<const M: usize, const N: usize, const O: usize, Tape = NoneT
 pub struct Tensor4D<const M: usize, const N: usize, const O: usize, const P: usize, Tape = NoneTape>
 {
     pub(crate) id: UniqueId,
-    pub(crate) data: std::rc::Rc<[[[[f32; P]; O]; N]; M]>,
+    pub(crate) data: std::sync::Arc<[[[[f32; P]; O]; N]; M]>,
     pub(crate) tape: Tape,
 }


### PR DESCRIPTION
Currently, tensors use `Rc` to allow cloning the tensor without reallocating the data. However, `Rc` is neither `Send` or `Sync`, which prevents tensors and everything that contain them (most notably, Modules) from being moved to another thread.

For example, it is currently impossible to share a network across threads except via suboptimal workarounds like serializing the network to bytes on one thread and deserializing it on the other.

By using `Arc`, tensors now implement `Send` and `Sync`. The cost of using atomic operations should be negligible.