### PR TITLE
Procedural macro: reset params

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "dfdx"
 version = "0.9.0"
@@ -31,6 +33,7 @@ matrixmultiply = { version = "0.3.2", default-features = false }
 zip = { version = "0.6.2", default-features = false, optional = true }
 cblas-sys = { version = "0.1.4", default-features = false, optional = true }
 libc = { version = "0.2", default-features = false, optional = true }
+dfdx-macros = { path = "./dfdx-macros", default-features = false, optional = true }
 
 [features]
 default = ["std", "numpy"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,6 @@ rand = "0.8.5"
 tempfile = "3.3.0"
 mnist = "0.5.0"
 indicatif = "0.16.2"
-## workaround to enable dfdx-macros for tests: https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
-#dfdx = { path = ".", features = ["dfdx-macros"]}
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,12 @@ matrixmultiply = { version = "0.3.2", default-features = false }
 zip = { version = "0.6.2", default-features = false, optional = true }
 cblas-sys = { version = "0.1.4", default-features = false, optional = true }
 libc = { version = "0.2", default-features = false, optional = true }
-dfdx-macros = { path = "./dfdx-macros", default-features = false, optional = true }
+dfdx-macros = { version = "0.1.0", path = "./dfdx-macros", default-features = false, optional = true }
 
 [features]
 default = ["std", "numpy"]
 std = ["no-std-compat/std", "rand/std", "rand_distr/std"]
+derive = ["dfdx-macros"]
 nightly = []
 numpy = ["dep:zip", "std"]
 cblas = ["dep:cblas-sys", "dep:libc"]
@@ -48,6 +49,8 @@ rand = "0.8.5"
 tempfile = "3.3.0"
 mnist = "0.5.0"
 indicatif = "0.16.2"
+# workaround to enable dfdx-macros for tests: https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
+dfdx = { path = ".", features = ["dfdx-macros"]}
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,11 @@ matrixmultiply = { version = "0.3.2", default-features = false }
 zip = { version = "0.6.2", default-features = false, optional = true }
 cblas-sys = { version = "0.1.4", default-features = false, optional = true }
 libc = { version = "0.2", default-features = false, optional = true }
-dfdx-macros = { version = "0.1.0", path = "./dfdx-macros", default-features = false, optional = true }
+dfdx-macros = { version = "0.1.0", path = "./dfdx-macros", default-features = false, optional = false }
 
 [features]
 default = ["std", "numpy"]
 std = ["no-std-compat/std", "rand/std", "rand_distr/std"]
-derive = ["dfdx-macros"]
 nightly = []
 numpy = ["dep:zip", "std"]
 cblas = ["dep:cblas-sys", "dep:libc"]
@@ -49,8 +48,8 @@ rand = "0.8.5"
 tempfile = "3.3.0"
 mnist = "0.5.0"
 indicatif = "0.16.2"
-# workaround to enable dfdx-macros for tests: https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
-dfdx = { path = ".", features = ["dfdx-macros"]}
+## workaround to enable dfdx-macros for tests: https://github.com/rust-lang/cargo/issues/2911#issuecomment-749580481
+#dfdx = { path = ".", features = ["dfdx-macros"]}
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/dfdx-macros/Cargo.toml
+++ b/dfdx-macros/Cargo.toml
@@ -22,18 +22,11 @@ keywords = [
 proc-macro = true
 
 [features]
-procout = ["procout/procout"]
 
 [dependencies]
 proc-macro2 = "^1.0"
 quote = "1"
 syn = { version = "^1.0", features = ["full"] }
 
-# TODO: remove when merging
-procout = { version = "0.1", features = ["procout"] }
-
-# If you copy one of the examples into a new project, you should be using
-# [dependencies] instead, and delete the **path**.
 [dev-dependencies]
-dfdx = { version = "0.9.0", path = "../." }
-trybuild = "1.0"
+dfdx = { version = "0.9.0", path = "../.", features = ["dfdx-macros"] }

--- a/dfdx-macros/Cargo.toml
+++ b/dfdx-macros/Cargo.toml
@@ -27,6 +27,8 @@ proc-macro = true
 proc-macro2 = "^1.0"
 quote = "1"
 syn = { version = "^1.0", features = ["full"] }
+darling = "0.14"
 
 [dev-dependencies]
 dfdx = { version = "0.10.0", path = "../." }
+rand = { version = "0.8.5", default-features = false, features = ["std_rng"] }

--- a/dfdx-macros/Cargo.toml
+++ b/dfdx-macros/Cargo.toml
@@ -32,3 +32,4 @@ darling = "0.14"
 [dev-dependencies]
 dfdx = { version = "0.10.0", path = "../." }
 rand = { version = "0.8.5", default-features = false, features = ["std_rng"] }
+rand_distr = { version = "0.4.3", default-features = false, features = ["std_math"] }

--- a/dfdx-macros/Cargo.toml
+++ b/dfdx-macros/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "dfdx-macros"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+description = "dfdx's procedural macros"
+homepage = "https://github.com/coreylowman/dfdx"
+documentation = "https://docs.rs/dfdx"
+repository = "https://github.com/coreylowman/dfdx"
+readme = "README.md"
+
+keywords = [
+    "deep-learning",
+    "neural-network",
+    "backprop",
+    "tensor",
+    "autodiff",
+]
+
+[lib]
+proc-macro = true
+
+[features]
+procout = ["procout/procout"]
+
+[dependencies]
+proc-macro2 = "^1.0"
+quote = "1"
+syn = { version = "^1.0", features = ["full"] }
+
+# TODO: remove when merging
+procout = { version = "0.1", features = ["procout"] }
+
+# If you copy one of the examples into a new project, you should be using
+# [dependencies] instead, and delete the **path**.
+[dev-dependencies]
+dfdx = { version = "0.9.0", path = "../." }
+trybuild = "1.0"

--- a/dfdx-macros/Cargo.toml
+++ b/dfdx-macros/Cargo.toml
@@ -29,4 +29,4 @@ quote = "1"
 syn = { version = "^1.0", features = ["full"] }
 
 [dev-dependencies]
-dfdx = { version = "0.9.0", path = "../.", features = ["dfdx-macros"] }
+dfdx = { version = "0.10.0", path = "../.", features = ["dfdx-macros"] }

--- a/dfdx-macros/Cargo.toml
+++ b/dfdx-macros/Cargo.toml
@@ -29,4 +29,4 @@ quote = "1"
 syn = { version = "^1.0", features = ["full"] }
 
 [dev-dependencies]
-dfdx = { version = "0.10.0", path = "../.", features = ["dfdx-macros"] }
+dfdx = { version = "0.10.0", path = "../." }

--- a/dfdx-macros/src/can_update_with_gradients.rs
+++ b/dfdx-macros/src/can_update_with_gradients.rs
@@ -8,12 +8,12 @@ pub fn gen(ast: syn::DeriveInput) -> TokenStream {
 
     let generics = add_trait_bounds(&ast.data, ast.generics);
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let updates = get_updates(&ast.data);
+    let fields_code = get_fields_code(&ast.data);
 
     quote! {
         impl #impl_generics dfdx::gradients::CanUpdateWithGradients for #name #ty_generics #where_clause {
             fn update<G: dfdx::gradients::GradientProvider>(&mut self, grads: &mut G, unused: &mut dfdx::gradients::UnusedTensors) {
-                #updates
+                #fields_code
             }
         }
     }
@@ -40,7 +40,7 @@ fn add_trait_bounds(data: &syn::Data, mut generics: syn::Generics) -> syn::Gener
 }
 
 // Generates the `self.f.update(grads, unused)` for each field
-fn get_updates(data: &syn::Data) -> TokenStream {
+fn get_fields_code(data: &syn::Data) -> TokenStream {
     // TODO: have attributes to mark which fields to add grads to (see batchnorm).
     //  maybe one attribute `nograd` and all the fields below won't have grads?
 

--- a/dfdx-macros/src/can_update_with_gradients.rs
+++ b/dfdx-macros/src/can_update_with_gradients.rs
@@ -1,0 +1,75 @@
+// Helper functions for the CanUpdateWithGradients derive macro
+use proc_macro2::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+
+pub fn gen(ast: syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+
+    let generics = add_trait_bounds(&ast.data, ast.generics);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let updates = get_updates(&ast.data);
+
+    quote! {
+        impl #impl_generics dfdx::gradients::CanUpdateWithGradients for #name #ty_generics #where_clause {
+            fn update<G: dfdx::gradients::GradientProvider>(&mut self, grads: &mut G, unused: &mut dfdx::gradients::UnusedTensors) {
+                #updates
+            }
+        }
+    }
+}
+
+// Add a bound `T: CanUpdateWithGradients` to every type parameter T
+// if the struct contains unnamed fields.
+fn add_trait_bounds(data: &syn::Data, mut generics: syn::Generics) -> syn::Generics {
+    let add_trait_bounds = match *data {
+        syn::Data::Struct(ref data) => matches!(data.fields, syn::Fields::Unnamed(_)),
+        _ => false,
+    };
+
+    if add_trait_bounds {
+        for param in &mut generics.params {
+            if let syn::GenericParam::Type(ref mut type_param) = *param {
+                type_param
+                    .bounds
+                    .push(syn::parse_quote!(dfdx::gradients::CanUpdateWithGradients));
+            }
+        }
+    }
+    generics
+}
+
+// Generates the `self.f.update(grads, unused)` for each field
+fn get_updates(data: &syn::Data) -> TokenStream {
+    // TODO: have attributes to mark which fields to add grads to (see batchnorm).
+    //  maybe one attribute `nograd` and all the fields below won't have grads?
+
+    match *data {
+        syn::Data::Struct(ref data) => match data.fields {
+            syn::Fields::Named(ref fields) => {
+                let recurse = fields.named.iter().map(|f| {
+                    let name = &f.ident;
+                    quote_spanned! {f.span() =>
+                        self.#name.update(grads, unused);
+                    }
+                });
+                quote! {
+                    #(#recurse)*
+                }
+            }
+            syn::Fields::Unnamed(ref fields) => {
+                let recurse = fields.unnamed.iter().enumerate().map(|(i, f)| {
+                    let index = syn::Index::from(i);
+                    quote_spanned! {f.span() =>
+                        self.#index.update(grads, unused);
+                    }
+                });
+                quote! {
+                    #(#recurse)*
+                }
+            }
+            syn::Fields::Unit => quote! {},
+        },
+        syn::Data::Enum(_) | syn::Data::Union(_) => quote!(),
+    }
+}

--- a/dfdx-macros/src/lib.rs
+++ b/dfdx-macros/src/lib.rs
@@ -1,0 +1,92 @@
+//! Macros for use with dfdx
+
+// This `extern` is required for older `rustc` versions but newer `rustc`
+// versions warn about the unused `extern crate`.
+#[allow(unused_extern_crates)]
+extern crate proc_macro;
+
+use proc_macro2::TokenStream;
+use procout::procout;
+use quote::{format_ident, quote, quote_spanned};
+use syn::spanned::Spanned;
+use syn::{DeriveInput, parse_macro_input};
+
+
+/// Implements CanUpdateWithGradients for a Module
+///
+/// ```rust
+/// use dfdx::prelude::*;
+/// use dfdx_macros::CanUpdateWithGradients;
+///
+/// #[derive(CanUpdateWithGradients)]
+/// pub struct Linear<const I: usize, const O: usize> {
+///     // Transposed weight matrix, shape (O, I)
+///     pub weight: Tensor2D<O, I>,
+///
+///     // Bias vector, shape (O, )
+///     pub bias: Tensor1D<O>,
+/// }
+/// ```
+#[proc_macro_derive(CanUpdateWithGradients)]
+pub fn derive_can_update_with_gradients(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = &ast.generics.split_for_impl();
+
+    let updates = get_updates(&ast.data);
+
+    let code_block = quote! {
+
+        use dfdx::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
+
+        impl #impl_generics CanUpdateWithGradients for #name #ty_generics #where_clause {
+            fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {
+                #updates
+            }
+        }
+
+    };
+
+    // TODO: remove when merging
+    procout(&TokenStream::from(code_block.clone()), Some(format_ident!("{}", name)), Some("macro-out"));
+
+    proc_macro::TokenStream::from(code_block)
+}
+
+fn get_updates(data: &syn::Data) -> TokenStream {
+    // Currently only works if a struct doesn't have a mix of named and unnamed fields
+
+    // TODO: have attributes to mark which fields to add grads to (see batchnorm).
+    //  maybe one attribute `nograd` and all the fields below won't have grads?
+
+    match *data {
+        syn::Data::Struct(ref data) => {
+            match data.fields {
+                syn::Fields::Named(ref fields) => {
+                    let recurse = fields.named.iter().map(|f| {
+                        let name = &f.ident;
+                        quote_spanned! {f.span() =>
+                            self.#name.update(grads, unused);
+                        }
+                    });
+                    quote! {
+                        #(#recurse)*
+                    }
+                },
+                syn::Fields::Unnamed(ref fields) => {
+                    let recurse = fields.unnamed.iter().enumerate().map(|(i, f)| {
+                        let index = syn::Index::from(i);
+                        quote_spanned! {f.span() =>
+                            self.#index.update(grads, unused);
+                        }
+                    });
+                    quote! {
+                        #(#recurse)*
+                    }
+                },
+                syn::Fields::Unit => quote! {},
+            }
+        },
+        syn::Data::Enum(_) | syn::Data::Union(_) => unimplemented!(),
+    }
+}

--- a/dfdx-macros/src/lib.rs
+++ b/dfdx-macros/src/lib.rs
@@ -5,10 +5,10 @@
 #[allow(unused_extern_crates)]
 extern crate proc_macro;
 
-use proc_macro2::TokenStream;
-use quote::{quote, quote_spanned};
-use syn::spanned::Spanned;
-use syn::{parse_macro_input, parse_quote, DeriveInput};
+use syn::{parse_macro_input, DeriveInput};
+
+mod can_update_with_gradients;
+mod reset_params;
 
 /// Implements CanUpdateWithGradients for a Module
 ///
@@ -28,76 +28,29 @@ use syn::{parse_macro_input, parse_quote, DeriveInput};
 #[proc_macro_derive(CanUpdateWithGradients)]
 pub fn derive_can_update_with_gradients(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
-    let name = &ast.ident;
-
-    let generics = add_trait_bounds(&ast.data, ast.generics);
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let updates = get_updates(&ast.data);
-
-    let code_block = quote! {
-        impl #impl_generics dfdx::gradients::CanUpdateWithGradients for #name #ty_generics #where_clause {
-            fn update<G: dfdx::gradients::GradientProvider>(&mut self, grads: &mut G, unused: &mut dfdx::gradients::UnusedTensors) {
-                #updates
-            }
-        }
-    };
-
-    proc_macro::TokenStream::from(code_block)
+    let gen = can_update_with_gradients::gen(ast);
+    gen.into()
 }
 
