### PR TITLE
Make ZeroElements unsafe, and AllocateZeros sound

### DIFF
--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -154,16 +154,16 @@ impl<const M: usize, const N: usize, const O: usize, const P: usize> HasLastAxis
     const SIZE: usize = P;
 }
 
-/// Something that has compile time known zero values.
-pub trait ZeroElements {
+/// Something that has a valid 0 value represented by all 0 bits.
+pub unsafe trait ZeroElements {
     const ZEROS: Self;
 }
 
-impl ZeroElements for f32 {
+unsafe impl ZeroElements for f32 {
     const ZEROS: Self = 0.0;
 }
 
-impl<T: ZeroElements, const M: usize> ZeroElements for [T; M] {
+unsafe impl<T: ZeroElements, const M: usize> ZeroElements for [T; M] {
     const ZEROS: Self = [T::ZEROS; M];
 }
 

--- a/src/devices/allocate.rs
+++ b/src/devices/allocate.rs
@@ -1,21 +1,21 @@
 use super::Cpu;
-use crate::arrays::CountElements;
+use crate::arrays::{CountElements, ZeroElements};
 use std::alloc::{alloc_zeroed, Layout};
 use std::boxed::Box;
 
 /// Allocate an Nd array on the heap.
 pub trait AllocateZeros {
     /// Allocate T directly on the heap.
-    fn zeros<T: CountElements>() -> Box<T>;
+    fn zeros<T: CountElements + ZeroElements>() -> Box<T>;
 }
 
 impl AllocateZeros for Cpu {
     /// Allocates using [alloc_zeroed].
-    fn zeros<T: CountElements>() -> Box<T> {
-        // TODO is this function safe for any T?
+    fn zeros<T: CountElements + ZeroElements>() -> Box<T> {
         // TODO move to using safe code once we can allocate an array directly on the heap.
         let layout = Layout::new::<T>();
         debug_assert_eq!(layout.size(), T::NUM_BYTES);
+        // SAFETY: ZeroElements guarantees that 0 is a valid value for this type.
         unsafe {
             let ptr = alloc_zeroed(layout) as *mut T;
             Box::from_raw(ptr)

--- a/src/devices/fill.rs
+++ b/src/devices/fill.rs
@@ -1,9 +1,9 @@
 use super::{AllocateZeros, Cpu};
-use crate::arrays::CountElements;
+use crate::arrays::{CountElements, ZeroElements};
 use std::boxed::Box;
 
 /// Fills all elements with the specified function
-pub trait FillElements<T: CountElements>: Sized + AllocateZeros {
+pub trait FillElements<T: CountElements + ZeroElements>: Sized + AllocateZeros {
     fn fill<F: FnMut(&mut T::Dtype)>(out: &mut T, f: &mut F);
 
     fn filled<F: FnMut(&mut T::Dtype)>(f: &mut F) -> Box<T> {
@@ -19,7 +19,7 @@ impl FillElements<f32> for Cpu {
     }
 }
 
-impl<T: CountElements, const M: usize> FillElements<[T; M]> for Cpu
+impl<T: CountElements + ZeroElements, const M: usize> FillElements<[T; M]> for Cpu
 where
     Self: FillElements<T>,
 {

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -28,11 +28,13 @@ pub use pool2d::*;
 use std::boxed::Box;
 use std::ops::*;
 
+use crate::arrays::ZeroElements;
+
 /// The CPU device
 pub struct Cpu;
 
 /// Represents something that can act on `T`.
-pub trait Device<T: crate::arrays::CountElements>:
+pub trait Device<T: crate::arrays::CountElements + ZeroElements>:
     FillElements<T> + DeviceReduce<T, crate::arrays::AllAxes> + AllocateZeros + ForEachElement<T>
 {
     /// Allocate a new `T` and then store `f` applied to `t` in the new `T`. Uses [ForEachElement::foreach_mr].


### PR DESCRIPTION
fixes #252 

Takes the approach I just mentioned in #252 of piggy-backing on `ZeroElements` instead of introducing another trait. There is a trade-off here  that this makes `ZeroElements` less flexible, but realistically I think every dtype ends up needing to be `ValidAsAllZeroBits` anyways, so I don't think the flexibility was likely to be useful