### PR TITLE
Add weight decay to SGD

### DIFF
--- a/examples/05-optim.rs
+++ b/examples/05-optim.rs
@@ -25,6 +25,7 @@ fn main() {
     let mut sgd: Sgd<Mlp> = Sgd::new(SgdConfig {
         lr: 1e-1,
         momentum: Some(Momentum::Nesterov(0.9)),
+        weight_decay: None,
     });
 
     // let's initialize our model and some dummy data

--- a/examples/nightly-transformer.rs
+++ b/examples/nightly-transformer.rs
@@ -12,7 +12,7 @@ fn main() {
 
     let src: Tensor3D<4, 12, 16> = TensorCreator::randn(&mut rng);
     let tgt: Tensor3D<4, 6, 16> = TensorCreator::randn(&mut rng);
-    let out: Tensor3D<4, 6, 16, _> = t.forward_mut((src.trace(), tgt));
+    let _out: Tensor3D<4, 6, 16, _> = t.forward_mut((src.trace(), tgt));
 }
 
 #[cfg(not(feature = "nightly"))]

--- a/examples/rl-dqn.rs
+++ b/examples/rl-dqn.rs
@@ -32,6 +32,7 @@ fn main() {
     let mut sgd = Sgd::new(SgdConfig {
         lr: 1e-1,
         momentum: Some(Momentum::Nesterov(0.9)),
+        weight_decay: None,
     });
 
     // run through training data

--- a/examples/rl-ppo.rs
+++ b/examples/rl-ppo.rs
@@ -29,6 +29,7 @@ fn main() {
     let mut sgd = Sgd::new(SgdConfig {
         lr: 1e-1,
         momentum: Some(Momentum::Nesterov(0.9)),
+        weight_decay: None,
     });
 
     // run through training data

--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::{boxed::Box, vec::Vec};
 
-use crate::arrays::HasArrayType;
+use crate::arrays::{HasArrayData, HasArrayType};
 use crate::devices::{AllocateZeros, HasDevice};
 use crate::unique_id::{HasUniqueId, UniqueId};
 
@@ -264,7 +264,7 @@ pub trait GradientProvider {
     /// based on the associated data!
     fn gradient<P>(&mut self, p: &P) -> Option<Box<P::Array>>
     where
-        P: HasUniqueId + HasArrayType<Dtype = f32> + HasDevice;
+        P: HasUniqueId + HasArrayType<Dtype = f32> + HasDevice + HasArrayData;
 }
 
 /// Represents something that can be updated with [GradientProvider].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,8 @@
 //! // Use stochastic gradient descent (Sgd), with a learning rate of 1e-2, and 0.9 momentum.
 //! let mut opt = Sgd::new(SgdConfig {
 //!     lr: 1e-2,
-//!     momentum: Some(Momentum::Classic(0.9))
+//!     momentum: Some(Momentum::Classic(0.9)),
+//!     weight_decay: None,
 //! });
 //!
 //! // pass the gradients & the model into the optimizer's update method

--- a/src/nn/impl_module_for_tuples.rs
+++ b/src/nn/impl_module_for_tuples.rs
@@ -121,6 +121,7 @@ mod tests {
         let mut sgd = Sgd::new(SgdConfig {
             lr: 1.0,
             momentum: None,
+            weight_decay: None,
         });
         sgd.update(&mut model, gradients).expect("");
 

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -126,6 +126,7 @@ mod npz_impls;
 
 #[cfg(test)]
 mod tests {
+    use crate::arrays::{HasArrayData, HasArrayType};
     use crate::gradients::{GradientProvider, Gradients};
     use crate::unique_id::HasUniqueId;
     use std::boxed::Box;
@@ -136,7 +137,7 @@ mod tests {
     impl GradientProvider for SimpleGradients {
         fn gradient<P>(&mut self, p: &P) -> Option<Box<P::Array>>
         where
-            P: HasUniqueId + crate::arrays::HasArrayType<Dtype = f32> + crate::devices::HasDevice,
+            P: HasUniqueId + HasArrayType<Dtype = f32> + crate::devices::HasDevice + HasArrayData,
         {
             self.0.remove(p)
         }

--- a/src/optim/adam.rs
+++ b/src/optim/adam.rs
@@ -99,7 +99,7 @@ impl<M> Adam<M> {
 impl<M> GradientProvider for Adam<M> {
     fn gradient<P>(&mut self, p: &P) -> Option<Box<P::Array>>
     where
-        P: HasUniqueId + HasArrayType<Dtype = f32> + HasDevice,
+        P: HasUniqueId + HasArrayType<Dtype = f32> + HasDevice + HasArrayData,
     {
         let mut g_t = self.gradients.remove(p)?;
         let m_t = self.moment1.mut_gradient(p);

--- a/src/optim/rmsprop.rs
+++ b/src/optim/rmsprop.rs
@@ -110,7 +110,7 @@ impl<M> RMSprop<M> {
 impl<M> GradientProvider for RMSprop<M> {
     fn gradient<P>(&mut self, p: &P) -> Option<Box<P::Array>>
     where
-        P: HasUniqueId + HasArrayType<Dtype = f32> + HasDevice,
+        P: HasUniqueId + HasArrayType<Dtype = f32> + HasDevice + HasArrayData,
     {
         let mut g_t = self.gradients.remove(p)?;
 

--- a/src/optim/sgd.rs
+++ b/src/optim/sgd.rs
@@ -12,8 +12,7 @@ use std::{boxed::Box, marker::PhantomData};
 ///
 /// Weight decay is implemented as described in
 /// [Decoupled Weight Decay Regularization](https://arxiv.org/abs/1711.05101)
-/// Note that weight decay is applied after momentum updates and is not equivalent to L2
-/// regularization when momentum is used.
+/// Both L2 weight_decay and decoupled weight_decay are available.
 ///
 /// # Example Usage
 ///
@@ -209,6 +208,7 @@ impl<M: CanUpdateWithGradients> Optimizer<M> for Sgd<M> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::assert_close;
     use rand::{prelude::StdRng, SeedableRng};
 
     #[test]
@@ -226,8 +226,8 @@ mod tests {
             let gradients = backward(loss);
             sgd.update(&mut pred, gradients).expect("");
         }
-        assert_eq!(pred.data(), &[1.0; 5]);
-        assert_eq!(targ.data(), &[1.0; 5]);
+        assert_close(pred.data(), &[1.0; 5]);
+        assert_close(targ.data(), &[1.0; 5]);
     }
 
     #[test]
@@ -247,7 +247,7 @@ mod tests {
         for e in expected.iter() {
             let gradients = backward((t.trace() * &rate).mean());
             sgd.update(&mut t, gradients).expect("");
-            assert_eq!(t.data(), e);
+            assert_close(t.data(), e);
         }
     }
 
@@ -272,7 +272,7 @@ mod tests {
         for e in expected.iter() {
             let gradients = backward((t.trace() * &rate).mean());
             sgd.update(&mut t, gradients).expect("");
-            assert_eq!(t.data(), e);
+            assert_close(t.data(), e);
         }
     }
 
@@ -297,7 +297,7 @@ mod tests {
         for e in expected.iter() {
             let gradients = backward((t.trace() * &rate).mean());
             sgd.update(&mut t, gradients).expect("");
-            assert_eq!(t.data(), e);
+            assert_close(t.data(), e);
         }
     }
 
@@ -322,18 +322,18 @@ mod tests {
             [0.99760115, 0.994003, 0.990005, 0.958021, 0.59820104],
             [0.9964036, 0.991009, 0.98501503, 0.937063, 0.39760286],
             [0.9952072, 0.988018, 0.98003, 0.9161259, 0.19720526],
-            [0.994012, 0.98502994, 0.97505, 0.8952098, -0.0029919297],
+            [0.994012, 0.98502994, 0.97505, 0.8952098, -0.00299193],
         ];
         for e in expected.iter() {
             let gradients = backward((t.trace() * &rate).mean());
             sgd_l2.update(&mut t, gradients).expect("");
-            assert_eq!(t.data(), e);
+            assert_close(t.data(), e);
         }
         t = Tensor1D::ones();
         for e in expected.iter() {
             let gradients = backward((t.trace() * &rate).mean());
             sgd_decoupled.update(&mut t, gradients).expect("");
-            assert_eq!(t.data(), e);
+            assert_close(t.data(), e);
         }
     }
 
@@ -349,15 +349,15 @@ mod tests {
         let rate = Tensor1D::new([0.1, 1.0, 2.0, 10.0, 100.0]);
         let expected = [
             [0.9988, 0.997, 0.995, 0.979, 0.799],
-            [0.9975012, 0.99300295, 0.988005, 0.948021, 0.49820104],
-            [0.9961537, 0.98850995, 0.980017, 0.91207296, 0.14770284],
-            [0.99478257, 0.98377144, 0.971537, 0.87366086, -0.22744486],
-            [0.9934003, 0.97891265, 0.96281546, 0.8340372, -0.61471736],
+            [0.9975012, 0.993003, 0.988005, 0.948021, 0.498201],
+            [0.9961537, 0.98851, 0.980017, 0.912073, 0.147703],
+            [0.9947826, 0.983771, 0.971537, 0.873661, -0.227445],
+            [0.9934003, 0.978913, 0.962815, 0.834037, -0.614717],
         ];
         for e in expected.iter() {
             let gradients = backward((t.trace() * &rate).mean());
             sgd.update(&mut t, gradients).expect("");
-            assert_eq!(t.data(), e);
+            assert_close(t.data(), e);
         }
     }
 
@@ -387,7 +387,7 @@ mod tests {
     //     for e in expected.iter() {
     //         let gradients = backward((t.trace() * &rate).mean());
     //         sgd_l2.update(&mut t, gradients).expect("");
-    //         assert_eq!(t.data(), e);
+    //         assert_close(t.data(), e);
     //     }
     //
     //     // Should be equivalent to l2 regularization, even with momentum
@@ -399,7 +399,7 @@ mod tests {
     //
     //         let gradients = backward(loss);
     //         sgd.update(&mut t, gradients).expect("");
-    //         assert_eq!(t.data(), e);
+    //         assert_close(t.data(), e);
     //     }
     // }
 


### PR DESCRIPTION
PR to add weight_decay to SGD.

Weight_decay is added after any momentum updates, so is NOT equivalent to L2 regularization.
(this is the similar to what is done in [tensorflow](https://github.com/tensorflow/addons/blob/v0.17.0/tensorflow_addons/optimizers/weight_decay_optimizers.py#L53) or AdamW in Pytorch).

Note: I had to add `HasArrayData` to `GradientProvider` because weight_decay makes use of the array data; I hope that's ok. Is there a case where we want to distinguish between a GradientProvider that can access the array data and one that cannot?

Related issue: #99 