### PR TITLE
Tensor5d6d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ libc = { version = "0.2", default-features = false, optional = true }
 default = ["std", "numpy"]
 std = ["no-std-compat/std", "rand/std", "rand_distr/std"]
 nightly = []
+tensor6d = []
 numpy = ["dep:zip", "std"]
 cblas = ["dep:cblas-sys", "dep:libc"]
 intel-mkl = ["cblas"]

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -66,6 +66,7 @@ pub type Axes4<const I: isize, const J: isize, const K: isize, const L: isize> =
 pub type Axes5<const I: isize, const J: isize, const K: isize, const L: isize, const M: isize> =
     (Axis<I>, Axis<J>, Axis<K>, Axis<L>, Axis<M>);
 
+#[cfg(tensor6d)]
 /// Six axes known at compile time.
 pub type Axes6<
     const I: isize,
@@ -112,12 +113,19 @@ impl_has_axis!([[[[[f32; Q]; P]; O]; N]; M], 1, N, {M, N, O, P, Q});
 impl_has_axis!([[[[[f32; Q]; P]; O]; N]; M], 2, O, {M, N, O, P, Q});
 impl_has_axis!([[[[[f32; Q]; P]; O]; N]; M], 3, P, {M, N, O, P, Q});
 impl_has_axis!([[[[[f32; Q]; P]; O]; N]; M], 4, Q, {M, N, O, P, Q});
-impl_has_axis!([[[[[[f32; R]; Q]; P]; O]; N]; M], 0, M, {M, N, O, P, Q, R});
-impl_has_axis!([[[[[[f32; R]; Q]; P]; O]; N]; M], 1, N, {M, N, O, P, Q, R});
-impl_has_axis!([[[[[[f32; R]; Q]; P]; O]; N]; M], 2, O, {M, N, O, P, Q, R});
-impl_has_axis!([[[[[[f32; R]; Q]; P]; O]; N]; M], 3, P, {M, N, O, P, Q, R});
-impl_has_axis!([[[[[[f32; R]; Q]; P]; O]; N]; M], 4, Q, {M, N, O, P, Q, R});
-impl_has_axis!([[[[[[f32; R]; Q]; P]; O]; N]; M], 5, R, {M, N, O, P, Q, R});
+
+#[cfg(tensor6d)]
+pub use tensor6d::*;
+
+#[cfg(tensor6d)]
+mod tensor6d {
+    impl_has_axis!([[[[[[f32; R]; Q]; P]; O]; N]; M], 0, M, {M, N, O, P, Q, R});
+    impl_has_axis!([[[[[[f32; R]; Q]; P]; O]; N]; M], 1, N, {M, N, O, P, Q, R});
+    impl_has_axis!([[[[[[f32; R]; Q]; P]; O]; N]; M], 2, O, {M, N, O, P, Q, R});
+    impl_has_axis!([[[[[[f32; R]; Q]; P]; O]; N]; M], 3, P, {M, N, O, P, Q, R});
+    impl_has_axis!([[[[[[f32; R]; Q]; P]; O]; N]; M], 4, Q, {M, N, O, P, Q, R});
+    impl_has_axis!([[[[[[f32; R]; Q]; P]; O]; N]; M], 5, R, {M, N, O, P, Q, R});
+}
 
 impl<T: CountElements> HasAxes<AllAxes> for T {
     const SIZE: usize = T::NUM_ELEMENTS;
@@ -162,6 +170,7 @@ where
         * <T as HasAxes<Axis<M>>>::SIZE;
 }
 
+#[cfg(tensor6d)]
 impl<
         T,
         const I: isize,
@@ -221,6 +230,7 @@ impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: us
     type LastAxis = Axis<4>;
     const SIZE: usize = Q;
 }
+#[cfg(tensor6d)]
 impl<
         const M: usize,
         const N: usize,

--- a/src/devices/broadcast_reduce/accumulator.rs
+++ b/src/devices/broadcast_reduce/accumulator.rs
@@ -126,3 +126,72 @@ pub(super) fn accum4d<A, L, R, const M: usize, const N: usize, const O: usize, c
         }
     }
 }