-// Add a bound `T: CanUpdateWithGradients` to every type parameter T
-// if the struct contains unnamed fields.
-fn add_trait_bounds(data: &syn::Data, mut generics: syn::Generics) -> syn::Generics {
-    let add_trait_bounds = match *data {
-        syn::Data::Struct(ref data) => matches!(data.fields, syn::Fields::Unnamed(_)),
-        _ => false,
-    };
+/// Implements ResetParams for a Module
+///
+/// ```ignore
+/// use dfdx::prelude::*;
+/// use dfdx_macros::ResetParams;
+///
+/// #[derive(ResetParams)]
+/// pub struct Linear<const I: usize, const O: usize> {
+///     // Transposed weight matrix, shape (O, I)
+///     pub weight: Tensor2D<O, I>,
+///
+///     // Bias vector, shape (O, )
+///     pub bias: Tensor1D<O>,
+/// }
+/// ```
+#[proc_macro_derive(ResetParams, attributes(reset_params))]
+pub fn derive_reset_params(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
 
-    if add_trait_bounds {
-        for param in &mut generics.params {
-            if let syn::GenericParam::Type(ref mut type_param) = *param {
-                type_param
-                    .bounds
-                    .push(parse_quote!(dfdx::gradients::CanUpdateWithGradients));
-            }
-        }
-    }
-    generics
-}
-
-// Generates the `self.f.update(grads, unused)` for each field
-fn get_updates(data: &syn::Data) -> TokenStream {
-    // Currently only works if a struct doesn't have a mix of named and unnamed fields
-
-    // TODO: have attributes to mark which fields to add grads to (see batchnorm).
-    //  maybe one attribute `nograd` and all the fields below won't have grads?
-
-    match *data {
-        syn::Data::Struct(ref data) => match data.fields {
-            syn::Fields::Named(ref fields) => {
-                let recurse = fields.named.iter().map(|f| {
-                    let name = &f.ident;
-                    quote_spanned! {f.span() =>
-                        self.#name.update(grads, unused);
-                    }
-                });
-                quote! {
-                    #(#recurse)*
-                }
-            }
-            syn::Fields::Unnamed(ref fields) => {
-                let recurse = fields.unnamed.iter().enumerate().map(|(i, f)| {
-                    let index = syn::Index::from(i);
-                    quote_spanned! {f.span() =>
-                        self.#index.update(grads, unused);
-                    }
-                });
-                quote! {
-                    #(#recurse)*
-                }
-            }
-            syn::Fields::Unit => quote! {},
-        },
-        syn::Data::Enum(_) | syn::Data::Union(_) => quote!(),
-    }
+    let gen = reset_params::gen(ast);
+    gen.into()
 }

--- a/dfdx-macros/src/lib.rs
+++ b/dfdx-macros/src/lib.rs
@@ -34,7 +34,6 @@ pub fn derive_can_update_with_gradients(input: proc_macro::TokenStream) -> proc_
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let updates = get_updates(&ast.data);
 
-    // let code_block = quote_spanned! { Span::call_site() =>
     let code_block = quote! {
         impl #impl_generics CanUpdateWithGradients for #name #ty_generics #where_clause {
             fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {
@@ -83,7 +82,7 @@ fn get_updates(data: &syn::Data) -> TokenStream {
                         self.#name.update(grads, unused);
                     }
                 });
-                quote_spanned! {fields.span() =>
+                quote! {
                     #(#recurse)*
                 }
             }
@@ -94,7 +93,7 @@ fn get_updates(data: &syn::Data) -> TokenStream {
                         self.#index.update(grads, unused);
                     }
                 });
-                quote_spanned! {fields.span() =>
+                quote! {
                     #(#recurse)*
                 }
             }

--- a/dfdx-macros/src/lib.rs
+++ b/dfdx-macros/src/lib.rs
@@ -5,16 +5,15 @@
 #[allow(unused_extern_crates)]
 extern crate proc_macro;
 
-use proc_macro2::TokenStream;
-use procout::procout;
-use quote::{format_ident, quote, quote_spanned};
+use proc_macro2::{TokenStream};
+use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
-use syn::{DeriveInput, parse_macro_input};
+use syn::{DeriveInput, parse_macro_input, parse_quote};
 
 
 /// Implements CanUpdateWithGradients for a Module
 ///
-/// ```rust
+/// ```ignore
 /// use dfdx::prelude::*;
 /// use dfdx_macros::CanUpdateWithGradients;
 ///
@@ -31,28 +30,48 @@ use syn::{DeriveInput, parse_macro_input};
 pub fn derive_can_update_with_gradients(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     let name = &ast.ident;
-    let (impl_generics, ty_generics, where_clause) = &ast.generics.split_for_impl();
 
+    let generics = add_trait_bounds(&ast.data, ast.generics);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let updates = get_updates(&ast.data);
 
+    // let code_block = quote_spanned! { Span::call_site() =>
     let code_block = quote! {
-
-        use dfdx::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
-
         impl #impl_generics CanUpdateWithGradients for #name #ty_generics #where_clause {
             fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {
                 #updates
             }
         }
-
     };
-
-    // TODO: remove when merging
-    procout(&TokenStream::from(code_block.clone()), Some(format_ident!("{}", name)), Some("macro-out"));
 
     proc_macro::TokenStream::from(code_block)
 }
 
+// Add a bound `T: CanUpdateWithGradients` to every type parameter T
+// if the struct contains unnamed fields.
+fn add_trait_bounds(data: &syn::Data, mut generics: syn::Generics) -> syn::Generics {
+    let add_trait_bounds = match *data {
+        syn::Data::Struct(ref data) => {
+            match data.fields {
+                syn::Fields::Unnamed(_) => true,
+                _ => false,
+            }
+        },
+        _ => false,
+    };
+
+    if add_trait_bounds {
+        for param in &mut generics.params {
+            if let syn::GenericParam::Type(ref mut type_param) = *param {
+                type_param.bounds.push(parse_quote!(CanUpdateWithGradients));
+            }
+        }
+    }
+    generics
+}
+
+
+// Generates the `self.f.update(grads, unused)` for each field
 fn get_updates(data: &syn::Data) -> TokenStream {
     // Currently only works if a struct doesn't have a mix of named and unnamed fields
 
@@ -69,7 +88,7 @@ fn get_updates(data: &syn::Data) -> TokenStream {
                             self.#name.update(grads, unused);
                         }
                     });
-                    quote! {
+                    quote_spanned! {fields.span() =>
                         #(#recurse)*
                     }
                 },
@@ -80,13 +99,13 @@ fn get_updates(data: &syn::Data) -> TokenStream {
                             self.#index.update(grads, unused);
                         }
                     });
-                    quote! {
+                    quote_spanned! {fields.span() =>
                         #(#recurse)*
                     }
                 },
                 syn::Fields::Unit => quote! {},
             }
         },
-        syn::Data::Enum(_) | syn::Data::Union(_) => unimplemented!(),
+        syn::Data::Enum(_) | syn::Data::Union(_) => quote!(),
     }
 }

--- a/dfdx-macros/src/reset_params.rs
+++ b/dfdx-macros/src/reset_params.rs
@@ -1,0 +1,29 @@
+// Helper functions for the ResetParams derive macro
+use darling::FromDeriveInput;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+#[derive(Debug, FromDeriveInput, Default)]
+#[darling(default, attributes(reset_params), forward_attrs(allow, doc, cfg))]
+struct Opts {
+    answer: Option<i32>,
+    etc: Option<String>,
+}
+
+pub fn gen(ast: syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+    let opts = Opts::from_derive_input(&ast).expect("Wrong options");
+    println!("{:?}", opts);
+
+    // let generics = add_trait_bounds(&ast.data, ast.generics);
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    // let updates = get_updates(&ast.data);
+
+    quote! {
+        impl #impl_generics dfdx::prelude::ResetParams for #name #ty_generics #where_clause {
+            fn reset_params<R: Rng>(&mut self, rng: &mut R) {
+                // #updates
+            }
+        }
+    }
+}

--- a/dfdx-macros/src/reset_params.rs
+++ b/dfdx-macros/src/reset_params.rs
@@ -1,29 +1,139 @@
 // Helper functions for the ResetParams derive macro
