### PR TITLE
Replacing conv2d implementation with matmuls

### DIFF
--- a/src/devices/conv.rs
+++ b/src/devices/conv.rs
@@ -1,4 +1,4 @@
-use super::{AllocateZeros, Cpu, FillElements};
+use super::{AllocateZeros, Cpu};
 #[cfg(feature = "cblas")]
 use cblas_sys::{
     cblas_sgemm as sgemm, CblasNoTrans as NoTr, CblasRowMajor as RowMajor, CblasTrans as Tr,


### PR DESCRIPTION
This addresses some slowness in conv2d implementation by leveraging matrix multiplication algorithms.

Here are some numbers from my local benchmarks with `Conv2D<128, 256, 4>` on `Tensor4D<64, 128, 28, 28>`:

| | pytorch| pytorch single thread* | matrixmultiply | mkl-dynamic-seq | mkl-dynamic-iomp | old naive approach |
|---| ---|--- | --- | --- | --- | --- |
| forward | 163ms | 400ms | 1597ms | 524ms | 382ms | 2000ms |
| backward | 293ms | 795ms | 4100ms | 1245ms | 876ms | 7714ms |

* pytorch has num_threads and num_interop_threads set to 1. Parallel batched convs will be addressed by #145 

There is probably still more work that can be done as far as reducing allocations/copying when creating the patches buffers used below.