+
+#[inline(always)]
+pub(super) fn accum5d<
+    A,
+    L,
+    R,
+    const M: usize,
+    const N: usize,
+    const O: usize,
+    const P: usize,
+    const Q: usize,
+>(
+    l: &mut L,
+    r: &R,
+) where
+    L: IndexMut<Index = [usize; 5]>,
+    R: IndexRef<Index = [usize; 5], Element = L::Element>,
+    A: Accumulator<L::Element>,
+{
+    for m in 0..M {
+        for n in 0..N {
+            for o in 0..O {
+                for p in 0..P {
+                    for q in 0..Q {
+                        A::accum(l.index_mut([m, n, o, p, q]), r.index_ref([m, n, o, p, q]));
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(tensor6d)]
+#[inline(always)]
+pub(super) fn accum6d<
+    A,
+    Lhs,
+    Rhs,
+    const M: usize,
+    const N: usize,
+    const O: usize,
+    const P: usize,
+    const Q: usize,
+    const R: usize,
+>(
+    lhs: &mut Lhs,
+    rhs: &Rhs,
+) where
+    Lhs: IndexMut<Index = [usize; 6]>,
+    Rhs: IndexRef<Index = [usize; 6], Element = Lhs::Element>,
+    A: Accumulator<Lhs::Element>,
+{
+    for m in 0..M {
+        for n in 0..N {
+            for o in 0..O {
+                for p in 0..P {
+                    for q in 0..Q {
+                        for r in 0..R {
+                            A::accum(
+                                lhs.index_mut([m, n, o, p, q, r]),
+                                rhs.index_ref([m, n, o, p, q, r]),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/devices/broadcast_reduce/indexing.rs
+++ b/src/devices/broadcast_reduce/indexing.rs
@@ -1,4 +1,4 @@
-use crate::arrays::{Axes2, Axes3, Axes4, Axis};
+use crate::arrays::*;
 use std::marker::PhantomData;
 
 /// Broadcasts `&'a T` along `Axes` to enable indexing as a higher dimensional array.
@@ -109,6 +109,62 @@ impl<const M: usize, const N: usize, const O: usize, const P: usize> IndexMut
     }
 }
 
+impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize> IndexRef
+    for [[[[[f32; Q]; P]; O]; N]; M]
+{
+    type Index = [usize; 5];
+    type Element = f32;
+    #[inline(always)]
+    fn index_ref(&self, i: Self::Index) -> &Self::Element {
+        &self[i[0]][i[1]][i[2]][i[3]][i[4]]
+    }
+}
+
+impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize> IndexMut
+    for [[[[[f32; Q]; P]; O]; N]; M]
+{
+    type Index = [usize; 5];
+    type Element = f32;
+    #[inline(always)]
+    fn index_mut(&mut self, i: Self::Index) -> &mut Self::Element {
+        &mut self[i[0]][i[1]][i[2]][i[3]][i[4]]
+    }
+}
+
+impl<
+        const M: usize,
+        const N: usize,
+        const O: usize,
+        const P: usize,
+        const Q: usize,
+        const R: usize,
+    > IndexRef for [[[[[[f32; R]; Q]; P]; O]; N]; M]
+{
+    type Index = [usize; 6];
+    type Element = f32;
+    #[inline(always)]
+    fn index_ref(&self, i: Self::Index) -> &Self::Element {
+        &self[i[0]][i[1]][i[2]][i[3]][i[4]][i[5]]
+    }
+}
+
+impl<
+        const M: usize,
+        const N: usize,
+        const O: usize,
+        const P: usize,
+        const Q: usize,
+        const R: usize,
+    > IndexMut for [[[[[[f32; R]; Q]; P]; O]; N]; M]
+{
+    type Index = [usize; 6];
+    type Element = f32;
+    #[inline(always)]
+    fn index_mut(&mut self, i: Self::Index) -> &mut Self::Element {
+        &mut self[i[0]][i[1]][i[2]][i[3]][i[4]][i[5]]
+    }
+}
+
 macro_rules! impl_bcast {
     ($ArrTy:ty, [$($Idx:expr),*], $AxisTy:ty, $IdxTy:ty, {$($CVars:tt),*}) => {
         impl<'a, $(const $CVars: usize, )*> IndexRef for BroadcastRef<'a, $ArrTy, $AxisTy> {
@@ -137,6 +193,7 @@ impl_bcast!(f32, [], Axis<0>, usize, {});
 impl_bcast!(f32, [], Axes2<0, 1>, [usize; 2], {});
 impl_bcast!(f32, [], Axes3<0, 1, 2>, [usize; 3], {});
 impl_bcast!(f32, [], Axes4<0, 1, 2, 3>, [usize; 4], {});
+impl_bcast!(f32, [], Axes5<0, 1, 2, 3, 4>, [usize; 5], {});
 
 // 1d -> 2d
 impl_bcast!([f32; M], [0], Axis<1>, [usize; 2], { M });
@@ -153,6 +210,13 @@ impl_bcast!([f32; M], [2], Axes3<0, 1, 3>, [usize; 4], { M });
 impl_bcast!([f32; M], [1], Axes3<0, 2, 3>, [usize; 4], { M });
 impl_bcast!([f32; M], [0], Axes3<1, 2, 3>, [usize; 4], { M });
 
+// 1d -> 5d
+impl_bcast!([f32; M], [4], Axes4<0, 1, 2, 3>, [usize; 5], { M });
+impl_bcast!([f32; M], [3], Axes4<0, 1, 2, 4>, [usize; 5], { M });
+impl_bcast!([f32; M], [2], Axes4<0, 1, 3, 4>, [usize; 5], { M });
+impl_bcast!([f32; M], [1], Axes4<0, 2, 3, 4>, [usize; 5], { M });
+impl_bcast!([f32; M], [0], Axes4<1, 2, 3, 4>, [usize; 5], { M });
+
 // 2d -> 3d
 impl_bcast!([[f32; N]; M], [0, 1], Axis<2>, [usize; 3], {M, N});
 impl_bcast!([[f32; N]; M], [0, 2], Axis<1>, [usize; 3], {M, N});
@@ -166,8 +230,122 @@ impl_bcast!([[f32; N]; M], [0, 3], Axes2<1, 2>, [usize; 4], {M, N});
 impl_bcast!([[f32; N]; M], [0, 2], Axes2<1, 3>, [usize; 4], {M, N});
 impl_bcast!([[f32; N]; M], [0, 1], Axes2<2, 3>, [usize; 4], {M, N});
 
+// 2d -> 5d
+impl_bcast!([[f32; N]; M], [3, 4], Axes3<0, 1, 2>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [2, 4], Axes3<0, 1, 3>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [1, 4], Axes3<0, 2, 3>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [0, 4], Axes3<1, 2, 3>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [2, 3], Axes3<0, 1, 4>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [1, 3], Axes3<0, 2, 4>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [0, 3], Axes3<1, 2, 4>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [1, 2], Axes3<0, 3, 4>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [0, 2], Axes3<1, 3, 4>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [0, 1], Axes3<2, 3, 4>, [usize; 5], {M, N});
+
 // 3d -> 4d
 impl_bcast!([[[f32; O]; N]; M], [0, 1, 2], Axis<3>, [usize; 4], {M, N, O});
 impl_bcast!([[[f32; O]; N]; M], [0, 1, 3], Axis<2>, [usize; 4], {M, N, O});
 impl_bcast!([[[f32; O]; N]; M], [0, 2, 3], Axis<1>, [usize; 4], {M, N, O});
 impl_bcast!([[[f32; O]; N]; M], [1, 2, 3], Axis<0>, [usize; 4], {M, N, O});
+
+// 3d -> 5d
+impl_bcast!([[[f32; O]; N]; M], [0, 1, 2], Axes2<3, 4>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 1, 3], Axes2<2, 4>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 1, 4], Axes2<2, 3>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 2, 3], Axes2<1, 4>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 2, 4], Axes2<1, 3>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 3, 4], Axes2<1, 2>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [1, 2, 3], Axes2<0, 4>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [1, 2, 4], Axes2<0, 3>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [1, 3, 4], Axes2<0, 2>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [2, 3, 4], Axes2<0, 1>, [usize; 5], {M, N, O});
+
+// 4d -> 5d
+impl_bcast!([[[[f32; P]; O]; N]; M], [0, 1, 2, 3], Axis<4>, [usize; 5], {M, N, O, P});
+impl_bcast!([[[[f32; P]; O]; N]; M], [0, 1, 2, 4], Axis<3>, [usize; 5], {M, N, O, P});
+impl_bcast!([[[[f32; P]; O]; N]; M], [0, 1, 3, 4], Axis<2>, [usize; 5], {M, N, O, P});
+impl_bcast!([[[[f32; P]; O]; N]; M], [0, 2, 3, 4], Axis<1>, [usize; 5], {M, N, O, P});
+impl_bcast!([[[[f32; P]; O]; N]; M], [1, 2, 3, 4], Axis<0>, [usize; 5], {M, N, O, P});
+
+#[cfg(tensor6d)]
+pub use tensor6d::*;
+
+#[cfg(tensor6d)]
+mod tensor6d {
+    use crate::arrays::*;
+
+    // 0d -> 6d
+    impl_bcast!(f32, [], Axes6<0, 1, 2, 3, 4, 5>, [usize; 6], {});
+
+    // 1d -> 6d
+    impl_bcast!([f32; M], [5], Axes5<0, 1, 2, 3, 4>, [usize; 6], { M });
+    impl_bcast!([f32; M], [4], Axes5<0, 1, 2, 3, 5>, [usize; 6], { M });
+    impl_bcast!([f32; M], [3], Axes5<0, 1, 2, 4, 5>, [usize; 6], { M });
+    impl_bcast!([f32; M], [2], Axes5<0, 1, 3, 4, 5>, [usize; 6], { M });
+    impl_bcast!([f32; M], [1], Axes5<0, 2, 3, 4, 5>, [usize; 6], { M });
+    impl_bcast!([f32; M], [0], Axes5<1, 2, 3, 4, 5>, [usize; 6], { M });
+
+    // 2d -> 6d
+    impl_bcast!([[f32; N]; M], [4, 5], Axes4<0, 1, 2, 3>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [3, 5], Axes4<0, 1, 2, 4>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [2, 5], Axes4<0, 1, 3, 4>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [1, 5], Axes4<0, 2, 3, 4>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [0, 5], Axes4<1, 2, 3, 4>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [3, 4], Axes4<0, 1, 2, 5>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [2, 4], Axes4<0, 1, 3, 5>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [1, 4], Axes4<0, 2, 3, 5>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [0, 4], Axes4<1, 2, 3, 5>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [2, 3], Axes4<0, 1, 4, 5>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [1, 3], Axes4<0, 2, 4, 5>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [0, 3], Axes4<1, 2, 4, 5>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [1, 2], Axes4<0, 3, 4, 5>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [0, 2], Axes4<1, 3, 4, 5>, [usize; 6], {M, N});
+    impl_bcast!([[f32; N]; M], [0, 1], Axes4<2, 3, 4, 5>, [usize; 6], {M, N});
+
+    // 3d -> 6d
+    impl_bcast!([[[f32; O]; N]; M], [0, 1, 2], Axes3<3, 4, 5>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [0, 1, 3], Axes3<2, 4, 5>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [0, 1, 4], Axes3<2, 3, 5>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [0, 1, 5], Axes3<2, 3, 4>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [0, 2, 3], Axes3<1, 4, 5>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [0, 2, 4], Axes3<1, 3, 5>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [0, 2, 5], Axes3<1, 3, 4>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [0, 3, 4], Axes3<1, 2, 5>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [0, 3, 5], Axes3<1, 2, 4>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [0, 4, 5], Axes3<1, 2, 3>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [1, 2, 3], Axes3<0, 4, 5>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [1, 2, 4], Axes3<0, 3, 5>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [1, 2, 5], Axes3<0, 3, 4>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [1, 3, 4], Axes3<0, 2, 5>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [1, 3, 5], Axes3<0, 2, 4>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [1, 4, 5], Axes3<0, 2, 3>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [2, 3, 4], Axes3<0, 1, 5>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [2, 3, 5], Axes3<0, 1, 4>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [2, 4, 5], Axes3<0, 1, 3>, [usize; 6], {M, N, O});
+    impl_bcast!([[[f32; O]; N]; M], [3, 4, 5], Axes3<0, 1, 2>, [usize; 6], {M, N, O});
+
+    // 4d -> 6d
+    impl_bcast!([[[[f32; P]; O]; N]; M], [0, 1, 2, 3], Axes2<4, 5>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [0, 1, 2, 4], Axes2<3, 5>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [0, 1, 2, 5], Axes2<3, 4>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [0, 1, 3, 4], Axes2<2, 5>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [0, 1, 3, 5], Axes2<2, 4>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [0, 1, 4, 5], Axes2<2, 3>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [0, 2, 3, 4], Axes2<1, 5>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [0, 2, 3, 5], Axes2<1, 4>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [0, 2, 4, 5], Axes2<1, 3>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [0, 3, 4, 5], Axes2<1, 2>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [1, 2, 3, 4], Axes2<0, 5>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [1, 2, 3, 5], Axes2<0, 4>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [1, 2, 4, 5], Axes2<0, 3>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [1, 3, 4, 5], Axes2<0, 2>, [usize; 6], {M, N, O, P});
+    impl_bcast!([[[[f32; P]; O]; N]; M], [2, 3, 4, 5], Axes2<0, 1>, [usize; 6], {M, N, O, P});
+
+    // 5d -> 6d
+    impl_bcast!([[[[[f32; Q]; P]; O]; N]; M], [0, 1, 2, 3, 4], Axis<5>, [usize; 6], {M, N, O, P, Q});
+    impl_bcast!([[[[[f32; Q]; P]; O]; N]; M], [0, 1, 2, 3, 5], Axis<4>, [usize; 6], {M, N, O, P, Q});
+    impl_bcast!([[[[[f32; Q]; P]; O]; N]; M], [0, 1, 2, 4, 5], Axis<3>, [usize; 6], {M, N, O, P, Q});
+    impl_bcast!([[[[[f32; Q]; P]; O]; N]; M], [0, 1, 3, 4, 5], Axis<2>, [usize; 6], {M, N, O, P, Q});
+    impl_bcast!([[[[[f32; Q]; P]; O]; N]; M], [0, 2, 3, 4, 5], Axis<1>, [usize; 6], {M, N, O, P, Q});
+    impl_bcast!([[[[[f32; Q]; P]; O]; N]; M], [1, 2, 3, 4, 5], Axis<0>, [usize; 6], {M, N, O, P, Q});
+}

--- a/src/devices/broadcast_reduce/mod.rs
+++ b/src/devices/broadcast_reduce/mod.rs
@@ -22,7 +22,7 @@ pub use accumulator::*;
 use super::allocate::AllocateZeros;
 use super::fill::FillElements;
 use super::Cpu;
-use crate::arrays::{AllAxes, Axes2, Axes3, Axes4, Axis, CountElements};
+use crate::arrays::*;
 use indexing::{BroadcastMut, BroadcastRef};
 use std::boxed::Box;
 
@@ -131,6 +131,130 @@ impl_reduce!([[[[f32; P]; O]; N]; M], Axes3<1, 2, 3>, [f32; M], accum4d, {M, N, 
 
 // 4d -> 0d
 impl_reduce!([[[[f32; P]; O]; N]; M], Axes4<0, 1, 2, 3>, f32, accum4d, {M, N, O, P});
+
+// 5d -> 4d
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axis<0>, [[[[f32; Q]; P]; O]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axis<1>, [[[[f32; Q]; P]; O]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axis<2>, [[[[f32; Q]; P]; N]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axis<3>, [[[[f32; Q]; O]; N]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axis<4>, [[[[f32; P]; O]; N]; M], accum5d, {M, N, O, P, Q});
+
+// 5d -> 3d
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<0, 1>, [[[f32; Q]; P]; O], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<0, 2>, [[[f32; Q]; P]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<0, 3>, [[[f32; Q]; O]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<0, 4>, [[[f32; P]; O]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<1, 2>, [[[f32; Q]; P]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<1, 3>, [[[f32; Q]; O]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<1, 4>, [[[f32; P]; O]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<2, 3>, [[[f32; Q]; N]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<2, 4>, [[[f32; P]; N]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<3, 4>, [[[f32; O]; N]; M], accum5d, {M, N, O, P, Q});
+
+// 5d -> 2d
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<0, 1, 2>, [[f32; Q]; P], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<0, 1, 3>, [[f32; Q]; O], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<0, 1, 4>, [[f32; P]; O], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<0, 2, 3>, [[f32; Q]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<0, 2, 4>, [[f32; P]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<0, 3, 4>, [[f32; O]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<1, 2, 3>, [[f32; Q]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<1, 2, 4>, [[f32; P]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<1, 3, 4>, [[f32; O]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<2, 3, 4>, [[f32; N]; M], accum5d, {M, N, O, P, Q});
+
+// 5d -> 1d
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes4<0, 1, 2, 3>, [f32; Q], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes4<0, 1, 2, 4>, [f32; P], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes4<0, 1, 3, 4>, [f32; O], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes4<0, 2, 3, 4>, [f32; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes4<1, 2, 3, 4>, [f32; M], accum5d, {M, N, O, P, Q});
+
+// 5d -> 0d
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes5<0, 1, 2, 3, 4>, f32, accum5d, {M, N, O, P, Q});
+
+#[cfg(tensor6d)]
+pub use impl_tensor6d::*;
+
+#[cfg(tensor6d)]
+mod impl_tensor6d {
+    use crate::arrays::*;
+
+    // 6d -> 5d
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axis<0>, [[[[[f32; R]; Q]; P]; O]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axis<1>, [[[[[f32; R]; Q]; P]; O]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axis<2>, [[[[[f32; R]; Q]; P]; N]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axis<3>, [[[[[f32; R]; Q]; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axis<4>, [[[[[f32; R]; P]; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axis<5>, [[[[[f32; Q]; P]; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+
+    // 6d -> 4d
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<0, 1>, [[[[f32; R]; Q]; P]; O], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<0, 2>, [[[[f32; R]; Q]; P]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<0, 3>, [[[[f32; R]; Q]; O]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<0, 4>, [[[[f32; R]; P]; O]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<0, 5>, [[[[f32; Q]; P]; O]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<1, 2>, [[[[f32; R]; Q]; P]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<1, 3>, [[[[f32; R]; Q]; O]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<1, 4>, [[[[f32; R]; P]; O]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<1, 5>, [[[[f32; Q]; P]; O]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<2, 3>, [[[[f32; R]; Q]; N]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<2, 4>, [[[[f32; R]; P]; N]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<2, 5>, [[[[f32; Q]; P]; N]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<3, 4>, [[[[f32; R]; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<3, 5>, [[[[f32; Q]; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<4, 5>, [[[[f32; P]; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+
+    // 6d -> 3d
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 1, 2>, [[[f32; R]; Q]; P], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 1, 3>, [[[f32; R]; Q]; O], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 1, 4>, [[[f32; R]; P]; O], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 1, 5>, [[[f32; Q]; P]; O], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 2, 3>, [[[f32; R]; Q]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 2, 4>, [[[f32; R]; P]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 2, 5>, [[[f32; Q]; P]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 3, 4>, [[[f32; R]; O]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 3, 5>, [[[f32; Q]; O]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 4, 5>, [[[f32; P]; O]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<1, 2, 3>, [[[f32; R]; Q]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<1, 2, 4>, [[[f32; R]; P]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<1, 2, 5>, [[[f32; Q]; P]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<1, 3, 4>, [[[f32; R]; O]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<1, 3, 5>, [[[f32; Q]; O]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<1, 4, 5>, [[[f32; P]; O]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<2, 3, 4>, [[[f32; R]; N]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<2, 3, 5>, [[[f32; Q]; N]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<2, 4, 5>, [[[f32; P]; N]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<3, 4, 5>, [[[f32; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+
+    // 6d -> 2d
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 1, 2, 3>, [[f32; R]; Q], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 1, 2, 4>, [[f32; R]; P], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 1, 2, 5>, [[f32; Q]; P], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 1, 3, 4>, [[f32; R]; O], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 1, 3, 5>, [[f32; Q]; O], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 1, 4, 5>, [[f32; P]; O], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 2, 3, 4>, [[f32; R]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 2, 3, 5>, [[f32; Q]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 2, 4, 5>, [[f32; P]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 3, 4, 5>, [[f32; O]; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<1, 2, 3, 4>, [[f32; R]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<1, 2, 3, 5>, [[f32; Q]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<1, 2, 4, 5>, [[f32; P]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<1, 3, 4, 5>, [[f32; O]; M], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<2, 3, 4, 5>, [[f32; N]; M], accum6d, {M, N, O, P, Q, R});
+
+    // 6d -> 1d
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes5<0, 1, 2, 3, 4>, [f32; R], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes5<0, 1, 2, 3, 5>, [f32; Q], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes5<0, 1, 2, 4, 5>, [f32; P], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes5<0, 1, 3, 4, 5>, [f32; O], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes5<0, 2, 3, 4, 5>, [f32; N], accum6d, {M, N, O, P, Q, R});
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes5<1, 2, 3, 4, 5>, [f32; M], accum6d, {M, N, O, P, Q, R});
+
+    // 6d -> 0d
+    impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes6<0, 1, 2, 3, 4, 5>, f32, accum6d, {M, N, O, P, Q, R});
+}
 
 impl DeviceReduce<f32, AllAxes> for Cpu {
     type Reduced = f32;

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -80,6 +80,7 @@ impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: us
     Device<[[[[[f32; Q]; P]; O]; N]; M]> for Cpu
 {
 }
+#[cfg(tensor6d)]
 impl<
         const M: usize,
         const N: usize,

--- a/src/devices/permute.rs
+++ b/src/devices/permute.rs
@@ -18,7 +18,7 @@
 //! this looping logic, but only differ in what they do with the indices.
 
 use super::Cpu;
-use crate::arrays::{Axes2, Axes3, Axes4};
+use crate::arrays::*;
 
 /// Permutes axes of `A` resulting in `B`.
 pub trait DevicePermute<A, B, Axes> {
@@ -28,7 +28,7 @@ pub trait DevicePermute<A, B, Axes> {
 
 /// Expands to the const generic for a specific axis. This is purely convention only.
 #[rustfmt::skip]
-macro_rules! axis { (0) => { M }; (1) => { N }; (2) => { O }; (3) => { P }; }
+macro_rules! axis { (0) => { M }; (1) => { N }; (2) => { O }; (3) => { P }; (4) => { Q }; (5) => { R }; }
 
 /// Expands to a array type using the axes passed in.
 /// E.g. `array!(2, 0, 1)` expands to `[[[f32; N]; M]; O]`
@@ -38,6 +38,8 @@ macro_rules! array {
     ($Ax0:tt, $Ax1:tt) => { [[f32; axis!($Ax1)]; axis!($Ax0)] };
     ($Ax0:tt, $Ax1:tt, $Ax2:tt) => { [[[f32; axis!($Ax2)]; axis!($Ax1)]; axis!($Ax0)] };
     ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt) => { [[[[f32; axis!($Ax3)]; axis!($Ax2)]; axis!($Ax1)]; axis!($Ax0)] };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt) => { [[[[[f32; axis!($Ax4)]; axis!($Ax3)]; axis!($Ax2)]; axis!($Ax1)]; axis!($Ax0)] };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt) => { [[[[[[f32; axis!($Ax5)]; axis!($Ax4)]; axis!($Ax3)]; axis!($Ax2)]; axis!($Ax1)]; axis!($Ax0)] };
 }
 
 /// Concrete implementations for the permute and inverse permute functions.
@@ -95,6 +97,46 @@ impl<const M: usize, const N: usize, const O: usize, const P: usize>
     }
 }
     };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt) => {
+impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize>
+    DevicePermute<array!(0,1,2,3,4), array!($Ax0,$Ax1,$Ax2,$Ax3,$Ax4), Axes5<$Ax0,$Ax1,$Ax2,$Ax3,$Ax4>> for Cpu
+{
+    fn permute(a: &array!(0, 1, 2, 3, 4), b: &mut array!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4)) {
+        permuted_loop5::<M, N, O, P, Q, $Ax0, $Ax1, $Ax2, $Ax3, $Ax4, _>(
+            &mut |[m, n, o, p, q], [c, d, e, f, g]| {
+                b[c][d][e][f][g] = a[m][n][o][p][q];
+            },
+        );
+    }
+    fn inverse_permute(a: &mut array!(0, 1, 2, 3, 4), b: &array!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4)) {
+        permuted_loop5::<M, N, O, P, Q, $Ax0, $Ax1, $Ax2, $Ax3, $Ax4, _>(
+            &mut |[m, n, o, p, q], [c, d, e, f, g]| {
+                a[m][n][o][p][q] = b[c][d][e][f][g];
+            },
+        );
+    }
+}
+    };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt) => {
+impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize, const R: usize>
+    DevicePermute<array!(0,1,2,3,4,5), array!($Ax0,$Ax1,$Ax2,$Ax3,$Ax4,$Ax5), Axes6<$Ax0,$Ax1,$Ax2,$Ax3,$Ax4,$Ax5>> for Cpu
+{
+    fn permute(a: &array!(0, 1, 2, 3, 4, 5), b: &mut array!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5)) {
+        permuted_loop6::<M, N, O, P, Q, R, $Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5, _>(
+            &mut |[m, n, o, p, q, r], [c, d, e, f, g, h]| {
+                b[c][d][e][f][g][h] = a[m][n][o][p][q][r];
+            },
+        );
+    }
+    fn inverse_permute(a: &mut array!(0, 1, 2, 3, 4, 5), b: &array!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5)) {
+        permuted_loop6::<M, N, O, P, Q, R, $Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5, _>(
+            &mut |[m, n, o, p, q, r], [c, d, e, f, g, h]| {
+                a[m][n][o][p][q][r] = b[c][d][e][f][g][h];
+            },
+        );
+    }
+}
+    };
 }
 
 /// Index into `indices` using the const `I`. If `I` < 0 then use `N - I`.
@@ -121,7 +163,7 @@ where
     }
 }
 
-/// Apply a function `f` to two sets of 2d indices.
+/// Apply a function `f` to two sets of 3d indices.
 fn permuted_loop3<
     const M: usize,
     const N: usize,
@@ -146,7 +188,7 @@ fn permuted_loop3<
     }
 }
 
-/// Apply a function `f` to two sets of 2d indices.
+/// Apply a function `f` to two sets of 4d indices.
 fn permuted_loop4<
     const M: usize,
     const N: usize,
@@ -176,7 +218,83 @@ fn permuted_loop4<
     }
 }
 
-/// Expand out all the possible permutations for 2-4d
+/// Apply a function `f` to two sets of 5d indices.
+fn permuted_loop5<
+    const M: usize,
+    const N: usize,
+    const O: usize,
+    const P: usize,
+    const Q: usize,
+    const A: isize,
+    const B: isize,
+    const C: isize,
+    const D: isize,
+    const E: isize,
+    F: FnMut([usize; 5], [usize; 5]),
+>(
+    f: &mut F,
+) {
+    for m in 0..M {
+        for n in 0..N {
+            for o in 0..O {
+                for p in 0..P {
+                    for q in 0..Q {
+                        let indices = [m, n, o, p, q];
+                        let a = const_idx::<A, 5>(&indices);
+                        let b = const_idx::<B, 5>(&indices);
+                        let c = const_idx::<C, 5>(&indices);
+                        let d = const_idx::<D, 5>(&indices);
+                        let e = const_idx::<E, 5>(&indices);
+                        f(indices, [a, b, c, d, e]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(tensor6d)]
+/// Apply a function `f` to two sets of 6d indices.
+fn permuted_loop6<
+    const M: usize,
+    const N: usize,
+    const O: usize,
+    const P: usize,
+    const Q: usize,
+    const R: usize,
+    const A: isize,
+    const B: isize,
+    const C: isize,
+    const D: isize,
+    const E: isize,
+    const F: isize,
+    Fn: FnMut([usize; 6], [usize; 6]),
+>(
+    func: &mut Fn,
+) {
+    for m in 0..M {
+        for n in 0..N {
+            for o in 0..O {
+                for p in 0..P {
+                    for q in 0..Q {
+                        for r in 0..R {
+                            let indices = [m, n, o, p, q, r];
+                            let a = const_idx::<A, 6>(&indices);
+                            let b = const_idx::<B, 6>(&indices);
+                            let c = const_idx::<C, 6>(&indices);
+                            let d = const_idx::<D, 6>(&indices);
+                            let e = const_idx::<E, 6>(&indices);
+                            let f = const_idx::<F, 6>(&indices);
+                            func(indices, [a, b, c, d, e, f]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Expand out all the possible permutations for 2-6d
 macro_rules! permutations {
     ([$Ax0:tt, $Ax1:tt]) => {
         impl_permute!($Ax0, $Ax1);
@@ -208,11 +326,68 @@ macro_rules! permutations {
         impl_permute!($Ax0, $Ax1, $Ax2, $Ax3);
         impl_permute!($Ax0, $Ax1, $Ax3, $Ax2);
     };
+
+    ([$Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt]) => {
+        permutations!($Ax0, [$Ax1, $Ax2, $Ax3, $Ax4]);
+        permutations!($Ax1, [$Ax0, $Ax2, $Ax3, $Ax4]);
+        permutations!($Ax2, [$Ax0, $Ax1, $Ax3, $Ax4]);
+        permutations!($Ax3, [$Ax0, $Ax1, $Ax2, $Ax4]);
+        permutations!($Ax4, [$Ax0, $Ax1, $Ax2, $Ax3]);
+    };
+    ($Ax0:tt, [$Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt]) => {
+        permutations!($Ax0, $Ax1, [$Ax2, $Ax3, $Ax4]);
+        permutations!($Ax0, $Ax2, [$Ax1, $Ax3, $Ax4]);
+        permutations!($Ax0, $Ax3, [$Ax1, $Ax2, $Ax4]);
+        permutations!($Ax0, $Ax4, [$Ax1, $Ax2, $Ax3]);
+    };
+    ($Ax0:tt, $Ax1:tt, [$Ax2:tt, $Ax3:tt, $Ax4:tt]) => {
+        permutations!($Ax0, $Ax1, $Ax2, [$Ax3, $Ax4]);
+        permutations!($Ax0, $Ax1, $Ax3, [$Ax2, $Ax4]);
+        permutations!($Ax0, $Ax1, $Ax4, [$Ax2, $Ax3]);
+    };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, [$Ax3:tt, $Ax4:tt]) => {
+        impl_permute!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4);
+        impl_permute!($Ax0, $Ax1, $Ax2, $Ax4, $Ax3);
+    };
+
+    ([$Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt]) => {
+        permutations!($Ax0, [$Ax1, $Ax2, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax1, [$Ax0, $Ax2, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax2, [$Ax0, $Ax1, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax3, [$Ax0, $Ax1, $Ax2, $Ax4, $Ax5]);
+        permutations!($Ax4, [$Ax0, $Ax1, $Ax2, $Ax3, $Ax5]);
+        permutations!($Ax5, [$Ax0, $Ax1, $Ax2, $Ax3, $Ax4]);
+    };
+    ($Ax0:tt, [$Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt]) => {
+        permutations!($Ax0, $Ax1, [$Ax2, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax2, [$Ax1, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax3, [$Ax1, $Ax2, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax4, [$Ax1, $Ax2, $Ax3, $Ax5]);
+        permutations!($Ax0, $Ax5, [$Ax1, $Ax2, $Ax3, $Ax4]);
+    };
+    ($Ax0:tt, $Ax1:tt, [$Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt]) => {
+        permutations!($Ax0, $Ax1, $Ax2, [$Ax3, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax3, [$Ax2, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax4, [$Ax2, $Ax3, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax5, [$Ax2, $Ax3, $Ax4]);
+    };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, [$Ax3:tt, $Ax4:tt, $Ax5:tt]) => {
+        permutations!($Ax0, $Ax1, $Ax2, $Ax3, [$Ax4, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax2, $Ax4, [$Ax3, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax2, $Ax5, [$Ax3, $Ax4]);
+    };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, [$Ax4:tt, $Ax5:tt]) => {
+        impl_permute!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5);
+        impl_permute!($Ax0, $Ax1, $Ax2, $Ax3, $Ax5, $Ax4);
+    };
 }
 
 permutations!([0, 1]);
 permutations!([0, 1, 2]);
 permutations!([0, 1, 2, 3]);
+permutations!([0, 1, 2, 3, 4]);
+#[cfg(tensor6d)]
+permutations!([0, 1, 2, 3, 4, 5]);
 
 #[cfg(test)]
 mod tests {
@@ -256,6 +431,39 @@ mod tests {
 
         let mut c = [[[[0.0; 9]; 7]; 5]; 3];
         <Cpu as DevicePermute<_, _, Axes4<2, 3, 1, 0>>>::inverse_permute(&mut c, &b);
+
+        assert_eq!(a, c);
+    }
+
+    #[test]
+    fn test_5d_permute() {
+        let mut rng = thread_rng();
+        let mut a = [[[[[0.0; 11]; 9]; 7]; 5]; 3];
+        Cpu::fill(&mut a, &mut |v| *v = rng.gen());
+
+        let mut b = [[[[[0.0; 3]; 5]; 7]; 9]; 11];
+        <Cpu as DevicePermute<_, _, Axes5<4, 3, 2, 1, 0>>>::permute(&a, &mut b);
+        assert_ne!(b, [[[[[0.0; 3]; 5]; 7]; 9]; 11]);
+
+        let mut c = [[[[[0.0; 11]; 9]; 7]; 5]; 3];
+        <Cpu as DevicePermute<_, _, Axes5<4, 3, 2, 1, 0>>>::inverse_permute(&mut c, &b);
+
+        assert_eq!(a, c);
+    }
+
+    #[cfg(tensor6d)]
+    #[test]
+    fn test_6d_permute() {
+        let mut rng = thread_rng();
+        let mut a = [[[[[[0.0; 2]; 11]; 9]; 7]; 5]; 3];
+        Cpu::fill(&mut a, &mut |v| *v = rng.gen());
+
+        let mut b = [[[[[[0.0; 3]; 5]; 7]; 9]; 11]; 2];
+        <Cpu as DevicePermute<_, _, Axes6<5, 4, 3, 2, 1, 0>>>::permute(&a, &mut b);
+        assert_ne!(b, [[[[[[0.0; 3]; 5]; 7]; 9]; 11]; 2]);
+
+        let mut c = [[[[[[0.0; 2]; 11]; 9]; 7]; 5]; 3];
+        <Cpu as DevicePermute<_, _, Axes6<5, 4, 3, 2, 1, 0>>>::inverse_permute(&mut c, &b);
 
         assert_eq!(a, c);
     }

--- a/src/devices/select.rs
+++ b/src/devices/select.rs
@@ -45,6 +45,9 @@ pub(crate) type SelectAx0 = select_modes::Index;
 pub(crate) type SelectAx1 = select_modes::Recurse<SelectAx0>;
 pub(crate) type SelectAx2 = select_modes::Recurse<SelectAx1>;
 pub(crate) type SelectAx3 = select_modes::Recurse<SelectAx2>;
+pub(crate) type SelectAx4 = select_modes::Recurse<SelectAx3>;
+#[cfg(tensor6d)]
+pub(crate) type SelectAx5 = select_modes::Recurse<SelectAx4>;
 pub(crate) type BSelectAx1 = select_modes::Broadcast<SelectAx0>;
 
 /// Select values from `T` using indices `I`. `Mode` is used to disambiguate the impl.

--- a/src/tensor/impl_default.rs
+++ b/src/tensor/impl_default.rs
@@ -18,4 +18,5 @@ tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
 tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
 tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);

--- a/src/tensor/impl_has_array.rs
+++ b/src/tensor/impl_has_array.rs
@@ -24,6 +24,7 @@ tensor_impl!(Tensor2D, [M, N], [[f32; N]; M]);
 tensor_impl!(Tensor3D, [M, N, O], [[[f32; O]; N]; M]);
 tensor_impl!(Tensor4D, [M, N, O, P], [[[[f32; P]; O]; N]; M]);
 tensor_impl!(Tensor5D, [M, N, O, P, Q], [[[[[f32; Q]; P]; O]; N]; M]);
+#[cfg(tensor6d)]
 tensor_impl!(
     Tensor6D,
     [M, N, O, P, Q, R],

--- a/src/tensor/impl_has_device.rs
+++ b/src/tensor/impl_has_device.rs
@@ -15,4 +15,5 @@ tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
 tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
 tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);

--- a/src/tensor/impl_has_unique_id.rs
+++ b/src/tensor/impl_has_unique_id.rs
@@ -17,4 +17,5 @@ tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
 tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
 tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);

--- a/src/tensor/impl_put_tape.rs
+++ b/src/tensor/impl_put_tape.rs
@@ -34,4 +34,5 @@ tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
 tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
 tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);

--- a/src/tensor/impl_randomize.rs
+++ b/src/tensor/impl_randomize.rs
@@ -24,6 +24,7 @@ tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
 tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
 tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]

--- a/src/tensor/impl_tensor.rs
+++ b/src/tensor/impl_tensor.rs
@@ -68,6 +68,7 @@ tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
 tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
 tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]

--- a/src/tensor/impl_tensor_creator.rs
+++ b/src/tensor/impl_tensor_creator.rs
@@ -70,6 +70,7 @@ tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
 tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
 tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]

--- a/src/tensor/impl_trace.rs
+++ b/src/tensor/impl_trace.rs
@@ -41,6 +41,7 @@ tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
 tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
 tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]

--- a/src/tensor/into_tensor.rs
+++ b/src/tensor/into_tensor.rs
@@ -1,4 +1,4 @@
-use super::{Tensor0D, Tensor1D, Tensor2D, Tensor3D, Tensor4D, Tensor5D, Tensor6D, TensorCreator};
+use super::*;
 use std::boxed::Box;
 
 /// Creates a tensor using the data based in. The return type is based
@@ -47,6 +47,7 @@ impl_into_tensor!([[f32; N]; M], Tensor2D<M, N>, {M, N});
 impl_into_tensor!([[[f32; O]; N]; M], Tensor3D<M, N, O>, {M, N, O});
 impl_into_tensor!([[[[f32; P]; O]; N]; M], Tensor4D<M, N, O, P>, {M, N, O, P});
 impl_into_tensor!([[[[[f32; Q]; P]; O]; N]; M], Tensor5D<M, N, O, P, Q>, {M, N, O, P, Q});
+#[cfg(tensor6d)]
 impl_into_tensor!([[[[[[f32; R]; Q]; P]; O]; N]; M], Tensor6D<M, N, O, P, Q, R>, {M, N, O, P, Q, R});
 
 #[cfg(test)]

--- a/src/tensor/structs.rs
+++ b/src/tensor/structs.rs
@@ -65,6 +65,7 @@ pub struct Tensor5D<
     pub(crate) tape: Tape,
 }
 
+#[cfg(tensor6d)]
 /// A 6d [super::Tensor] with shape (M, N, O, P, Q, R). Backed by data `[[[[[[f32; R]; Q]; P]; O]; N]; M]`.
 #[derive(Debug)]
 #[allow(clippy::type_complexity)]

--- a/src/tensor_ops/arith_scalar.rs
+++ b/src/tensor_ops/arith_scalar.rs
@@ -147,6 +147,9 @@ scalar_ops_impl!(Tensor1D, [N]);
 scalar_ops_impl!(Tensor2D, [M, N]);
 scalar_ops_impl!(Tensor3D, [M, N, O]);
 scalar_ops_impl!(Tensor4D, [M, N, O, P]);
+scalar_ops_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+scalar_ops_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_add.rs
+++ b/src/tensor_ops/impl_add.rs
@@ -41,6 +41,9 @@ binary_ops_impl!(Tensor1D, [N]);
 binary_ops_impl!(Tensor2D, [M, N]);
 binary_ops_impl!(Tensor3D, [M, N, O]);
 binary_ops_impl!(Tensor4D, [M, N, O, P]);
+binary_ops_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+binary_ops_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_broadcast_reduce.rs
+++ b/src/tensor_ops/impl_broadcast_reduce.rs
@@ -1,5 +1,5 @@
 use super::utils::move_tape_and_add_backward_op;
-use crate::arrays::{AllAxes, Axes2, Axes3, Axis, HasArrayType};
+use crate::arrays::*;
 use crate::devices::{AddAccum, CopyAccum, Cpu, DeviceReduce};
 use crate::gradients::Tape;
 use crate::prelude::*;
@@ -78,6 +78,7 @@ impl_broadcast_reduce!(Tensor0D<H>, AllAxes, Tensor1D<M, H>, {M});
 impl_broadcast_reduce!(Tensor0D<H>, AllAxes, Tensor2D<M, N, H>, {M, N});
 impl_broadcast_reduce!(Tensor0D<H>, AllAxes, Tensor3D<M, N, O, H>, {M, N, O});
 impl_broadcast_reduce!(Tensor0D<H>, AllAxes, Tensor4D<M, N, O, P, H>, {M, N, O, P});
+impl_broadcast_reduce!(Tensor0D<H>, AllAxes, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
 
 // 1d -> Nd
 impl_broadcast_reduce!(Tensor1D<M, H>, Axis<1>, Tensor2D<M, N, H>, {M, N});
@@ -89,6 +90,11 @@ impl_broadcast_reduce!(Tensor1D<M, H>, Axes3<1, 2, 3>, Tensor4D<M, N, O, P, H>, 
 impl_broadcast_reduce!(Tensor1D<N, H>, Axes3<0, 2, 3>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor1D<O, H>, Axes3<0, 1, 3>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor1D<P, H>, Axes3<0, 1, 2>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
+impl_broadcast_reduce!(Tensor1D<M, H>, Axes4<1, 2, 3, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor1D<N, H>, Axes4<0, 2, 3, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor1D<O, H>, Axes4<0, 1, 3, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor1D<P, H>, Axes4<0, 1, 2, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor1D<Q, H>, Axes4<0, 1, 2, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
 
 // 2d -> Nd
 impl_broadcast_reduce!(Tensor2D<M, N, H>, Axis<2>, Tensor3D<M, N, O, H>, {M, N, O});
@@ -100,12 +106,122 @@ impl_broadcast_reduce!(Tensor2D<M, P, H>, Axes2<1, 2>, Tensor4D<M, N, O, P, H>, 
 impl_broadcast_reduce!(Tensor2D<N, O, H>, Axes2<0, 3>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor2D<N, P, H>, Axes2<0, 2>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor2D<O, P, H>, Axes2<0, 1>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
+impl_broadcast_reduce!(Tensor2D<M, N, H>, Axes3<2, 3, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<M, O, H>, Axes3<1, 3, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<M, P, H>, Axes3<1, 2, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<M, Q, H>, Axes3<1, 2, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<N, P, H>, Axes3<0, 2, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<N, Q, H>, Axes3<0, 2, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<O, P, H>, Axes3<0, 1, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<O, Q, H>, Axes3<0, 1, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<P, Q, H>, Axes3<0, 1, 2>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
 
-// 3d -> 4d
+// 3d -> Nd
 impl_broadcast_reduce!(Tensor3D<M, N, O, H>, Axis<3>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor3D<M, N, P, H>, Axis<2>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor3D<M, O, P, H>, Axis<1>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor3D<N, O, P, H>, Axis<0>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
+impl_broadcast_reduce!(Tensor3D<M, N, O, H>, Axes2<3, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<M, N, P, H>, Axes2<2, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<M, N, Q, H>, Axes2<2, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<M, O, P, H>, Axes2<1, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<M, O, Q, H>, Axes2<1, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<M, P, Q, H>, Axes2<1, 2>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<N, O, P, H>, Axes2<0, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<N, O, Q, H>, Axes2<0, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<N, P, Q, H>, Axes2<0, 2>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<O, P, Q, H>, Axes2<0, 1>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+
+// 4d -> 5d
+impl_broadcast_reduce!(Tensor4D<M, N, O, P, H>, Axis<4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor4D<M, N, O, Q, H>, Axis<3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor4D<M, N, P, Q, H>, Axis<2>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor4D<M, O, P, Q, H>, Axis<1>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor4D<N, O, P, Q, H>, Axis<0>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+
+
+#[cfg(tensor6d)]
+pub use tensor6d::*;
+
+#[cfg(tensor6d)]
+mod tensor6d {
+    use crate::prelude::*;
+
+    // 0d -> 6d
+    impl_broadcast_reduce!(Tensor0D<H>, AllAxes, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+
+    // 1d -> 6d
+    impl_broadcast_reduce!(Tensor1D<M, H>, Axes5<1, 2, 3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor1D<N, H>, Axes5<0, 2, 3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor1D<O, H>, Axes5<0, 1, 3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor1D<P, H>, Axes5<0, 1, 2, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor1D<Q, H>, Axes5<0, 1, 2, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor1D<R, H>, Axes5<0, 1, 2, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+
+    // 2d -> 6d
+    impl_broadcast_reduce!(Tensor2D<M, N, H>, Axes4<2, 3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<M, O, H>, Axes4<1, 3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<M, P, H>, Axes4<1, 2, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<M, Q, H>, Axes4<1, 2, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<M, R, H>, Axes4<1, 2, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<N, O, H>, Axes4<0, 3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<N, P, H>, Axes4<0, 2, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<N, Q, H>, Axes4<0, 2, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<N, R, H>, Axes4<0, 2, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<O, P, H>, Axes4<0, 1, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<O, Q, H>, Axes4<0, 1, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<O, R, H>, Axes4<0, 1, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<P, Q, H>, Axes4<0, 1, 2, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<P, R, H>, Axes4<0, 1, 2, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor2D<Q, R, H>, Axes4<0, 1, 2, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+
+    // 3d -> 6d
+    impl_broadcast_reduce!(Tensor3D<M, N, O, H>, Axes3<3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<M, N, P, H>, Axes3<2, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<M, N, Q, H>, Axes3<2, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<M, N, R, H>, Axes3<2, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<M, O, P, H>, Axes3<1, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<M, O, Q, H>, Axes3<1, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<M, O, R, H>, Axes3<1, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<M, P, Q, H>, Axes3<1, 2, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<M, P, R, H>, Axes3<1, 2, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<M, Q, R, H>, Axes3<1, 2, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<N, O, P, H>, Axes3<0, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<N, O, Q, H>, Axes3<0, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<N, O, R, H>, Axes3<0, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<N, P, Q, H>, Axes3<0, 2, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<N, P, R, H>, Axes3<0, 2, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<N, Q, R, H>, Axes3<0, 2, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<O, P, Q, H>, Axes3<0, 1, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<O, P, R, H>, Axes3<0, 1, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<O, Q, R, H>, Axes3<0, 1, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor3D<P, Q, R, H>, Axes3<0, 1, 2>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+
+    // 4d -> 6d
+    impl_broadcast_reduce!(Tensor4D<M, N, O, P, H>, Axes2<4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<M, N, O, Q, H>, Axes2<3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<M, N, O, R, H>, Axes2<3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<M, N, P, Q, H>, Axes2<2, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<M, N, P, R, H>, Axes2<2, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<M, N, Q, R, H>, Axes2<2, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<M, O, P, Q, H>, Axes2<1, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<M, O, P, R, H>, Axes2<1, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<M, O, Q, R, H>, Axes2<1, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<M, P, Q, R, H>, Axes2<1, 2>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<N, O, P, Q, H>, Axes2<0, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<N, O, P, R, H>, Axes2<0, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<N, O, Q, R, H>, Axes2<0, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<N, P, Q, R, H>, Axes2<0, 2>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor4D<O, P, Q, R, H>, Axes2<0, 1>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+
+    // 5d -> 6d
+    impl_broadcast_reduce!(Tensor5D<M, N, O, P, Q, H>, Axis<5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor5D<M, N, O, P, R, H>, Axis<4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor5D<M, N, O, Q, R, H>, Axis<3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor5D<M, N, P, Q, R, H>, Axis<2>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor5D<M, O, P, Q, R, H>, Axis<1>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_broadcast_reduce!(Tensor5D<N, O, P, Q, R, H>, Axis<0>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_broadcast_reduce.rs
+++ b/src/tensor_ops/impl_broadcast_reduce.rs
@@ -139,7 +139,6 @@ impl_broadcast_reduce!(Tensor4D<M, N, P, Q, H>, Axis<2>, Tensor5D<M, N, O, P, Q,
 impl_broadcast_reduce!(Tensor4D<M, O, P, Q, H>, Axis<1>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
 impl_broadcast_reduce!(Tensor4D<N, O, P, Q, H>, Axis<0>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
 
-
 #[cfg(tensor6d)]
 pub use tensor6d::*;
 

--- a/src/tensor_ops/impl_clamp.rs
+++ b/src/tensor_ops/impl_clamp.rs
@@ -34,6 +34,9 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_div.rs
+++ b/src/tensor_ops/impl_div.rs
@@ -45,6 +45,9 @@ binary_ops_impl!(Tensor1D, [N]);
 binary_ops_impl!(Tensor2D, [M, N]);
 binary_ops_impl!(Tensor3D, [M, N, O]);
 binary_ops_impl!(Tensor4D, [M, N, O, P]);
+binary_ops_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+binary_ops_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_dropout.rs
+++ b/src/tensor_ops/impl_dropout.rs
@@ -77,6 +77,9 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_mask.rs
+++ b/src/tensor_ops/impl_mask.rs
@@ -48,6 +48,9 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_max.rs
+++ b/src/tensor_ops/impl_max.rs
@@ -55,6 +55,9 @@ max_axis_impl!(Tensor1D, [M]);
 max_axis_impl!(Tensor2D, [M, N]);
 max_axis_impl!(Tensor3D, [M, N, O]);
 max_axis_impl!(Tensor4D, [M, N, O, P]);
+max_axis_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+max_axis_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_maximum.rs
+++ b/src/tensor_ops/impl_maximum.rs
@@ -63,6 +63,9 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_mean.rs
+++ b/src/tensor_ops/impl_mean.rs
@@ -48,6 +48,9 @@ mean_axis_impl!(Tensor1D, [M]);
 mean_axis_impl!(Tensor2D, [M, N]);
 mean_axis_impl!(Tensor3D, [M, N, O]);
 mean_axis_impl!(Tensor4D, [M, N, O, P]);
+mean_axis_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+mean_axis_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_min.rs
+++ b/src/tensor_ops/impl_min.rs
@@ -55,6 +55,9 @@ min_axis_impl!(Tensor1D, [M]);
 min_axis_impl!(Tensor2D, [M, N]);
 min_axis_impl!(Tensor3D, [M, N, O]);
 min_axis_impl!(Tensor4D, [M, N, O, P]);
+min_axis_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+min_axis_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_minimum.rs
+++ b/src/tensor_ops/impl_minimum.rs
@@ -63,6 +63,9 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_mul.rs
+++ b/src/tensor_ops/impl_mul.rs
@@ -41,6 +41,9 @@ binary_ops_impl!(Tensor1D, [N]);
 binary_ops_impl!(Tensor2D, [M, N]);
 binary_ops_impl!(Tensor3D, [M, N, O]);
 binary_ops_impl!(Tensor4D, [M, N, O, P]);
+binary_ops_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+binary_ops_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_nans.rs
+++ b/src/tensor_ops/impl_nans.rs
@@ -36,6 +36,9 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_normalize.rs
+++ b/src/tensor_ops/impl_normalize.rs
@@ -45,6 +45,9 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_pow.rs
+++ b/src/tensor_ops/impl_pow.rs
@@ -55,6 +55,9 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_reshape.rs
+++ b/src/tensor_ops/impl_reshape.rs
@@ -31,6 +31,9 @@ macro_rules! impl_all_reshapes {
         tensor_impl!($src_ty, [$($SrcVs),*], Tensor2D, [M, N], $assert_lhs, (M * N));
         tensor_impl!($src_ty, [$($SrcVs),*], Tensor3D, [M, N, O], $assert_lhs, (M * N * O));
         tensor_impl!($src_ty, [$($SrcVs),*], Tensor4D, [M, N, O, P], $assert_lhs, (M * N * O * P));
+        tensor_impl!($src_ty, [$($SrcVs),*], Tensor5D, [M, N, O, P, Q], $assert_lhs, (M * N * O * P * Q));
+        #[cfg(tensor6d)]
+        tensor_impl!($src_ty, [$($SrcVs),*], Tensor6D, [M, N, O, P, Q, R], $assert_lhs, (M * N * O * P * Q * R));
     };
 }
 
@@ -39,6 +42,9 @@ impl_all_reshapes!(Tensor1D, [A], (A));
 impl_all_reshapes!(Tensor2D, [A, B], (A * B));
 impl_all_reshapes!(Tensor3D, [A, B, C], (A * B * C));
 impl_all_reshapes!(Tensor4D, [A, B, C, D], (A * B * C * D));
+impl_all_reshapes!(Tensor5D, [A, B, C, D, E], (A * B * C * D * E));
+#[cfg(tensor6d)]
+impl_all_reshapes!(Tensor6D, [A, B, C, D, E, F], (A * B * C * D * E * F));
 
 /// Reshapes `T` into `R`'s shape. This is unsafe because there are no compile
 /// time guaruntees that `T` and `R` have the same number of elements.
@@ -77,24 +83,56 @@ mod tests {
         let _: Tensor1D<16> = Tensor2D::<2, 8>::zeros().reshape();
         let _: Tensor1D<16> = Tensor3D::<2, 2, 4>::zeros().reshape();
         let _: Tensor1D<16> = Tensor4D::<2, 2, 2, 2>::zeros().reshape();
+        let _: Tensor1D<16> = Tensor5D::<2, 2, 2, 2, 1>::zeros().reshape();
+        #[cfg(tensor6d)]
+        let _: Tensor1D<16> = Tensor6D::<2, 2, 2, 2, 1, 1>::zeros().reshape();
 
         let _: Tensor2D<1, 1> = Tensor0D::zeros().reshape();
         let _: Tensor2D<2, 8> = Tensor1D::<16>::zeros().reshape();
         let _: Tensor2D<2, 8> = Tensor2D::<8, 2>::zeros().reshape();
         let _: Tensor2D<2, 8> = Tensor3D::<2, 2, 4>::zeros().reshape();
         let _: Tensor2D<2, 8> = Tensor4D::<2, 2, 2, 2>::zeros().reshape();
+        let _: Tensor2D<2, 8> = Tensor5D::<2, 2, 2, 2, 1>::zeros().reshape();
+        #[cfg(tensor6d)]
+        let _: Tensor2D<2, 8> = Tensor6D::<2, 2, 2, 2, 1, 1>::zeros().reshape();
 
         let _: Tensor3D<1, 1, 1> = Tensor0D::zeros().reshape();
         let _: Tensor3D<2, 2, 4> = Tensor1D::<16>::zeros().reshape();
         let _: Tensor3D<2, 2, 4> = Tensor2D::<2, 8>::zeros().reshape();
         let _: Tensor3D<2, 2, 4> = Tensor3D::<4, 2, 2>::zeros().reshape();
         let _: Tensor3D<2, 2, 4> = Tensor4D::<2, 2, 2, 2>::zeros().reshape();
+        let _: Tensor3D<2, 2, 4> = Tensor5D::<2, 2, 2, 2, 1>::zeros().reshape();
+        #[cfg(tensor6d)]
+        let _: Tensor3D<2, 2, 4> = Tensor6D::<2, 2, 2, 2, 1, 1>::zeros().reshape();
 
         let _: Tensor4D<1, 1, 1, 1> = Tensor0D::zeros().reshape();
         let _: Tensor4D<2, 2, 2, 2> = Tensor1D::<16>::zeros().reshape();
         let _: Tensor4D<2, 2, 2, 2> = Tensor2D::<2, 8>::zeros().reshape();
         let _: Tensor4D<2, 2, 2, 2> = Tensor3D::<4, 2, 2>::zeros().reshape();
         let _: Tensor4D<2, 2, 2, 2> = Tensor4D::<4, 1, 2, 2>::zeros().reshape();
+        let _: Tensor4D<2, 2, 2, 2> = Tensor5D::<4, 1, 2, 2, 1>::zeros().reshape();
+        #[cfg(tensor6d)]
+        let _: Tensor4D<2, 2, 2, 2> = Tensor6D::<4, 1, 2, 2, 1, 1>::zeros().reshape();
+
+        let _: Tensor5D<1, 1, 1, 1, 1> = Tensor0D::zeros().reshape();
+        let _: Tensor5D<2, 2, 2, 2, 2> = Tensor1D::<32>::zeros().reshape();
+        let _: Tensor5D<2, 2, 2, 2, 2> = Tensor2D::<2, 16>::zeros().reshape();
+        let _: Tensor5D<2, 2, 2, 2, 2> = Tensor3D::<4, 2, 4>::zeros().reshape();
+        let _: Tensor5D<2, 2, 2, 2, 2> = Tensor4D::<4, 1, 2, 4>::zeros().reshape();
+        let _: Tensor5D<2, 2, 2, 2, 2> = Tensor5D::<4, 1, 2, 2, 2>::zeros().reshape();
+        #[cfg(tensor6d)]
+        let _: Tensor5D<2, 2, 2, 2, 2> = Tensor6D::<4, 1, 2, 2, 2, 1>::zeros().reshape();
+
+        #[cfg(tensor6d)]
+        {
+            let _: Tensor6D<1, 1, 1, 1, 1, 1> = Tensor0D::zeros().reshape();
+            let _: Tensor6D<2, 2, 2, 2, 2, 2> = Tensor1D::<64>::zeros().reshape();
+            let _: Tensor6D<2, 2, 2, 2, 2, 2> = Tensor2D::<4, 16>::zeros().reshape();
+            let _: Tensor6D<2, 2, 2, 2, 2, 2> = Tensor3D::<8, 2, 4>::zeros().reshape();
+            let _: Tensor6D<2, 2, 2, 2, 2, 2> = Tensor4D::<8, 1, 2, 4>::zeros().reshape();
+            let _: Tensor6D<2, 2, 2, 2, 2, 2> = Tensor5D::<8, 1, 2, 2, 2>::zeros().reshape();
+            let _: Tensor6D<2, 2, 2, 2, 2, 2> = Tensor6D::<2, 4, 1, 2, 2, 2>::zeros().reshape();
+        }
     }
 
     #[test]

--- a/src/tensor_ops/impl_softmax.rs
+++ b/src/tensor_ops/impl_softmax.rs
@@ -106,6 +106,9 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_stddev.rs
+++ b/src/tensor_ops/impl_stddev.rs
@@ -73,6 +73,9 @@ impl_std_and_var!(Tensor1D, [M]);
 impl_std_and_var!(Tensor2D, [M, N]);
 impl_std_and_var!(Tensor3D, [M, N, O]);
 impl_std_and_var!(Tensor4D, [M, N, O, P]);
+impl_std_and_var!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+impl_std_and_var!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_sub.rs
+++ b/src/tensor_ops/impl_sub.rs
@@ -41,6 +41,9 @@ binary_ops_impl!(Tensor1D, [N]);
 binary_ops_impl!(Tensor2D, [M, N]);
 binary_ops_impl!(Tensor3D, [M, N, O]);
 binary_ops_impl!(Tensor4D, [M, N, O, P]);
+binary_ops_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+binary_ops_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_sum.rs
+++ b/src/tensor_ops/impl_sum.rs
@@ -52,6 +52,9 @@ sum_axis_impl!(Tensor1D, [M]);
 sum_axis_impl!(Tensor2D, [M, N]);
 sum_axis_impl!(Tensor3D, [M, N, O]);
 sum_axis_impl!(Tensor4D, [M, N, O, P]);
+sum_axis_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+sum_axis_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/map.rs
+++ b/src/tensor_ops/map.rs
@@ -253,6 +253,9 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+#[cfg(tensor6d)]
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/matmul.rs
+++ b/src/tensor_ops/matmul.rs
@@ -84,10 +84,16 @@ matmul_typing!(nt Tensor2D<M, K, L>, Tensor2D<K, N, R>, Tensor2D<M, N, L>, {M, K
 matmul_typing!(nt Tensor3D<B, M, K, L>, Tensor3D<B, K, N, R>, Tensor3D<B, M, N, L>, {B, M, K, N});
 matmul_typing!(nt Tensor3D<B, M, K, L>, Tensor2D<K, N, R>, Tensor3D<B, M, N, L>, {B, M, K, N});
 matmul_typing!(nt Tensor4D<B1, B2, M, K, L>, Tensor4D<B1, B2, K, N, R>, Tensor4D<B1, B2, M, N, L>, {B1, B2, M, K, N});
+matmul_typing!(nt Tensor5D<B1, B2, B3, M, K, L>, Tensor5D<B1, B2, B3, K, N, R>, Tensor5D<B1, B2, B3, M, N, L>, {B1, B2, B3, M, K, N});
+#[cfg(tensor6d)]
+matmul_typing!(nt Tensor6D<B1, B2, B3, B4, M, K, L>, Tensor6D<B1, B2, B3, B4, K, N, R>, Tensor6D<B1, B2, B3, B4, M, N, L>, {B1, B2, B3, B4, M, K, N});
 matmul_typing!(tr Tensor2D<M, K, L>, Tensor2D<N, K, R>, Tensor2D<M, N, L>, {M, K, N});
 matmul_typing!(tr Tensor3D<B, M, K, L>, Tensor3D<B, N, K, R>, Tensor3D<B, M, N, L>, {B, M, K, N});
 matmul_typing!(tr Tensor3D<B, M, K, L>, Tensor2D<N, K, R>, Tensor3D<B, M, N, L>, {B, M, K, N});
 matmul_typing!(tr Tensor4D<B1, B2, M, K, L>, Tensor4D<B1, B2, N, K, R>, Tensor4D<B1, B2, M, N, L>, {B1, B2, M, K, N});
+matmul_typing!(tr Tensor5D<B1, B2, B3, M, K, L>, Tensor5D<B1, B2, B3, N, K, R>, Tensor5D<B1, B2, B3, M, N, L>, {B1, B2, B3, M, K, N});
+#[cfg(tensor6d)]
+matmul_typing!(tr Tensor6D<B1, B2, B3, B4, M, K, L>, Tensor6D<B1, B2, B3, B4, N, K, R>, Tensor6D<B1, B2, B3, B4, M, N, L>, {B1, B2, B3, B4, M, K, N});
 
 /// Matrix multiplication with the transpose of `rhs`. Equivalent to `matmul(lhs, transpose(rhs))`.
 /// This supports the same variants as [matmul] (broadcasted, batched, etc).
@@ -239,6 +245,17 @@ mod tests {
         let _: Tensor4D<20, 10, 5, 2> = matmul(
             Tensor4D::<20, 10, 5, 3>::zeros(),
             Tensor4D::<20, 10, 3, 2>::zeros(),
+        );
+
+        let _: Tensor5D<20, 10, 5, 2, 2> = matmul(
+            Tensor5D::<20, 10, 5, 2, 3>::zeros(),
+            Tensor5D::<20, 10, 5, 3, 2>::zeros(),
+        );
+
+        #[cfg(tensor6d)]
+        let _: Tensor6D<20, 10, 5, 2, 2, 2> = matmul(
+            Tensor6D::<20, 10, 5, 2, 3, 2>::zeros(),
+            Tensor6D::<20, 10, 5, 3, 2, 3>::zeros(),
         );
     }
 

--- a/src/tensor_ops/select.rs
+++ b/src/tensor_ops/select.rs
@@ -150,7 +150,6 @@ impl_select!(Axis<0>, BSelectAx1, Tensor4D<M, N, O, P, H>, [[usize; Z]; B], Tens
 #[cfg(tensor6d)]
 impl_select!(Axis<0>, BSelectAx1, Tensor5D<M, N, O, P, Q, H>, [[usize; Z]; B], Tensor6D<B, Z, N, O, P, Q, H>, {M, N, O, P, Q, B, Z});
 
-
 pub(crate) fn select<T, I, R, Mode>(t: T, indices: &I) -> R
 where
     T: Tensor<Dtype = f32>,

--- a/src/tensor_ops/select.rs
+++ b/src/tensor_ops/select.rs
@@ -109,10 +109,47 @@ impl_select!(Axis<2>, SelectAx2, Tensor4D<M, N, O, P, H>, [[[usize; Z]; N]; M], 
 impl_select!(Axis<3>, SelectAx3, Tensor4D<M, N, O, P, H>, [[[usize; O]; N]; M], Tensor3D<M, N, O, H>, {M, N, O, P});
 impl_select!(Axis<3>, SelectAx3, Tensor4D<M, N, O, P, H>, [[[[usize; Z]; O]; N]; M], Tensor4D<M, N, O, Z, H>, {M, N, O, P, Z});
 
+// 5d
+impl_select!(Axis<0>, SelectAx0, Tensor5D<M, N, O, P, Q, H>, usize, Tensor4D<N, O, P, Q, H>, {M, N, O, P, Q});
+impl_select!(Axis<0>, SelectAx0, Tensor5D<M, N, O, P, Q, H>, [usize; Z], Tensor5D<Z, N, O, P, Q, H>, {M, N, O, P, Z, Q});
+impl_select!(Axis<1>, SelectAx1, Tensor5D<M, N, O, P, Q, H>, [usize; M], Tensor4D<M, O, P, Q, H>, {M, N, O, P, Q});
+impl_select!(Axis<1>, SelectAx1, Tensor5D<M, N, O, P, Q, H>, [[usize; Z]; M], Tensor5D<M, Z, O, P, Q, H>, {M, N, O, P, Z, Q});
+impl_select!(Axis<2>, SelectAx2, Tensor5D<M, N, O, P, Q, H>, [[usize; N]; M], Tensor4D<M, N, P, Q, H>, {M, N, O, P, Q});
+impl_select!(Axis<2>, SelectAx2, Tensor5D<M, N, O, P, Q, H>, [[[usize; Z]; N]; M], Tensor5D<M, N, Z, P, Q, H>, {M, N, O, P, Z, Q});
+impl_select!(Axis<3>, SelectAx3, Tensor5D<M, N, O, P, Q, H>, [[[usize; O]; N]; M], Tensor4D<M, N, O, Q, H>, {M, N, O, P, Q});
+impl_select!(Axis<3>, SelectAx3, Tensor5D<M, N, O, P, Q, H>, [[[[usize; Z]; O]; N]; M], Tensor5D<M, N, O, Z, Q, H>, {M, N, O, P, Z, Q});
+impl_select!(Axis<4>, SelectAx4, Tensor5D<M, N, O, P, Q, H>, [[[[usize; P]; O]; N]; M], Tensor4D<M, N, O, P, H>, {M, N, O, P, Q});
+impl_select!(Axis<4>, SelectAx4, Tensor5D<M, N, O, P, Q, H>, [[[[[usize; Z]; P]; O]; N]; M], Tensor5D<M, N, O, P, Z, H>, {M, N, O, P, Z, Q});
+
+#[cfg(tensor6d)]
+pub use tensor6d::*;
+
+#[cfg(tensor6d)]
+mod tensor6d {
+    use crate::prelude::*;
+
+    impl_select!(Axis<0>, SelectAx0, Tensor6D<M, N, O, P, Q, R, H>, usize, Tensor5D<N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_select!(Axis<0>, SelectAx0, Tensor6D<M, N, O, P, Q, R, H>, [usize; Z], Tensor6D<Z, N, O, P, R, Q, H>, {M, N, O, P, Z, Q, R});
+    impl_select!(Axis<1>, SelectAx1, Tensor6D<M, N, O, P, Q, R, H>, [usize; M], Tensor5D<M, O, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_select!(Axis<1>, SelectAx1, Tensor6D<M, N, O, P, Q, R, H>, [[usize; Z]; M], Tensor6D<M, Z, O, P, Q, R, H>, {M, N, O, P, Z, Q, R});
+    impl_select!(Axis<2>, SelectAx2, Tensor6D<M, N, O, P, Q, R, H>, [[usize; N]; M], Tensor5D<M, N, P, Q, R, H>, {M, N, O, P, Q, R});
+    impl_select!(Axis<2>, SelectAx2, Tensor6D<M, N, O, P, Q, R, H>, [[[usize; Z]; N]; M], Tensor6D<M, N, Z, P, Q, R, H>, {M, N, O, P, Z, Q, R});
+    impl_select!(Axis<3>, SelectAx3, Tensor6D<M, N, O, P, Q, R, H>, [[[usize; O]; N]; M], Tensor5D<M, N, O, Q, R, H>, {M, N, O, P, Q, R});
+    impl_select!(Axis<3>, SelectAx3, Tensor6D<M, N, O, P, Q, R, H>, [[[[usize; Z]; O]; N]; M], Tensor6D<M, N, O, Z, Q, R, H>, {M, N, O, P, Z, Q, R});
+    impl_select!(Axis<4>, SelectAx4, Tensor6D<M, N, O, P, Q, R, H>, [[[[usize; P]; O]; N]; M], Tensor5D<M, N, O, P, R, H>, {M, N, O, P, Q, R});
+    impl_select!(Axis<4>, SelectAx4, Tensor6D<M, N, O, P, Q, R, H>, [[[[[usize; Z]; P]; O]; N]; M], Tensor6D<M, N, O, P, Z, R, H>, {M, N, O, P, Z, Q, R});
+    impl_select!(Axis<5>, SelectAx5, Tensor6D<M, N, O, P, Q, R, H>, [[[[[usize; Q]; P]; O]; N]; M], Tensor5D<M, N, O, P, R, H>, {M, N, O, P, Q, R});
+    impl_select!(Axis<5>, SelectAx5, Tensor6D<M, N, O, P, Q, R, H>, [[[[[[usize; Z]; Q]; P]; O]; N]; M], Tensor6D<M, N, O, P, Z, R, H>, {M, N, O, P, Z, Q, R});
+}
+
 // batched select
 impl_select!(Axis<0>, BSelectAx1, Tensor1D<M, H>, [[usize; Z]; B], Tensor2D<B, Z, H>, {M, B, Z});
 impl_select!(Axis<0>, BSelectAx1, Tensor2D<M, N, H>, [[usize; Z]; B], Tensor3D<B, Z, N, H>, {M, N, B, Z});
 impl_select!(Axis<0>, BSelectAx1, Tensor3D<M, N, O, H>, [[usize; Z]; B], Tensor4D<B, Z, N, O, H>, {M, N, O, B, Z});
+impl_select!(Axis<0>, BSelectAx1, Tensor4D<M, N, O, P, H>, [[usize; Z]; B], Tensor5D<B, Z, N, O, P, H>, {M, N, O, P, B, Z});
+#[cfg(tensor6d)]
+impl_select!(Axis<0>, BSelectAx1, Tensor5D<M, N, O, P, Q, H>, [[usize; Z]; B], Tensor6D<B, Z, N, O, P, Q, H>, {M, N, O, P, Q, B, Z});
+
 
 pub(crate) fn select<T, I, R, Mode>(t: T, indices: &I) -> R
 where


### PR DESCRIPTION
Impl's should be already impl'ed, just added (PAINFULLY ARGHHHH) all the broadcast/reduce impls. Added `tensor6d`-feature since this adds about 80% compilation time (18s -> 33s) due to all the permutation macro expansion (6! = 720 functions?).