-use darling::FromDeriveInput;
+use darling::{FromDeriveInput, FromMeta, Result, Error};
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+
+
+
+#[derive(Debug)]
+enum Initializers {
+    Zeros,
+    Ones,
+    Normal,
+    // TODO: add initializers that take parameters, such as RandomUniform(min, max)
+    //  should those initializers be added to the main crate?
+    //  how can they be imported in both the main and macro crate? maybe they should live in a
+    //  third crate?
+}
+
+impl Default for Initializers {
+    fn default() -> Self {
+        Initializers::Normal
+    }
+}
+
+impl FromMeta for Initializers {
+    fn from_string(value: &str) -> Result<Self> {
+        match value {
+            "zeros" => Ok(Initializers::Zeros),
+            "ones" => Ok(Initializers::Ones),
+            "normal" => Ok(Initializers::Normal),
+            _ => Err(Error::unknown_value(value)),
+        }
+    }
+}
 
 #[derive(Debug, FromDeriveInput, Default)]
 #[darling(default, attributes(reset_params), forward_attrs(allow, doc, cfg))]
 struct Opts {
-    answer: Option<i32>,
-    etc: Option<String>,
+    initializer: Option<Initializers>,
 }
 
 pub fn gen(ast: syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
-    let opts = Opts::from_derive_input(&ast).expect("Wrong options");
-    println!("{:?}", opts);
+    let opts = Opts::from_derive_input(&ast).expect("Error in parsing attribute 'initializer'");
 
-    // let generics = add_trait_bounds(&ast.data, ast.generics);
-    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
-    // let updates = get_updates(&ast.data);
+    let generics = add_trait_bounds(&ast.data, ast.generics);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let init_code = get_initializer_code(&opts.initializer);
+    let fields_code = get_fields_code(&ast.data, &opts.initializer);
 
     quote! {
         impl #impl_generics dfdx::prelude::ResetParams for #name #ty_generics #where_clause {
             fn reset_params<R: Rng>(&mut self, rng: &mut R) {
-                // #updates
+                #init_code
+                #fields_code
             }
+        }
+    }
+}
+
+
+// Add a bound `T: ResetParams` to every type parameter T
+// if the struct contains unnamed fields.
+fn add_trait_bounds(data: &syn::Data, mut generics: syn::Generics) -> syn::Generics {
+    let add_trait_bounds = match *data {
+        syn::Data::Struct(ref data) => matches!(data.fields, syn::Fields::Unnamed(_)),
+        _ => false,
+    };
+
+    if add_trait_bounds {
+        for param in &mut generics.params {
+            if let syn::GenericParam::Type(ref mut type_param) = *param {
+                type_param
+                    .bounds
+                    .push(syn::parse_quote!(dfdx::prelude::ResetParams));
+            }
+        }
+    }
+    generics
+}
+
+
+// Generates `self.f.randomize(rng, &dist);` for each named field f
+// or `self.x.reset_params(rng);` for each unnamed field x
+fn get_fields_code(data: &syn::Data, init: &Option<Initializers>) -> TokenStream {
+    match *data {
+        syn::Data::Struct(ref data) => match data.fields {
+            syn::Fields::Named(ref fields) => {
+                let recurse = fields.named.iter().map(|f| {
+                    let field_gen = get_named_field_fn(f, init);
+                    quote_spanned! {f.span() => #field_gen; }
+                });
+                quote! {
+                    #(#recurse)*
+                }
+            }
+            syn::Fields::Unnamed(ref fields) => {
+                let recurse = fields.unnamed.iter().enumerate().map(|(i, f)| {
+                    let index = syn::Index::from(i);
+                    quote_spanned! {f.span() =>
+                        self.#index.reset_params(rng);
+                    }
+                });
+                quote! {
+                    #(#recurse)*
+                }
+            }
+            syn::Fields::Unit => quote! {},
+        },
+        syn::Data::Enum(_) | syn::Data::Union(_) => quote!(),
+    }
+}
+
+
+fn get_named_field_fn(f: &syn::Field, init: &Option<Initializers>) -> TokenStream {
+    let name = &f.ident;
+    match init {
+        Some(Initializers::Zeros) => {
+            quote! { Cpu::fill(self.#name.mut_data(), &mut |v| *v = 0.0); }
+        },
+        Some(Initializers::Ones) => {
+            quote! { Cpu::fill(self.#name.mut_data(), &mut |v| *v = 1.0); }
+        },
+        Some(Initializers::Normal) | None => {
+            quote! { self.#name.randomize(rng, &dist); }
+        },
+    }
+}
+
+
+fn get_initializer_code(init: &Option<Initializers>) -> TokenStream {
+    match init {
+        Some(Initializers::Zeros) | Some(Initializers::Ones) => { TokenStream::new() },
+        Some(Initializers::Normal) | None => {
+            quote! { let dist = StandardNormal; }
         }
     }
 }

--- a/dfdx-macros/src/reset_params.rs
+++ b/dfdx-macros/src/reset_params.rs
@@ -1,10 +1,8 @@
 // Helper functions for the ResetParams derive macro
-use darling::{FromDeriveInput, FromMeta, Result, Error};
+use darling::{Error, FromDeriveInput, FromMeta, Result};
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
-
-
 
 #[derive(Debug)]
 enum Initializers {
@@ -59,7 +57,6 @@ pub fn gen(ast: syn::DeriveInput) -> TokenStream {
     }
 }
 
-
 // Add a bound `T: ResetParams` to every type parameter T
 // if the struct contains unnamed fields.
 fn add_trait_bounds(data: &syn::Data, mut generics: syn::Generics) -> syn::Generics {
@@ -79,7 +76,6 @@ fn add_trait_bounds(data: &syn::Data, mut generics: syn::Generics) -> syn::Gener
     }
     generics
 }
-
 
 // Generates `self.f.randomize(rng, &dist);` for each named field f
 // or `self.x.reset_params(rng);` for each unnamed field x
@@ -112,22 +108,20 @@ fn get_fields_code(data: &syn::Data, init: &Option<Initializers>) -> TokenStream
     }
 }
 
-
 fn get_named_field_fn(f: &syn::Field, init: &Option<Initializers>) -> TokenStream {
     let name = &f.ident;
     match init {
         Some(Initializers::Zeros) => {
             quote! { Cpu::fill(self.#name.mut_data(), &mut |v| *v = 0.0); }
-        },
+        }
         Some(Initializers::Ones) => {
             quote! { Cpu::fill(self.#name.mut_data(), &mut |v| *v = 1.0); }
-        },
+        }
         Some(Initializers::Normal) | None => {
             quote! { self.#name.randomize(rng, &dist); }
-        },
+        }
     }
 }
-
 
 fn get_initializer_code(data: &syn::Data, init: &Option<Initializers>) -> TokenStream {
     let add_initializer_code = match *data {
@@ -137,7 +131,9 @@ fn get_initializer_code(data: &syn::Data, init: &Option<Initializers>) -> TokenS
 
     if add_initializer_code {
         match init {
-            Some(Initializers::Zeros) | Some(Initializers::Ones) => { quote! {} },
+            Some(Initializers::Zeros) | Some(Initializers::Ones) => {
+                quote! {}
+            }
             Some(Initializers::Normal) | None => {
                 quote! { let dist = StandardNormal; }
             }

--- a/dfdx-macros/tests/test_can_upgrade_with_gradients.rs
+++ b/dfdx-macros/tests/test_can_upgrade_with_gradients.rs
@@ -2,7 +2,7 @@
 use dfdx::optim::Sgd;
 use dfdx::tensor::*;
 
-use dfdx::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
+use dfdx::gradients::{CanUpdateWithGradients, UnusedTensors};
 use dfdx::nn::Linear;
 use dfdx_macros::CanUpdateWithGradients;
 

--- a/dfdx-macros/tests/test_can_upgrade_with_gradients.rs
+++ b/dfdx-macros/tests/test_can_upgrade_with_gradients.rs
@@ -1,0 +1,23 @@
+use dfdx::optim::Sgd;
+use dfdx_macros::CanUpdateWithGradients;
+use dfdx::tensor::*;
+
+
+
+#[derive(Default, CanUpdateWithGradients)]
+pub struct Linear<const I: usize, const O: usize> {
+    // Transposed weight matrix, shape (O, I)
+    pub weight: Tensor2D<O, I>,
+
+    // Bias vector, shape (O, )
+    pub bias: Tensor1D<O>,
+}
+
+
+#[test]
+fn test_derive_can_update_with_gradients() {
+    let mut model: Linear<5, 2> = Linear::default();
+    let mut gradients_provider: Sgd<f32> = Default::default();
+    let mut unused: UnusedTensors = Default::default();
+    model.update(&mut gradients_provider, &mut unused);
+}

--- a/dfdx-macros/tests/test_can_upgrade_with_gradients.rs
+++ b/dfdx-macros/tests/test_can_upgrade_with_gradients.rs
@@ -2,13 +2,12 @@
 use dfdx::optim::Sgd;
 use dfdx::tensor::*;
 
-use dfdx_macros::CanUpdateWithGradients;
-use dfdx::gradients::{UnusedTensors, GradientProvider, CanUpdateWithGradients};
+use dfdx::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use dfdx::nn::Linear;
+use dfdx_macros::CanUpdateWithGradients;
 
 #[test]
 fn test_named_fields() {
-
     #[derive(CanUpdateWithGradients, Default)]
     pub struct Linear<const I: usize, const O: usize> {
         // Transposed weight matrix, shape (O, I)
@@ -25,7 +24,6 @@ fn test_named_fields() {
 
 #[test]
 fn test_unnamed_fields() {
-
     #[derive(CanUpdateWithGradients, Default)]
     pub struct Residual<F>(pub F);
 

--- a/dfdx-macros/tests/test_can_upgrade_with_gradients.rs
+++ b/dfdx-macros/tests/test_can_upgrade_with_gradients.rs
@@ -1,22 +1,35 @@
+// Test macro expansion with `cargo expand --test test_can_upgrade_with_gradients`
 use dfdx::optim::Sgd;
-use dfdx_macros::CanUpdateWithGradients;
 use dfdx::tensor::*;
 
-
-
-#[derive(Default, CanUpdateWithGradients)]
-pub struct Linear<const I: usize, const O: usize> {
-    // Transposed weight matrix, shape (O, I)
-    pub weight: Tensor2D<O, I>,
-
-    // Bias vector, shape (O, )
-    pub bias: Tensor1D<O>,
-}
-
+use dfdx_macros::CanUpdateWithGradients;
+use dfdx::gradients::{UnusedTensors, GradientProvider, CanUpdateWithGradients};
+use dfdx::nn::Linear;
 
 #[test]
-fn test_derive_can_update_with_gradients() {
+fn test_named_fields() {
+
+    #[derive(CanUpdateWithGradients, Default)]
+    pub struct Linear<const I: usize, const O: usize> {
+        // Transposed weight matrix, shape (O, I)
+        pub weight: Tensor2D<O, I>,
+
+        // Bias vector, shape (O, )
+        pub bias: Tensor1D<O>,
+    }
     let mut model: Linear<5, 2> = Linear::default();
+    let mut gradients_provider: Sgd<f32> = Default::default();
+    let mut unused: UnusedTensors = Default::default();
+    model.update(&mut gradients_provider, &mut unused);
+}
+
+#[test]
+fn test_unnamed_fields() {
+
+    #[derive(CanUpdateWithGradients, Default)]
+    pub struct Residual<F>(pub F);
+
+    let mut model: Residual<Linear<2, 5>> = Default::default();
     let mut gradients_provider: Sgd<f32> = Default::default();
     let mut unused: UnusedTensors = Default::default();
     model.update(&mut gradients_provider, &mut unused);

--- a/dfdx-macros/tests/test_reset_params.rs
+++ b/dfdx-macros/tests/test_reset_params.rs
@@ -2,11 +2,10 @@
 use dfdx::tensor::*;
 use rand::prelude::*;
 
+use dfdx::arrays::AllAxes;
+use dfdx::devices::{Cpu, FillElements};
 use dfdx::prelude::*;
 use dfdx_macros::ResetParams;
-use dfdx::devices::{Cpu, FillElements};
-use dfdx::arrays::AllAxes;
-
 
 #[test]
 fn test_named_fields_default_attribute() {
@@ -27,7 +26,7 @@ fn test_named_fields_default_attribute() {
 #[test]
 fn test_named_fields_with_attribute() {
     #[derive(ResetParams, Default)]
-    #[reset_params(initializer="ones")]
+    #[reset_params(initializer = "ones")]
     pub struct Linear<const I: usize, const O: usize> {
         // Transposed weight matrix, shape (O, I)
         pub weight: Tensor2D<O, I>,

--- a/dfdx-macros/tests/test_reset_params.rs
+++ b/dfdx-macros/tests/test_reset_params.rs
@@ -2,13 +2,15 @@
 use dfdx::tensor::*;
 use rand::prelude::*;
 
-use dfdx::nn::Linear;
+use dfdx::prelude::*;
 use dfdx::prelude::ResetParams;
 use dfdx_macros::ResetParams;
+use dfdx::devices::{Cpu, FillElements};
 
 #[test]
 fn test_named_fields() {
     #[derive(ResetParams, Default)]
+    #[reset_params(initializer="ones")]
     pub struct Linear<const I: usize, const O: usize> {
         // Transposed weight matrix, shape (O, I)
         pub weight: Tensor2D<O, I>,
@@ -21,7 +23,7 @@ fn test_named_fields() {
     model.reset_params(&mut rng);
 }
 
-#[test]
+/*#[test]
 fn test_unnamed_fields() {
     #[derive(ResetParams, Default)]
     pub struct Residual<F>(pub F);
@@ -29,4 +31,4 @@ fn test_unnamed_fields() {
     let mut model: Residual<Linear<2, 5>> = Default::default();
     let mut rng = StdRng::seed_from_u64(0);
     model.reset_params(&mut rng);
-}
+}*/

--- a/dfdx-macros/tests/test_reset_params.rs
+++ b/dfdx-macros/tests/test_reset_params.rs
@@ -3,14 +3,15 @@ use dfdx::tensor::*;
 use rand::prelude::*;
 
 use dfdx::prelude::*;
-use dfdx::prelude::ResetParams;
 use dfdx_macros::ResetParams;
 use dfdx::devices::{Cpu, FillElements};
+use dfdx::arrays::AllAxes;
+
 
 #[test]
-fn test_named_fields() {
+fn test_named_fields_default_attribute() {
+    use rand_distr::StandardNormal;
     #[derive(ResetParams, Default)]
-    #[reset_params(initializer="ones")]
     pub struct Linear<const I: usize, const O: usize> {
         // Transposed weight matrix, shape (O, I)
         pub weight: Tensor2D<O, I>,
@@ -23,7 +24,24 @@ fn test_named_fields() {
     model.reset_params(&mut rng);
 }
 
-/*#[test]
+#[test]
+fn test_named_fields_with_attribute() {
+    #[derive(ResetParams, Default)]
+    #[reset_params(initializer="ones")]
+    pub struct Linear<const I: usize, const O: usize> {
+        // Transposed weight matrix, shape (O, I)
+        pub weight: Tensor2D<O, I>,
+
+        // Bias vector, shape (O, )
+        pub bias: Tensor1D<O>,
+    }
+    let mut model: Linear<5, 2> = Linear::default();
+    let mut rng = StdRng::seed_from_u64(0);
+    model.reset_params(&mut rng);
+    assert_eq!(model.weight.sum::<_, AllAxes>().data(), &10.0)
+}
+
+#[test]
 fn test_unnamed_fields() {
     #[derive(ResetParams, Default)]
     pub struct Residual<F>(pub F);
@@ -31,4 +49,4 @@ fn test_unnamed_fields() {
     let mut model: Residual<Linear<2, 5>> = Default::default();
     let mut rng = StdRng::seed_from_u64(0);
     model.reset_params(&mut rng);
-}*/
+}

--- a/dfdx-macros/tests/test_reset_params.rs
+++ b/dfdx-macros/tests/test_reset_params.rs
@@ -1,0 +1,32 @@
+// Test macro expansion with `cargo expand --test test_reset_params`
+use dfdx::tensor::*;
+use rand::prelude::*;
+
+use dfdx::nn::Linear;
+use dfdx::prelude::ResetParams;
+use dfdx_macros::ResetParams;
+
+#[test]
+fn test_named_fields() {
+    #[derive(ResetParams, Default)]
+    pub struct Linear<const I: usize, const O: usize> {
+        // Transposed weight matrix, shape (O, I)
+        pub weight: Tensor2D<O, I>,
+
+        // Bias vector, shape (O, )
+        pub bias: Tensor1D<O>,
+    }
+    let mut model: Linear<5, 2> = Linear::default();
+    let mut rng = StdRng::seed_from_u64(0);
+    model.reset_params(&mut rng);
+}
+
+#[test]
+fn test_unnamed_fields() {
+    #[derive(ResetParams, Default)]
+    pub struct Residual<F>(pub F);
+
+    let mut model: Residual<Linear<2, 5>> = Default::default();
+    let mut rng = StdRng::seed_from_u64(0);
+    model.reset_params(&mut rng);
+}

--- a/examples/07-custom-module.rs
+++ b/examples/07-custom-module.rs
@@ -29,7 +29,6 @@ impl<const IN: usize, const INNER: usize, const OUT: usize> ResetParams for Mlp<
     }
 }
 
-
 // impl Module for single item
 impl<const IN: usize, const INNER: usize, const OUT: usize> Module<Tensor1D<IN>>
     for Mlp<IN, INNER, OUT>

--- a/examples/07-custom-module.rs
+++ b/examples/07-custom-module.rs
@@ -2,7 +2,7 @@
 
 use rand::prelude::*;
 
-use dfdx::gradients::{CanUpdateWithGradients, GradientProvider, OwnedTape, Tape, UnusedTensors};
+use dfdx::gradients::{OwnedTape, Tape};
 use dfdx::nn::{Linear, Module, ReLU, ResetParams};
 use dfdx::tensor::{Tensor1D, Tensor2D, TensorCreator};
 use dfdx_macros::CanUpdateWithGradients;

--- a/examples/07-custom-module.rs
+++ b/examples/07-custom-module.rs
@@ -5,11 +5,15 @@ use rand::prelude::*;
 use dfdx::gradients::{CanUpdateWithGradients, GradientProvider, OwnedTape, Tape, UnusedTensors};
 use dfdx::nn::{Linear, Module, ReLU, ResetParams};
 use dfdx::tensor::{Tensor1D, Tensor2D, TensorCreator};
+use dfdx_macros::CanUpdateWithGradients;
 
 /// Custom model struct
 /// This case is trivial and should be done with a tuple of linears and relus,
 /// but it demonstrates how to build models with custom behavior
-#[derive(Default)]
+///
+/// CanUpdateWithGradients lets you update a model's parameters using gradients, and is implemented
+/// via a macro
+#[derive(Default, CanUpdateWithGradients)]
 struct Mlp<const IN: usize, const INNER: usize, const OUT: usize> {
     l1: Linear<IN, INNER>,
     l2: Linear<INNER, OUT>,
@@ -25,16 +29,6 @@ impl<const IN: usize, const INNER: usize, const OUT: usize> ResetParams for Mlp<
     }
 }
 
-// CanUpdateWithGradients lets you update a model's parameters using gradients
-impl<const IN: usize, const INNER: usize, const OUT: usize> CanUpdateWithGradients
-    for Mlp<IN, INNER, OUT>
-{
-    fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {
-        self.l1.update(grads, unused);
-        self.l2.update(grads, unused);
-        self.relu.update(grads, unused);
-    }
-}
 
 // impl Module for single item
 impl<const IN: usize, const INNER: usize, const OUT: usize> Module<Tensor1D<IN>>

--- a/examples/07-custom-module.rs
+++ b/examples/07-custom-module.rs
@@ -11,8 +11,8 @@ use dfdx_macros::CanUpdateWithGradients;
 /// This case is trivial and should be done with a tuple of linears and relus,
 /// but it demonstrates how to build models with custom behavior
 ///
-/// CanUpdateWithGradients lets you update a model's parameters using gradients, and is implemented
-/// via a macro
+/// CanUpdateWithGradients lets you update a model's parameters using gradients,
+/// The trait implementation is generated via a procedural macro
 #[derive(Default, CanUpdateWithGradients)]
 struct Mlp<const IN: usize, const INNER: usize, const OUT: usize> {
     l1: Linear<IN, INNER>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,8 @@
 extern crate alloc;
 extern crate no_std_compat as std;
 
+extern crate self as dfdx;
+
 pub mod arrays;
 pub mod data;
 pub mod devices;
@@ -117,7 +119,7 @@ pub mod unique_id;
 pub mod prelude {
     pub use crate::arrays::{AllAxes, Axes2, Axes3, Axes4, Axis, HasArrayData};
     pub use crate::devices::HasDevice;
-    pub use crate::gradients::{NoneTape, OwnedTape};
+    pub use crate::gradients::{CanUpdateWithGradients, NoneTape, OwnedTape};
     pub use crate::losses::*;
     pub use crate::nn::*;
     pub use crate::optim::*;

--- a/src/nn/activations.rs
+++ b/src/nn/activations.rs
@@ -1,18 +1,13 @@
 use crate::arrays::{HasArrayType, HasLastAxis};
 use crate::prelude::*;
-use dfdx_macros::CanUpdateWithGradients;
+use dfdx_macros::{CanUpdateWithGradients, ResetParams};
 use rand::Rng;
 
 macro_rules! activation_impls {
     ($struct_name:ident, $func_name:ident, #[$docstring:meta]) => {
         #[$docstring]
-        #[derive(Default, Debug, Clone, Copy, CanUpdateWithGradients)]
+        #[derive(Default, Debug, Clone, Copy, CanUpdateWithGradients, ResetParams)]
         pub struct $struct_name;
-
-        impl ResetParams for $struct_name {
-            /// Does nothing.
-            fn reset_params<R: Rng>(&mut self, _: &mut R) {}
-        }
 
         impl<T: Tensor<Dtype = f32>> Module<T> for $struct_name {
             type Output = T;

--- a/src/nn/activations.rs
+++ b/src/nn/activations.rs
@@ -2,18 +2,19 @@ use crate::arrays::{HasArrayType, HasLastAxis};
 use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use rand::Rng;
+use dfdx_macros::CanUpdateWithGradients;
 
 macro_rules! activation_impls {
     ($struct_name:ident, $func_name:ident, #[$docstring:meta]) => {
         #[$docstring]
-        #[derive(Default, Debug, Clone, Copy)]
+        #[derive(Default, Debug, Clone, Copy, CanUpdateWithGradients)]
         pub struct $struct_name;
 
-        impl CanUpdateWithGradients for $struct_name {
+       /* impl CanUpdateWithGradients for $struct_name {
             /// Does nothing.
             fn update<G: GradientProvider>(&mut self, _: &mut G, _: &mut UnusedTensors) {}
         }
-
+*/
         impl ResetParams for $struct_name {
             /// Does nothing.
             fn reset_params<R: Rng>(&mut self, _: &mut R) {}
@@ -50,13 +51,9 @@ activation_impls!(Sqrt, sqrt, #[doc="Unit struct that impls [Module] as calling 
 activation_impls!(Abs, abs, #[doc="Unit struct that impls [Module] as calling [abs()] on `input`."]);
 
 /// Unit struct that impls [Module] as calling [softmax()] on `input`."
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, CanUpdateWithGradients)]
 pub struct Softmax;
 
-impl CanUpdateWithGradients for Softmax {
-    /// Does nothing.
-    fn update<G: GradientProvider>(&mut self, _: &mut G, _: &mut UnusedTensors) {}
-}
 
 impl ResetParams for Softmax {
     /// Does nothing.

--- a/src/nn/activations.rs
+++ b/src/nn/activations.rs
@@ -10,11 +10,6 @@ macro_rules! activation_impls {
         #[derive(Default, Debug, Clone, Copy, CanUpdateWithGradients)]
         pub struct $struct_name;
 
-        /* impl CanUpdateWithGradients for $struct_name {
-                    /// Does nothing.
-                    fn update<G: GradientProvider>(&mut self, _: &mut G, _: &mut UnusedTensors) {}
-                }
-        */
         impl ResetParams for $struct_name {
             /// Does nothing.
             fn reset_params<R: Rng>(&mut self, _: &mut R) {}

--- a/src/nn/activations.rs
+++ b/src/nn/activations.rs
@@ -1,8 +1,8 @@
 use crate::arrays::{HasArrayType, HasLastAxis};
 use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
-use rand::Rng;
 use dfdx_macros::CanUpdateWithGradients;
+use rand::Rng;
 
 macro_rules! activation_impls {
     ($struct_name:ident, $func_name:ident, #[$docstring:meta]) => {
@@ -10,11 +10,11 @@ macro_rules! activation_impls {
         #[derive(Default, Debug, Clone, Copy, CanUpdateWithGradients)]
         pub struct $struct_name;
 
-       /* impl CanUpdateWithGradients for $struct_name {
-            /// Does nothing.
-            fn update<G: GradientProvider>(&mut self, _: &mut G, _: &mut UnusedTensors) {}
-        }
-*/
+        /* impl CanUpdateWithGradients for $struct_name {
+                    /// Does nothing.
+                    fn update<G: GradientProvider>(&mut self, _: &mut G, _: &mut UnusedTensors) {}
+                }
+        */
         impl ResetParams for $struct_name {
             /// Does nothing.
             fn reset_params<R: Rng>(&mut self, _: &mut R) {}
@@ -53,7 +53,6 @@ activation_impls!(Abs, abs, #[doc="Unit struct that impls [Module] as calling [a
 /// Unit struct that impls [Module] as calling [softmax()] on `input`."
 #[derive(Default, Debug, Clone, Copy, CanUpdateWithGradients)]
 pub struct Softmax;
-
 
 impl ResetParams for Softmax {
     /// Does nothing.

--- a/src/nn/activations.rs
+++ b/src/nn/activations.rs
@@ -1,5 +1,4 @@
 use crate::arrays::{HasArrayType, HasLastAxis};
-use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use dfdx_macros::CanUpdateWithGradients;
 use rand::Rng;

--- a/src/nn/add_into.rs
+++ b/src/nn/add_into.rs
@@ -1,5 +1,5 @@
-use dfdx_macros::{CanUpdateWithGradients, ResetParams};
 use crate::prelude::*;
+use dfdx_macros::{CanUpdateWithGradients, ResetParams};
 use rand::Rng;
 
 /// Add inputs together into a single tensor. `T` should be a tuple
@@ -19,7 +19,6 @@ use rand::Rng;
 /// ```
 #[derive(Debug, Default, Clone, CanUpdateWithGradients, ResetParams)]
 pub struct AddInto<T>(pub T);
-
 
 macro_rules! tuple_impls {
     ($head:ident $headin:ident [$($tails:ident $tailsin:ident),+]) => {

--- a/src/nn/add_into.rs
+++ b/src/nn/add_into.rs
@@ -1,8 +1,9 @@
-use crate::gradients::{GradientProvider, UnusedTensors};
+use dfdx_macros::{CanUpdateWithGradients, ResetParams};
 use crate::prelude::*;
+use rand::Rng;
 
 /// Add inputs together into a single tensor. `T` should be a tuple
-//// where every element of the tuple has the same output type
+/// where every element of the tuple has the same output type
 ///
 /// This provides a utility for networks where multiple inputs are needed
 ///
@@ -16,20 +17,9 @@ use crate::prelude::*;
 /// let model: Model = Default::default();
 /// let _: Tensor1D<5> = model.forward((Tensor1D::<2>::zeros(), Tensor1D::<3>::zeros()));
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, CanUpdateWithGradients, ResetParams)]
 pub struct AddInto<T>(pub T);
 
-impl<T: CanUpdateWithGradients> CanUpdateWithGradients for AddInto<T> {
-    fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {
-        self.0.update(grads, unused);
-    }
-}
-
-impl<T: ResetParams> ResetParams for AddInto<T> {
-    fn reset_params<R: rand::Rng>(&mut self, rng: &mut R) {
-        self.0.reset_params(rng);
-    }
-}
 
 macro_rules! tuple_impls {
     ($head:ident $headin:ident [$($tails:ident $tailsin:ident),+]) => {

--- a/src/nn/add_into.rs
+++ b/src/nn/add_into.rs
@@ -1,4 +1,4 @@
-use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
+use crate::gradients::{GradientProvider, UnusedTensors};
 use crate::prelude::*;
 
 /// Add inputs together into a single tensor. `T` should be a tuple

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -2,6 +2,7 @@ use crate::gradients::*;
 use crate::prelude::*;
 use rand::Rng;
 use rand_distr::Uniform;
+use dfdx_macros::CanUpdateWithGradients;
 
 /// **Requires Nightly** Performs 2d convolutions on 3d and 4d images.
 ///
@@ -24,7 +25,7 @@ use rand_distr::Uniform;
 /// #[cfg(feature = "nightly")]
 /// let _: Tensor4D<2, 33, 13, 12> = m.forward(Tensor4D::<2, 16, 15, 14>::zeros());
 /// ```
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, CanUpdateWithGradients)]
 pub struct Conv2D<
     const IN_CHAN: usize,
     const OUT_CHAN: usize,
@@ -36,14 +37,6 @@ pub struct Conv2D<
     pub bias: Tensor1D<OUT_CHAN>,
 }
 
-impl<const I: usize, const O: usize, const K: usize, const S: usize, const P: usize>
-    CanUpdateWithGradients for Conv2D<I, O, K, S, P>
-{
-    fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {
-        self.weight.update(grads, unused);
-        self.bias.update(grads, unused);
-    }
-}
 
 impl<const I: usize, const O: usize, const K: usize, const S: usize, const P: usize> ResetParams
     for Conv2D<I, O, K, S, P>

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -1,4 +1,4 @@
-use crate::gradients::*;
+use crate::gradients::Tape;
 use crate::prelude::*;
 use dfdx_macros::CanUpdateWithGradients;
 use rand::Rng;

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "nightly")]
 use crate::gradients::Tape;
 use crate::prelude::*;
 use dfdx_macros::CanUpdateWithGradients;

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -1,8 +1,8 @@
 use crate::gradients::*;
 use crate::prelude::*;
+use dfdx_macros::CanUpdateWithGradients;
 use rand::Rng;
 use rand_distr::Uniform;
-use dfdx_macros::CanUpdateWithGradients;
 
 /// **Requires Nightly** Performs 2d convolutions on 3d and 4d images.
 ///
@@ -36,7 +36,6 @@ pub struct Conv2D<
     pub weight: Tensor4D<OUT_CHAN, IN_CHAN, KERNEL_SIZE, KERNEL_SIZE>,
     pub bias: Tensor1D<OUT_CHAN>,
 }
-
 
 impl<const I: usize, const O: usize, const K: usize, const S: usize, const P: usize> ResetParams
     for Conv2D<I, O, K, S, P>

--- a/src/nn/flatten.rs
+++ b/src/nn/flatten.rs
@@ -1,8 +1,10 @@
-use crate::gradients::Tape;
 use crate::prelude::*;
-#[cfg(feature = "nightly")]
-use crate::{Assert, ConstTrue};
 use dfdx_macros::CanUpdateWithGradients;
+#[cfg(feature = "nightly")]
+use {
+    crate::prelude::*,
+    crate::{Assert, ConstTrue},
+};
 
 /// **Requires Nightly** Flattens 3d tensors to 1d, and 4d tensors to 2d.
 ///

--- a/src/nn/flatten.rs
+++ b/src/nn/flatten.rs
@@ -1,8 +1,8 @@
-use dfdx_macros::CanUpdateWithGradients;
 use crate::gradients::*;
 use crate::prelude::*;
 #[cfg(feature = "nightly")]
 use crate::{Assert, ConstTrue};
+use dfdx_macros::CanUpdateWithGradients;
 
 /// **Requires Nightly** Flattens 3d tensors to 1d, and 4d tensors to 2d.
 ///
@@ -18,7 +18,6 @@ pub struct Flatten2D;
 impl ResetParams for Flatten2D {
     fn reset_params<R: rand::Rng>(&mut self, _: &mut R) {}
 }
-
 
 #[cfg(feature = "nightly")]
 impl<const M: usize, const N: usize, const O: usize, H: Tape> Module<Tensor3D<M, N, O, H>>

--- a/src/nn/flatten.rs
+++ b/src/nn/flatten.rs
@@ -1,3 +1,4 @@
+use dfdx_macros::CanUpdateWithGradients;
 use crate::gradients::*;
 use crate::prelude::*;
 #[cfg(feature = "nightly")]
@@ -11,16 +12,13 @@ use crate::{Assert, ConstTrue};
 /// let _: Tensor1D<{3 * 5 * 7}> = Flatten2D.forward(Tensor3D::<3, 5, 7>::zeros());
 /// let _: Tensor2D<8, {3 * 5 * 7}> = Flatten2D.forward(Tensor4D::<8, 3, 5, 7>::zeros());
 /// ```
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone, Copy, CanUpdateWithGradients)]
 pub struct Flatten2D;
 
 impl ResetParams for Flatten2D {
     fn reset_params<R: rand::Rng>(&mut self, _: &mut R) {}
 }
 
-impl CanUpdateWithGradients for Flatten2D {
-    fn update<G: GradientProvider>(&mut self, _: &mut G, _: &mut UnusedTensors) {}
-}
 
 #[cfg(feature = "nightly")]
 impl<const M: usize, const N: usize, const O: usize, H: Tape> Module<Tensor3D<M, N, O, H>>

--- a/src/nn/flatten.rs
+++ b/src/nn/flatten.rs
@@ -1,4 +1,4 @@
-use crate::gradients::*;
+use crate::gradients::Tape;
 use crate::prelude::*;
 #[cfg(feature = "nightly")]
 use crate::{Assert, ConstTrue};

--- a/src/nn/flatten.rs
+++ b/src/nn/flatten.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use dfdx_macros::CanUpdateWithGradients;
 #[cfg(feature = "nightly")]
 use {
-    crate::prelude::*,
+    crate::gradients::Tape,
     crate::{Assert, ConstTrue},
 };
 

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -23,7 +23,7 @@ pub struct GeneralizedResidual<F, R> {
 }
 
 impl<F: CanUpdateWithGradients, R: CanUpdateWithGradients> CanUpdateWithGradients
-for GeneralizedResidual<F, R>
+    for GeneralizedResidual<F, R>
 {
     /// Pass through to `F`'s [CanUpdateWithGradients].
     fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -23,7 +23,7 @@ pub struct GeneralizedResidual<F, R> {
 }
 
 impl<F: CanUpdateWithGradients, R: CanUpdateWithGradients> CanUpdateWithGradients
-    for GeneralizedResidual<F, R>
+for GeneralizedResidual<F, R>
 {
     /// Pass through to `F`'s [CanUpdateWithGradients].
     fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -22,10 +22,8 @@ pub struct GeneralizedResidual<F, R> {
     pub r: R,
 }
 
-impl<
-        F: ::dfdx::gradients::CanUpdateWithGradients,
-        R: ::dfdx::gradients::CanUpdateWithGradients,
-    > ::dfdx::gradients::CanUpdateWithGradients for GeneralizedResidual<F, R>
+impl<F: CanUpdateWithGradients, R: CanUpdateWithGradients> CanUpdateWithGradients
+for GeneralizedResidual<F, R>
 {
     /// Pass through to `F`'s [CanUpdateWithGradients].
     fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -1,4 +1,4 @@
-use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
+use crate::gradients::{GradientProvider, UnusedTensors};
 use crate::prelude::*;
 
 /// A residual connection `R` around `F`: `F(x) + R(x)`,
@@ -22,8 +22,10 @@ pub struct GeneralizedResidual<F, R> {
     pub r: R,
 }
 
-impl<F: CanUpdateWithGradients, R: CanUpdateWithGradients> CanUpdateWithGradients
-    for GeneralizedResidual<F, R>
+impl<
+        F: ::dfdx::gradients::CanUpdateWithGradients,
+        R: ::dfdx::gradients::CanUpdateWithGradients,
+    > ::dfdx::gradients::CanUpdateWithGradients for GeneralizedResidual<F, R>
 {
     /// Pass through to `F`'s [CanUpdateWithGradients].
     fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {

--- a/src/nn/impl_module_for_tuples.rs
+++ b/src/nn/impl_module_for_tuples.rs
@@ -1,4 +1,4 @@
-use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
+use crate::gradients::{GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use rand::prelude::Rng;
 

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -1,6 +1,6 @@
 use crate::arrays::Axis;
 use crate::devices::{Cpu, FillElements};
-use crate::gradients::{CanUpdateWithGradients, GradientProvider, Tape, UnusedTensors};
+use crate::gradients::{GradientProvider, Tape, UnusedTensors};
 use crate::prelude::*;
 
 /// Implements layer normalization as described in [Layer Normalization](https://arxiv.org/abs/1607.06450).

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -1,4 +1,4 @@
-use crate::gradients::{CanUpdateWithGradients, GradientProvider, Tape, UnusedTensors};
+use crate::gradients::Tape;
 use crate::prelude::*;
 use dfdx_macros::CanUpdateWithGradients;
 use rand::Rng;

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -31,7 +31,6 @@ pub struct Linear<const I: usize, const O: usize> {
     pub bias: Tensor1D<O>,
 }
 
-
 impl<const I: usize, const O: usize> ResetParams for Linear<I, O> {
     /// Initializes [Self::weight] and [Self::bias] from a [Uniform] distribution
     /// between [-1 / sqrt(I), 1 / sqrt(I)].

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -1,5 +1,6 @@
 use crate::gradients::{CanUpdateWithGradients, GradientProvider, Tape, UnusedTensors};
 use crate::prelude::*;
+use dfdx_macros::CanUpdateWithGradients;
 use rand::Rng;
 use rand_distr::Uniform;
 
@@ -21,7 +22,7 @@ use rand_distr::Uniform;
 /// let y: Tensor1D<2> = model.forward(x);
 /// assert_eq!(y.data(), &[0.0; 2]);
 /// ```
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, CanUpdateWithGradients)]
 pub struct Linear<const I: usize, const O: usize> {
     /// Transposed weight matrix, shape (O, I)
     pub weight: Tensor2D<O, I>,
@@ -30,12 +31,6 @@ pub struct Linear<const I: usize, const O: usize> {
     pub bias: Tensor1D<O>,
 }
 
-impl<const I: usize, const O: usize> CanUpdateWithGradients for Linear<I, O> {
-    fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {
-        self.weight.update(grads, unused);
-        self.bias.update(grads, unused);
-    }
-}
 
 impl<const I: usize, const O: usize> ResetParams for Linear<I, O> {
     /// Initializes [Self::weight] and [Self::bias] from a [Uniform] distribution

--- a/src/nn/pool2d.rs
+++ b/src/nn/pool2d.rs
@@ -36,7 +36,6 @@ pub struct MinPool2D<const KERNEL_SIZE: usize, const STRIDE: usize = 1, const PA
 
 macro_rules! impl_pools {
     ($PoolTy:tt, $Method:ident) => {
-
         #[cfg(feature = "nightly")]
         impl<
                 const K: usize,

--- a/src/nn/pool2d.rs
+++ b/src/nn/pool2d.rs
@@ -3,6 +3,7 @@ use crate::gradients::*;
 #[cfg(feature = "nightly")]
 use crate::tensor::*;
 use rand::Rng;
+use dfdx_macros::CanUpdateWithGradients;
 
 /// Average pool with 2d kernel that operates on images (3d) and batches of images (4d).
 /// Each patch reduces to the average of the values in the patch.
@@ -11,7 +12,7 @@ use rand::Rng;
 /// - `KERNEL_SIZE`: The size of the kernel applied to both width and height of the images.
 /// - `STRIDE`: How far to move the kernel each step. Defaults to `1`
 /// - `PADDING`: How much zero padding to add around the images. Defaults to `0`.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, CanUpdateWithGradients)]
 pub struct AvgPool2D<const KERNEL_SIZE: usize, const STRIDE: usize = 1, const PADDING: usize = 0>;
 
 /// Max pool with 2d kernel that operates on images (3d) and batches of images (4d).
@@ -21,7 +22,7 @@ pub struct AvgPool2D<const KERNEL_SIZE: usize, const STRIDE: usize = 1, const PA
 /// - `KERNEL_SIZE`: The size of the kernel applied to both width and height of the images.
 /// - `STRIDE`: How far to move the kernel each step. Defaults to `1`
 /// - `PADDING`: How much zero padding to add around the images. Defaults to `0`.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, CanUpdateWithGradients)]
 pub struct MaxPool2D<const KERNEL_SIZE: usize, const STRIDE: usize = 1, const PADDING: usize = 0>;
 
 /// Minimum pool with 2d kernel that operates on images (3d) and batches of images (4d).
@@ -31,17 +32,11 @@ pub struct MaxPool2D<const KERNEL_SIZE: usize, const STRIDE: usize = 1, const PA
 /// - `KERNEL_SIZE`: The size of the kernel applied to both width and height of the images.
 /// - `STRIDE`: How far to move the kernel each step. Defaults to `1`
 /// - `PADDING`: How much zero padding to add around the images. Defaults to `0`.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, CanUpdateWithGradients)]
 pub struct MinPool2D<const KERNEL_SIZE: usize, const STRIDE: usize = 1, const PADDING: usize = 0>;
 
 macro_rules! impl_pools {
     ($PoolTy:tt, $Method:ident) => {
-        impl<const K: usize, const S: usize, const P: usize> CanUpdateWithGradients
-            for $PoolTy<K, S, P>
-        {
-            fn update<G: GradientProvider>(&mut self, _: &mut G, _: &mut UnusedTensors) {}
-        }
-
         impl<const K: usize, const S: usize, const P: usize> ResetParams for $PoolTy<K, S, P> {
             fn reset_params<R: Rng>(&mut self, _: &mut R) {}
         }

--- a/src/nn/pool2d.rs
+++ b/src/nn/pool2d.rs
@@ -2,8 +2,8 @@ use super::{Module, ModuleMut, ResetParams};
 use crate::gradients::*;
 #[cfg(feature = "nightly")]
 use crate::tensor::*;
-use rand::Rng;
 use dfdx_macros::CanUpdateWithGradients;
+use rand::Rng;
 
 /// Average pool with 2d kernel that operates on images (3d) and batches of images (4d).
 /// Each patch reduces to the average of the values in the patch.

--- a/src/nn/pool2d.rs
+++ b/src/nn/pool2d.rs
@@ -1,5 +1,5 @@
 use super::{Module, ModuleMut, ResetParams};
-use crate::gradients::*;
+use crate::gradients::Tape;
 #[cfg(feature = "nightly")]
 use crate::tensor::*;
 use dfdx_macros::CanUpdateWithGradients;

--- a/src/nn/pool2d.rs
+++ b/src/nn/pool2d.rs
@@ -1,5 +1,5 @@
-use super::{Module, ModuleMut, ResetParams};
-use dfdx_macros::CanUpdateWithGradients;
+use super::{Module, ModuleMut};
+use dfdx_macros::{CanUpdateWithGradients, ResetParams};
 use rand::Rng;
 #[cfg(feature = "nightly")]
 use {crate::gradients::Tape, crate::tensor::*};
@@ -11,7 +11,7 @@ use {crate::gradients::Tape, crate::tensor::*};
 /// - `KERNEL_SIZE`: The size of the kernel applied to both width and height of the images.
 /// - `STRIDE`: How far to move the kernel each step. Defaults to `1`
 /// - `PADDING`: How much zero padding to add around the images. Defaults to `0`.
-#[derive(Debug, Default, Clone, CanUpdateWithGradients)]
+#[derive(Debug, Default, Clone, CanUpdateWithGradients, ResetParams)]
 pub struct AvgPool2D<const KERNEL_SIZE: usize, const STRIDE: usize = 1, const PADDING: usize = 0>;
 
 /// Max pool with 2d kernel that operates on images (3d) and batches of images (4d).
@@ -21,7 +21,7 @@ pub struct AvgPool2D<const KERNEL_SIZE: usize, const STRIDE: usize = 1, const PA
 /// - `KERNEL_SIZE`: The size of the kernel applied to both width and height of the images.
 /// - `STRIDE`: How far to move the kernel each step. Defaults to `1`
 /// - `PADDING`: How much zero padding to add around the images. Defaults to `0`.
-#[derive(Debug, Default, Clone, CanUpdateWithGradients)]
+#[derive(Debug, Default, Clone, CanUpdateWithGradients, ResetParams)]
 pub struct MaxPool2D<const KERNEL_SIZE: usize, const STRIDE: usize = 1, const PADDING: usize = 0>;
 
 /// Minimum pool with 2d kernel that operates on images (3d) and batches of images (4d).
@@ -31,14 +31,11 @@ pub struct MaxPool2D<const KERNEL_SIZE: usize, const STRIDE: usize = 1, const PA
 /// - `KERNEL_SIZE`: The size of the kernel applied to both width and height of the images.
 /// - `STRIDE`: How far to move the kernel each step. Defaults to `1`
 /// - `PADDING`: How much zero padding to add around the images. Defaults to `0`.
-#[derive(Debug, Default, Clone, CanUpdateWithGradients)]
+#[derive(Debug, Default, Clone, CanUpdateWithGradients, ResetParams)]
 pub struct MinPool2D<const KERNEL_SIZE: usize, const STRIDE: usize = 1, const PADDING: usize = 0>;
 
 macro_rules! impl_pools {
     ($PoolTy:tt, $Method:ident) => {
-        impl<const K: usize, const S: usize, const P: usize> ResetParams for $PoolTy<K, S, P> {
-            fn reset_params<R: Rng>(&mut self, _: &mut R) {}
-        }
 
         #[cfg(feature = "nightly")]
         impl<

--- a/src/nn/pool2d.rs
+++ b/src/nn/pool2d.rs
@@ -1,9 +1,8 @@
 use super::{Module, ModuleMut, ResetParams};
-use crate::gradients::Tape;
-#[cfg(feature = "nightly")]
-use crate::tensor::*;
 use dfdx_macros::CanUpdateWithGradients;
 use rand::Rng;
+#[cfg(feature = "nightly")]
+use {crate::gradients::Tape, crate::tensor::*};
 
 /// Average pool with 2d kernel that operates on images (3d) and batches of images (4d).
 /// Each patch reduces to the average of the values in the patch.

--- a/src/nn/pool_global.rs
+++ b/src/nn/pool_global.rs
@@ -1,5 +1,5 @@
 use super::{Module, ModuleMut, ResetParams};
-use crate::gradients::*;
+use crate::gradients::Tape;
 use crate::tensor::*;
 use dfdx_macros::CanUpdateWithGradients;
 

--- a/src/nn/pool_global.rs
+++ b/src/nn/pool_global.rs
@@ -60,7 +60,6 @@ pub struct MinPoolGlobal;
 
 macro_rules! impl_pools {
     ($PoolTy:ty, $Method:ident) => {
-
         impl<const C: usize, const L: usize, T: Tape> Module<Tensor2D<C, L, T>> for $PoolTy {
             type Output = Tensor1D<C, T>;
             fn forward(&self, input: Tensor2D<C, L, T>) -> Self::Output {

--- a/src/nn/pool_global.rs
+++ b/src/nn/pool_global.rs
@@ -1,3 +1,4 @@
+use dfdx_macros::CanUpdateWithGradients;
 use super::{Module, ModuleMut, ResetParams};
 use crate::gradients::*;
 use crate::tensor::*;
@@ -17,7 +18,7 @@ use crate::tensor::*;
 /// let _: Tensor1D<5> = m.forward(Tensor3D::<5, 16, 8>::zeros());
 /// let _: Tensor2D<10, 5> = m.forward(Tensor4D::<10, 5, 16, 8>::zeros());
 /// ```
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, CanUpdateWithGradients)]
 pub struct AvgPoolGlobal;
 
 /// Applies max pooling over an entire image, fully reducing the height and width
@@ -35,7 +36,7 @@ pub struct AvgPoolGlobal;
 /// let _: Tensor1D<5> = m.forward(Tensor3D::<5, 16, 8>::zeros());
 /// let _: Tensor2D<10, 5> = m.forward(Tensor4D::<10, 5, 16, 8>::zeros());
 /// ```
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, CanUpdateWithGradients)]
 pub struct MaxPoolGlobal;
 
 /// Applies min pooling over an entire image, fully reducing the height and width
@@ -53,16 +54,13 @@ pub struct MaxPoolGlobal;
 /// let _: Tensor1D<5> = m.forward(Tensor3D::<5, 16, 8>::zeros());
 /// let _: Tensor2D<10, 5> = m.forward(Tensor4D::<10, 5, 16, 8>::zeros());
 /// ```
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, CanUpdateWithGradients)]
 pub struct MinPoolGlobal;
 
 macro_rules! impl_pools {
     ($PoolTy:ty, $Method:ident) => {
         impl ResetParams for $PoolTy {
             fn reset_params<R: rand::Rng>(&mut self, _: &mut R) {}
-        }
-        impl CanUpdateWithGradients for $PoolTy {
-            fn update<G: GradientProvider>(&mut self, _: &mut G, _: &mut UnusedTensors) {}
         }
 
         impl<const C: usize, const L: usize, T: Tape> Module<Tensor2D<C, L, T>> for $PoolTy {

--- a/src/nn/pool_global.rs
+++ b/src/nn/pool_global.rs
@@ -1,7 +1,7 @@
-use dfdx_macros::CanUpdateWithGradients;
 use super::{Module, ModuleMut, ResetParams};
 use crate::gradients::*;
 use crate::tensor::*;
+use dfdx_macros::CanUpdateWithGradients;
 
 /// Applies average pooling over an entire image, fully reducing the height and width
 /// dimensions:

--- a/src/nn/pool_global.rs
+++ b/src/nn/pool_global.rs
@@ -1,7 +1,8 @@
-use super::{Module, ModuleMut, ResetParams};
+use super::{Module, ModuleMut};
 use crate::gradients::Tape;
 use crate::tensor::*;
-use dfdx_macros::CanUpdateWithGradients;
+use dfdx_macros::{CanUpdateWithGradients, ResetParams};
+use rand::Rng;
 
 /// Applies average pooling over an entire image, fully reducing the height and width
 /// dimensions:
@@ -18,7 +19,7 @@ use dfdx_macros::CanUpdateWithGradients;
 /// let _: Tensor1D<5> = m.forward(Tensor3D::<5, 16, 8>::zeros());
 /// let _: Tensor2D<10, 5> = m.forward(Tensor4D::<10, 5, 16, 8>::zeros());
 /// ```
-#[derive(Clone, Copy, Default, CanUpdateWithGradients)]
+#[derive(Clone, Copy, Default, CanUpdateWithGradients, ResetParams)]
 pub struct AvgPoolGlobal;
 
 /// Applies max pooling over an entire image, fully reducing the height and width
@@ -36,7 +37,7 @@ pub struct AvgPoolGlobal;
 /// let _: Tensor1D<5> = m.forward(Tensor3D::<5, 16, 8>::zeros());
 /// let _: Tensor2D<10, 5> = m.forward(Tensor4D::<10, 5, 16, 8>::zeros());
 /// ```
-#[derive(Clone, Copy, Default, CanUpdateWithGradients)]
+#[derive(Clone, Copy, Default, CanUpdateWithGradients, ResetParams)]
 pub struct MaxPoolGlobal;
 
 /// Applies min pooling over an entire image, fully reducing the height and width
@@ -54,14 +55,11 @@ pub struct MaxPoolGlobal;
 /// let _: Tensor1D<5> = m.forward(Tensor3D::<5, 16, 8>::zeros());
 /// let _: Tensor2D<10, 5> = m.forward(Tensor4D::<10, 5, 16, 8>::zeros());
 /// ```
-#[derive(Clone, Copy, Default, CanUpdateWithGradients)]
+#[derive(Clone, Copy, Default, CanUpdateWithGradients, ResetParams)]
 pub struct MinPoolGlobal;
 
 macro_rules! impl_pools {
     ($PoolTy:ty, $Method:ident) => {
-        impl ResetParams for $PoolTy {
-            fn reset_params<R: rand::Rng>(&mut self, _: &mut R) {}
-        }
 
         impl<const C: usize, const L: usize, T: Tape> Module<Tensor2D<C, L, T>> for $PoolTy {
             type Output = Tensor1D<C, T>;

--- a/src/nn/repeated.rs
+++ b/src/nn/repeated.rs
@@ -1,4 +1,4 @@
-use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
+use crate::gradients::{GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use std::vec::Vec;
 

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
-use dfdx_macros::CanUpdateWithGradients;
+use dfdx_macros::{CanUpdateWithGradients, ResetParams};
+use rand::Rng;
 
 /// A residual connection around `F`: `F(x) + x`,
 /// as introduced in [Deep Residual Learning for Image Recognition](https://arxiv.org/abs/1512.03385).
@@ -15,15 +16,9 @@ use dfdx_macros::CanUpdateWithGradients;
 /// let y = module.forward(x);
 /// assert_eq!(y.data(), &[-2.0, -1.0, 0.0, 2.0, 4.0]);
 /// ```
-#[derive(Debug, Clone, Default, CanUpdateWithGradients)]
+#[derive(Debug, Clone, Default, CanUpdateWithGradients, ResetParams)]
 pub struct Residual<F>(pub F);
 
-impl<F: ResetParams> ResetParams for Residual<F> {
-    /// Pass through to `F`'s [ResetParams].
-    fn reset_params<R: rand::Rng>(&mut self, rng: &mut R) {
-        self.0.reset_params(rng);
-    }
-}
 
 impl<T: Tensor<Dtype = f32>, F: Module<T, Output = T>> Module<T> for Residual<F> {
     type Output = F::Output;

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -19,7 +19,6 @@ use rand::Rng;
 #[derive(Debug, Clone, Default, CanUpdateWithGradients, ResetParams)]
 pub struct Residual<F>(pub F);
 
-
 impl<T: Tensor<Dtype = f32>, F: Module<T, Output = T>> Module<T> for Residual<F> {
     type Output = F::Output;
     fn forward(&self, x: T) -> Self::Output {

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -1,6 +1,6 @@
-use dfdx_macros::CanUpdateWithGradients;
 use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
+use dfdx_macros::CanUpdateWithGradients;
 
 /// A residual connection around `F`: `F(x) + x`,
 /// as introduced in [Deep Residual Learning for Image Recognition](https://arxiv.org/abs/1512.03385).
@@ -18,7 +18,6 @@ use crate::prelude::*;
 /// ```
 #[derive(Debug, Clone, Default, CanUpdateWithGradients)]
 pub struct Residual<F>(pub F);
-
 
 impl<F: ResetParams> ResetParams for Residual<F> {
     /// Pass through to `F`'s [ResetParams].

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -1,3 +1,4 @@
+use dfdx_macros::CanUpdateWithGradients;
 use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 
@@ -15,15 +16,9 @@ use crate::prelude::*;
 /// let y = module.forward(x);
 /// assert_eq!(y.data(), &[-2.0, -1.0, 0.0, 2.0, 4.0]);
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, CanUpdateWithGradients)]
 pub struct Residual<F>(pub F);
 
-impl<F: CanUpdateWithGradients> CanUpdateWithGradients for Residual<F> {
-    /// Pass through to `F`'s [CanUpdateWithGradients].
-    fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {
-        self.0.update(grads, unused);
-    }
-}
 
 impl<F: ResetParams> ResetParams for Residual<F> {
     /// Pass through to `F`'s [ResetParams].

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -1,4 +1,3 @@
-use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use dfdx_macros::CanUpdateWithGradients;
 

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
-use rand::Rng;
 use dfdx_macros::{CanUpdateWithGradients, ResetParams};
+use rand::Rng;
 
 /// Splits input into multiple heads. `T` should be a tuple,
 /// where every element of the tuple accepts the same input type.
@@ -20,7 +20,6 @@ use dfdx_macros::{CanUpdateWithGradients, ResetParams};
 /// ```
 #[derive(Debug, Default, Clone, CanUpdateWithGradients, ResetParams)]
 pub struct SplitInto<T>(pub T);
-
 
 macro_rules! tuple_impls {
     ([$($heads:ident),+] $tail:ident) => {

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
-use dfdx_macros::CanUpdateWithGradients;
+use rand::Rng;
+use dfdx_macros::{CanUpdateWithGradients, ResetParams};
 
 /// Splits input into multiple heads. `T` should be a tuple,
 /// where every element of the tuple accepts the same input type.
@@ -17,14 +18,9 @@ use dfdx_macros::CanUpdateWithGradients;
 /// let model: Model = Default::default();
 /// let _: (Tensor1D<3>, Tensor1D<7>) = model.forward(Tensor1D::<5>::zeros());
 /// ```
-#[derive(Debug, Default, Clone, CanUpdateWithGradients)]
+#[derive(Debug, Default, Clone, CanUpdateWithGradients, ResetParams)]
 pub struct SplitInto<T>(pub T);
 
-impl<T: ResetParams> ResetParams for SplitInto<T> {
-    fn reset_params<R: rand::Rng>(&mut self, rng: &mut R) {
-        self.0.reset_params(rng);
-    }
-}
 
 macro_rules! tuple_impls {
     ([$($heads:ident),+] $tail:ident) => {

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -1,3 +1,4 @@
+use dfdx_macros::CanUpdateWithGradients;
 use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 
@@ -17,14 +18,9 @@ use crate::prelude::*;
 /// let model: Model = Default::default();
 /// let _: (Tensor1D<3>, Tensor1D<7>) = model.forward(Tensor1D::<5>::zeros());
 /// ```
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, CanUpdateWithGradients)]
 pub struct SplitInto<T>(pub T);
 
-impl<T: CanUpdateWithGradients> CanUpdateWithGradients for SplitInto<T> {
-    fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {
-        self.0.update(grads, unused);
-    }
-}
 
 impl<T: ResetParams> ResetParams for SplitInto<T> {
     fn reset_params<R: rand::Rng>(&mut self, rng: &mut R) {

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -1,6 +1,6 @@
-use dfdx_macros::CanUpdateWithGradients;
 use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
+use dfdx_macros::CanUpdateWithGradients;
 
 /// Splits input into multiple heads. `T` should be a tuple,
 /// where every element of the tuple accepts the same input type.
@@ -20,7 +20,6 @@ use crate::prelude::*;
 /// ```
 #[derive(Debug, Default, Clone, CanUpdateWithGradients)]
 pub struct SplitInto<T>(pub T);
-
 
 impl<T: ResetParams> ResetParams for SplitInto<T> {
     fn reset_params<R: rand::Rng>(&mut self, rng: &mut R) {

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -1,4 +1,3 @@
-use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use dfdx_macros::CanUpdateWithGradients;
 

--- a/src/nn/transformer/decoder.rs
+++ b/src/nn/transformer/decoder.rs
@@ -20,7 +20,6 @@ pub struct TransformerDecoder<
     const NUM_LAYERS: usize,
 >(pub Repeated<TransformerDecoderBlock<MODEL_DIM, NUM_HEADS, FF_DIM>, NUM_LAYERS>);
 
-
 impl<const M: usize, const H: usize, const F: usize, const L: usize, Tgt, Mem> Module<(Tgt, Mem)>
     for TransformerDecoder<M, H, F, L>
 where

--- a/src/nn/transformer/decoder.rs
+++ b/src/nn/transformer/decoder.rs
@@ -1,6 +1,6 @@
 use super::mha::MultiHeadAttention;
 use crate::prelude::*;
-use dfdx_macros::CanUpdateWithGradients;
+use dfdx_macros::{CanUpdateWithGradients, ResetParams};
 use rand::Rng;
 
 /// **Requires Nightly** A transformer decoder.
@@ -12,7 +12,7 @@ use rand::Rng;
 ///   the feedforward network in [TransformerDecoderBlock].
 /// - `NUM_LAYERS`: The number of [TransformerDecoderBlock] to use.
 /// TODO: Doctests
-#[derive(Clone, Debug, Default, CanUpdateWithGradients)]
+#[derive(Clone, Debug, Default, CanUpdateWithGradients, ResetParams)]
 pub struct TransformerDecoder<
     const MODEL_DIM: usize,
     const NUM_HEADS: usize,
@@ -20,13 +20,6 @@ pub struct TransformerDecoder<
     const NUM_LAYERS: usize,
 >(pub Repeated<TransformerDecoderBlock<MODEL_DIM, NUM_HEADS, FF_DIM>, NUM_LAYERS>);
 
-impl<const M: usize, const H: usize, const F: usize, const L: usize> ResetParams
-    for TransformerDecoder<M, H, F, L>
-{
-    fn reset_params<R: Rng>(&mut self, rng: &mut R) {
-        self.0.reset_params(rng);
-    }
-}
 
 impl<const M: usize, const H: usize, const F: usize, const L: usize, Tgt, Mem> Module<(Tgt, Mem)>
     for TransformerDecoder<M, H, F, L>

--- a/src/nn/transformer/decoder.rs
+++ b/src/nn/transformer/decoder.rs
@@ -1,5 +1,4 @@
 use super::mha::MultiHeadAttention;
-use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use dfdx_macros::CanUpdateWithGradients;
 use rand::Rng;

--- a/src/nn/transformer/decoder.rs
+++ b/src/nn/transformer/decoder.rs
@@ -1,8 +1,8 @@
 use super::mha::MultiHeadAttention;
 use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
-use rand::Rng;
 use dfdx_macros::CanUpdateWithGradients;
+use rand::Rng;
 
 /// **Requires Nightly** A transformer decoder.
 ///
@@ -28,7 +28,6 @@ impl<const M: usize, const H: usize, const F: usize, const L: usize> ResetParams
         self.0.reset_params(rng);
     }
 }
-
 
 impl<const M: usize, const H: usize, const F: usize, const L: usize, Tgt, Mem> Module<(Tgt, Mem)>
     for TransformerDecoder<M, H, F, L>
@@ -101,7 +100,6 @@ impl<const MODEL_DIM: usize, const NUM_HEADS: usize, const FF_DIM: usize> ResetP
         self.norm3.reset_params(rng);
     }
 }
-
 
 impl<const M: usize, const H: usize, const F: usize, Tgt, Mem> Module<(Tgt, Mem)>
     for TransformerDecoderBlock<M, H, F>

--- a/src/nn/transformer/decoder.rs
+++ b/src/nn/transformer/decoder.rs
@@ -2,6 +2,7 @@ use super::mha::MultiHeadAttention;
 use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use rand::Rng;
+use dfdx_macros::CanUpdateWithGradients;
 
 /// **Requires Nightly** A transformer decoder.
 ///
@@ -12,7 +13,7 @@ use rand::Rng;
 ///   the feedforward network in [TransformerDecoderBlock].
 /// - `NUM_LAYERS`: The number of [TransformerDecoderBlock] to use.
 /// TODO: Doctests
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, CanUpdateWithGradients)]
 pub struct TransformerDecoder<
     const MODEL_DIM: usize,
     const NUM_HEADS: usize,
@@ -28,13 +29,6 @@ impl<const M: usize, const H: usize, const F: usize, const L: usize> ResetParams
     }
 }
 
-impl<const M: usize, const H: usize, const F: usize, const L: usize> CanUpdateWithGradients
-    for TransformerDecoder<M, H, F, L>
-{
-    fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {
-        self.0.update(grads, unused);
-    }
-}
 
 impl<const M: usize, const H: usize, const F: usize, const L: usize, Tgt, Mem> Module<(Tgt, Mem)>
     for TransformerDecoder<M, H, F, L>
@@ -79,7 +73,7 @@ where
 /// )
 /// ```
 /// TODO: Doctests
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, CanUpdateWithGradients)]
 pub struct TransformerDecoderBlock<
     const MODEL_DIM: usize,
     const NUM_HEADS: usize,
@@ -108,18 +102,6 @@ impl<const MODEL_DIM: usize, const NUM_HEADS: usize, const FF_DIM: usize> ResetP
     }
 }
 
-impl<const MODEL_DIM: usize, const NUM_HEADS: usize, const FF_DIM: usize> CanUpdateWithGradients
-    for TransformerDecoderBlock<MODEL_DIM, NUM_HEADS, FF_DIM>
-{
-    fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {
-        self.self_attn.update(grads, unused);
-        self.norm1.update(grads, unused);
-        self.mh_attn.update(grads, unused);
-        self.norm2.update(grads, unused);
-        self.ff.update(grads, unused);
-        self.norm3.update(grads, unused);
-    }
-}
 
 impl<const M: usize, const H: usize, const F: usize, Tgt, Mem> Module<(Tgt, Mem)>
     for TransformerDecoderBlock<M, H, F>

--- a/src/nn/transformer/encoder.rs
+++ b/src/nn/transformer/encoder.rs
@@ -1,3 +1,4 @@
+use dfdx_macros::CanUpdateWithGradients;
 use super::mha::MultiHeadAttention;
 use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
@@ -32,7 +33,7 @@ pub type TransformerEncoder<
 /// )
 /// ```
 /// TODO: Doctests
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, CanUpdateWithGradients)]
 pub struct TransformerEncoderBlock<
     const MODEL_DIM: usize,
     const NUM_HEADS: usize,
@@ -57,16 +58,6 @@ impl<const M: usize, const H: usize, const F: usize> ResetParams
     }
 }
 
-impl<const M: usize, const H: usize, const F: usize> CanUpdateWithGradients
-    for TransformerEncoderBlock<M, H, F>
-{
-    fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {
-        self.self_attn.update(grads, unused);
-        self.norm1.update(grads, unused);
-        self.ff.update(grads, unused);
-        self.norm2.update(grads, unused);
-    }
-}
 
 impl<const M: usize, const H: usize, const F: usize, Src> Module<Src>
     for TransformerEncoderBlock<M, H, F>

--- a/src/nn/transformer/encoder.rs
+++ b/src/nn/transformer/encoder.rs
@@ -1,7 +1,7 @@
-use dfdx_macros::CanUpdateWithGradients;
 use super::mha::MultiHeadAttention;
 use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
+use dfdx_macros::CanUpdateWithGradients;
 
 /// **Requires Nightly** A transformer encoder.
 ///
@@ -57,7 +57,6 @@ impl<const M: usize, const H: usize, const F: usize> ResetParams
         self.norm2.reset_params(rng);
     }
 }
-
 
 impl<const M: usize, const H: usize, const F: usize, Src> Module<Src>
     for TransformerEncoderBlock<M, H, F>

--- a/src/nn/transformer/encoder.rs
+++ b/src/nn/transformer/encoder.rs
@@ -1,5 +1,4 @@
 use super::mha::MultiHeadAttention;
-use crate::gradients::{CanUpdateWithGradients, GradientProvider, UnusedTensors};
 use crate::prelude::*;
 use dfdx_macros::CanUpdateWithGradients;
 

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -3,6 +3,7 @@ use crate::prelude::*;
 #[cfg(feature = "nightly")]
 use crate::{Assert, ConstTrue};
 use rand::Rng;
+use dfdx_macros::CanUpdateWithGradients;
 
 /// **Requires Nightly** A multi-head attention layer.
 ///
@@ -19,7 +20,7 @@ use rand::Rng;
 /// - `MultiHeadAttention<8, 2, 6, 4>` is an attention layer with the key and value dimension different
 ///   than the embed dimension
 /// TODO: Doctests fail for some reason
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, CanUpdateWithGradients)]
 pub struct MultiHeadAttention<
     const EMBED_DIM: usize,
     const NUM_HEADS: usize,
@@ -43,16 +44,6 @@ impl<const M: usize, const H: usize, const K: usize, const V: usize> ResetParams
     }
 }
 
-impl<const M: usize, const H: usize, const K: usize, const V: usize> CanUpdateWithGradients
-    for MultiHeadAttention<M, H, K, V>
-{
-    fn update<G: GradientProvider>(&mut self, grads: &mut G, unused: &mut UnusedTensors) {
-        self.w_q.update(grads, unused);
-        self.w_k.update(grads, unused);
-        self.w_v.update(grads, unused);
-        self.w_o.update(grads, unused);
-    }
-}
 
 #[cfg(feature = "nightly")]
 impl<

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -2,8 +2,8 @@ use crate::gradients::*;
 use crate::prelude::*;
 #[cfg(feature = "nightly")]
 use crate::{Assert, ConstTrue};
-use rand::Rng;
 use dfdx_macros::CanUpdateWithGradients;
+use rand::Rng;
 
 /// **Requires Nightly** A multi-head attention layer.
 ///
@@ -43,7 +43,6 @@ impl<const M: usize, const H: usize, const K: usize, const V: usize> ResetParams
         self.w_o.reset_params(rng);
     }
 }
-
 
 #[cfg(feature = "nightly")]
 impl<

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -1,4 +1,4 @@
-use crate::gradients::*;
+use crate::gradients::Tape;
 use crate::prelude::*;
 #[cfg(feature = "nightly")]
 use crate::{Assert, ConstTrue};

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -1,9 +1,11 @@
-use crate::gradients::Tape;
 use crate::prelude::*;
-#[cfg(feature = "nightly")]
-use crate::{Assert, ConstTrue};
 use dfdx_macros::CanUpdateWithGradients;
 use rand::Rng;
+#[cfg(feature = "nightly")]
+use {
+    crate::gradients::Tape,
+    crate::{Assert, ConstTrue},
+};
 
 /// **Requires Nightly** A multi-head attention layer.
 ///

--- a/src/optim/adam.rs
+++ b/src/optim/adam.rs
@@ -1,6 +1,6 @@
 use crate::arrays::HasArrayType;
 use crate::devices::ForEachElement;
-use crate::gradients::{CanUpdateWithGradients, GradientProvider, Gradients};
+use crate::gradients::{GradientProvider, Gradients};
 use crate::prelude::*;
 use crate::unique_id::HasUniqueId;
 use std::{boxed::Box, marker::PhantomData};


### PR DESCRIPTION
Followup PR: Must be merged after https://github.com/coreylowman/dfdx/pull/273 
Relevant Issue(s): https://github.com/coreylowman/dfdx/issues/95, https://github.com/coreylowman/dfdx/issues/279 

This PR adds a procedural macro for ResetParams.

Note:

- rand::Rng or rand_distr::StandardNormal must be imported if they are generated by the macro

- I show an example of how procedural macro attributes could work to customize the code-generation. I think this might need a bit more work; and we might want a better `Initializer` trait defined in the main crate?
