### PR TITLE
Tensor 5d 6d ops

### DIFF
--- a/src/devices/broadcast_reduce/accumulator.rs
+++ b/src/devices/broadcast_reduce/accumulator.rs
@@ -126,3 +126,49 @@ pub(super) fn accum4d<A, L, R, const M: usize, const N: usize, const O: usize, c
         }
     }
 }
+
+#[inline(always)]
+pub(super) fn accum5d<A, L, R, const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize>(
+    l: &mut L,
+    r: &R,
+) where
+    L: IndexMut<Index = [usize; 5]>,
+    R: IndexRef<Index = [usize; 5], Element = L::Element>,
+    A: Accumulator<L::Element>,
+{
+    for m in 0..M {
+        for n in 0..N {
+            for o in 0..O {
+                for p in 0..P {
+                    for q in 0..Q {
+                        A::accum(l.index_mut([m, n, o, p, q]), r.index_ref([m, n, o, p, q]));
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[inline(always)]
+pub(super) fn accum6d<A, L, R, const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize, const K: usize>(
+    l: &mut L,
+    r: &R,
+) where
+    L: IndexMut<Index = [usize; 6]>,
+    R: IndexRef<Index = [usize; 6], Element = L::Element>,
+    A: Accumulator<L::Element>,
+{
+    for m in 0..M {
+        for n in 0..N {
+            for o in 0..O {
+                for p in 0..P {
+                    for q in 0..Q {
+                        for k in 0..K {
+                            A::accum(l.index_mut([m, n, o, p, q, k]), r.index_ref([m, n, o, p, q, k]));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/devices/broadcast_reduce/indexing.rs
+++ b/src/devices/broadcast_reduce/indexing.rs
@@ -1,4 +1,4 @@
-use crate::arrays::{Axes2, Axes3, Axes4, Axis};
+use crate::arrays::{Axes2, Axes3, Axes4, Axes5, Axes6, Axis};
 use std::marker::PhantomData;
 
 /// Broadcasts `&'a T` along `Axes` to enable indexing as a higher dimensional array.
@@ -109,6 +109,50 @@ impl<const M: usize, const N: usize, const O: usize, const P: usize> IndexMut
     }
 }
 
+impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize> IndexRef
+for [[[[[f32; Q]; P]; O]; N]; M]
+{
+    type Index = [usize; 5];
+    type Element = f32;
+    #[inline(always)]
+    fn index_ref(&self, i: Self::Index) -> &Self::Element {
+        &self[i[0]][i[1]][i[2]][i[3]][i[4]]
+    }
+}
+
+impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize> IndexMut
+for [[[[[f32; Q]; P]; O]; N]; M]
+{
+    type Index = [usize; 5];
+    type Element = f32;
+    #[inline(always)]
+    fn index_mut(&mut self, i: Self::Index) -> &mut Self::Element {
+        &mut self[i[0]][i[1]][i[2]][i[3]][i[4]]
+    }
+}
+
+impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize, const R: usize> IndexRef
+for [[[[[[f32; R]; Q]; P]; O]; N]; M]
+{
+    type Index = [usize; 6];
+    type Element = f32;
+    #[inline(always)]
+    fn index_ref(&self, i: Self::Index) -> &Self::Element {
+        &self[i[0]][i[1]][i[2]][i[3]][i[4]][i[5]]
+    }
+}
+
+impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize, const R: usize> IndexMut
+for [[[[[[f32; R]; Q]; P]; O]; N]; M]
+{
+    type Index = [usize; 6];
+    type Element = f32;
+    #[inline(always)]
+    fn index_mut(&mut self, i: Self::Index) -> &mut Self::Element {
+        &mut self[i[0]][i[1]][i[2]][i[3]][i[4]][i[5]]
+    }
+}
+
 macro_rules! impl_bcast {
     ($ArrTy:ty, [$($Idx:expr),*], $AxisTy:ty, $IdxTy:ty, {$($CVars:tt),*}) => {
         impl<'a, $(const $CVars: usize, )*> IndexRef for BroadcastRef<'a, $ArrTy, $AxisTy> {
@@ -137,6 +181,8 @@ impl_bcast!(f32, [], Axis<0>, usize, {});
 impl_bcast!(f32, [], Axes2<0, 1>, [usize; 2], {});
 impl_bcast!(f32, [], Axes3<0, 1, 2>, [usize; 3], {});
 impl_bcast!(f32, [], Axes4<0, 1, 2, 3>, [usize; 4], {});
+impl_bcast!(f32, [], Axes5<0, 1, 2, 3, 4>, [usize; 5], {});
+impl_bcast!(f32, [], Axes6<0, 1, 2, 3, 4, 5>, [usize; 6], {});
 
 // 1d -> 2d
 impl_bcast!([f32; M], [0], Axis<1>, [usize; 2], { M });
@@ -153,6 +199,21 @@ impl_bcast!([f32; M], [2], Axes3<0, 1, 3>, [usize; 4], { M });
 impl_bcast!([f32; M], [1], Axes3<0, 2, 3>, [usize; 4], { M });
 impl_bcast!([f32; M], [0], Axes3<1, 2, 3>, [usize; 4], { M });
 
+// 1d -> 5d
+impl_bcast!([f32; M], [4], Axes4<0, 1, 2, 3>, [usize; 5], { M });
+impl_bcast!([f32; M], [3], Axes4<0, 1, 2, 4>, [usize; 5], { M });
+impl_bcast!([f32; M], [2], Axes4<0, 1, 3, 4>, [usize; 5], { M });
+impl_bcast!([f32; M], [1], Axes4<0, 2, 3, 4>, [usize; 5], { M });
+impl_bcast!([f32; M], [0], Axes4<1, 2, 3, 4>, [usize; 5], { M });
+
+// 1d -> 6d
+impl_bcast!([f32; M], [5], Axes5<0, 1, 2, 3, 4>, [usize; 6], { M });
+impl_bcast!([f32; M], [4], Axes5<0, 1, 2, 3, 5>, [usize; 6], { M });
+impl_bcast!([f32; M], [3], Axes5<0, 1, 2, 4, 5>, [usize; 6], { M });
+impl_bcast!([f32; M], [2], Axes5<0, 1, 3, 4, 5>, [usize; 6], { M });
+impl_bcast!([f32; M], [1], Axes5<0, 2, 3, 4, 5>, [usize; 6], { M });
+impl_bcast!([f32; M], [0], Axes5<1, 2, 3, 4, 5>, [usize; 6], { M });
+
 // 2d -> 3d
 impl_bcast!([[f32; N]; M], [0, 1], Axis<2>, [usize; 3], {M, N});
 impl_bcast!([[f32; N]; M], [0, 2], Axis<1>, [usize; 3], {M, N});
@@ -166,8 +227,103 @@ impl_bcast!([[f32; N]; M], [0, 3], Axes2<1, 2>, [usize; 4], {M, N});
 impl_bcast!([[f32; N]; M], [0, 2], Axes2<1, 3>, [usize; 4], {M, N});
 impl_bcast!([[f32; N]; M], [0, 1], Axes2<2, 3>, [usize; 4], {M, N});
 
+// 2d -> 5d
+impl_bcast!([[f32; N]; M], [3, 4], Axes3<0, 1, 2>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [2, 4], Axes3<0, 1, 3>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [2, 3], Axes3<0, 1, 4>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [1, 4], Axes3<0, 2, 3>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [1, 3], Axes3<0, 2, 4>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [1, 2], Axes3<0, 3, 4>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [0, 4], Axes3<1, 2, 3>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [0, 3], Axes3<1, 2, 4>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [0, 2], Axes3<1, 3, 4>, [usize; 5], {M, N});
+impl_bcast!([[f32; N]; M], [0, 1], Axes3<2, 3, 4>, [usize; 5], {M, N});
+
+// 2d -> 6d
+impl_bcast!([[f32; N]; M], [4, 5], Axes4<0, 1, 2, 3>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [3, 5], Axes4<0, 1, 2, 4>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [3, 4], Axes4<0, 1, 2, 5>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [2, 5], Axes4<0, 1, 3, 4>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [2, 4], Axes4<0, 1, 3, 5>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [2, 3], Axes4<0, 1, 4, 5>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [1, 5], Axes4<0, 2, 3, 4>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [1, 4], Axes4<0, 2, 3, 5>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [1, 3], Axes4<0, 2, 4, 5>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [1, 2], Axes4<0, 3, 4, 5>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [0, 5], Axes4<1, 2, 3, 4>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [0, 4], Axes4<1, 2, 3, 5>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [0, 3], Axes4<1, 2, 4, 5>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [0, 2], Axes4<1, 3, 4, 5>, [usize; 6], {M, N});
+impl_bcast!([[f32; N]; M], [0, 1], Axes4<2, 3, 4, 5>, [usize; 6], {M, N});
+
 // 3d -> 4d
 impl_bcast!([[[f32; O]; N]; M], [0, 1, 2], Axis<3>, [usize; 4], {M, N, O});
 impl_bcast!([[[f32; O]; N]; M], [0, 1, 3], Axis<2>, [usize; 4], {M, N, O});
 impl_bcast!([[[f32; O]; N]; M], [0, 2, 3], Axis<1>, [usize; 4], {M, N, O});
 impl_bcast!([[[f32; O]; N]; M], [1, 2, 3], Axis<0>, [usize; 4], {M, N, O});
+
+// 3d -> 5d
+impl_bcast!([[[f32; O]; N]; M], [0, 1, 2], Axes2<3, 4>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 1, 3], Axes2<2, 4>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 1, 4], Axes2<2, 3>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 2, 3], Axes2<1, 4>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 2, 4], Axes2<1, 3>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 3, 4], Axes2<1, 2>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [1, 2, 3], Axes2<0, 4>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [1, 2, 4], Axes2<0, 3>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [1, 3, 4], Axes2<0, 2>, [usize; 5], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [2, 3, 4], Axes2<0, 1>, [usize; 5], {M, N, O});
+
+// 3d -> 6d
+impl_bcast!([[[f32; O]; N]; M], [0, 1, 2], Axes3<3, 4, 5>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 1, 3], Axes3<2, 4, 5>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 1, 4], Axes3<2, 3, 5>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 1, 5], Axes3<2, 3, 4>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 2, 3], Axes3<1, 4, 5>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 2, 4], Axes3<1, 3, 5>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 2, 5], Axes3<1, 3, 4>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 3, 4], Axes3<1, 2, 5>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 3, 5], Axes3<1, 2, 4>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [0, 4, 5], Axes3<1, 2, 3>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [1, 2, 3], Axes3<0, 4, 5>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [1, 2, 4], Axes3<0, 3, 5>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [1, 2, 5], Axes3<0, 3, 4>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [1, 3, 4], Axes3<0, 2, 5>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [1, 3, 5], Axes3<0, 2, 4>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [1, 4, 5], Axes3<0, 2, 3>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [2, 3, 4], Axes3<0, 1, 5>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [2, 3, 5], Axes3<0, 1, 4>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [2, 4, 5], Axes3<0, 1, 3>, [usize; 6], {M, N, O});
+impl_bcast!([[[f32; O]; N]; M], [3, 4, 5], Axes3<0, 1, 2>, [usize; 6], {M, N, O});
+
+// 4d -> 5d
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 1, 2, 3], Axis<4>, [usize; 5], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 1, 2, 4], Axis<3>, [usize; 5], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 1, 3, 4], Axis<2>, [usize; 5], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 2, 3, 4], Axis<1>, [usize; 5], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [1, 2, 3, 4], Axis<0>, [usize; 5], {M, N, O, P});
+
+// 4d -> 6d
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 1, 2, 3], Axes2<4, 5>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 1, 2, 4], Axes2<3, 5>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 1, 2, 5], Axes2<3, 4>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 1, 3, 4], Axes2<2, 5>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 1, 3, 5], Axes2<2, 4>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 1, 4, 5], Axes2<2, 3>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 2, 3, 4], Axes2<1, 5>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 2, 3, 5], Axes2<1, 4>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 2, 4, 5], Axes2<1, 3>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [0, 3, 4, 5], Axes2<1, 2>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [1, 2, 3, 4], Axes2<0, 5>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [1, 2, 3, 5], Axes2<0, 4>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [1, 2, 4, 5], Axes2<0, 3>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [1, 3, 4, 5], Axes2<0, 2>, [usize; 6], {M, N, O, P});
+impl_bcast!([[[[f32; O]; N]; M]; P], [2, 3, 4, 5], Axes2<0, 1>, [usize; 6], {M, N, O, P});
+
+// 5d -> 6d
+impl_bcast!([[[[[f32; Q]; P]; O]; N]; M], [0, 1, 2, 3, 4], Axis<5>, [usize; 6], {M, N, O, P, Q});
+impl_bcast!([[[[[f32; Q]; P]; O]; N]; M], [0, 1, 2, 3, 5], Axis<4>, [usize; 6], {M, N, O, P, Q});
+impl_bcast!([[[[[f32; Q]; P]; O]; N]; M], [0, 1, 2, 4, 5], Axis<3>, [usize; 6], {M, N, O, P, Q});
+impl_bcast!([[[[[f32; Q]; P]; O]; N]; M], [0, 1, 3, 4, 5], Axis<2>, [usize; 6], {M, N, O, P, Q});
+impl_bcast!([[[[[f32; Q]; P]; O]; N]; M], [0, 2, 3, 4, 5], Axis<1>, [usize; 6], {M, N, O, P, Q});
+impl_bcast!([[[[[f32; Q]; P]; O]; N]; M], [1, 2, 3, 4, 5], Axis<0>, [usize; 6], {M, N, O, P, Q});

--- a/src/devices/broadcast_reduce/mod.rs
+++ b/src/devices/broadcast_reduce/mod.rs
@@ -22,7 +22,7 @@ pub use accumulator::*;
 use super::allocate::AllocateZeros;
 use super::fill::FillElements;
 use super::Cpu;
-use crate::arrays::{AllAxes, Axes2, Axes3, Axes4, Axis, CountElements};
+use crate::arrays::{AllAxes, Axes2, Axes3, Axes4, Axes5, Axes6, Axis, CountElements};
 use indexing::{BroadcastMut, BroadcastRef};
 use std::boxed::Box;
 
@@ -132,6 +132,122 @@ impl_reduce!([[[[f32; P]; O]; N]; M], Axes3<1, 2, 3>, [f32; M], accum4d, {M, N, 
 // 4d -> 0d
 impl_reduce!([[[[f32; P]; O]; N]; M], Axes4<0, 1, 2, 3>, f32, accum4d, {M, N, O, P});
 
+// 5d -> 4d
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axis<0>, [[[[f32; Q]; P]; O]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axis<1>, [[[[f32; Q]; P]; O]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axis<2>, [[[[f32; Q]; P]; N]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axis<3>, [[[[f32; Q]; O]; N]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axis<4>, [[[[f32; P]; O]; N]; M], accum5d, {M, N, O, P, Q});
+
+// 5d -> 3d
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<0, 1>, [[[f32; Q]; P]; O], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<0, 2>, [[[f32; Q]; P]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<0, 3>, [[[f32; Q]; O]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<0, 4>, [[[f32; P]; O]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<1, 2>, [[[f32; Q]; P]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<1, 3>, [[[f32; Q]; O]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<1, 4>, [[[f32; P]; O]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<2, 3>, [[[f32; Q]; N]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<2, 4>, [[[f32; P]; N]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes2<3, 4>, [[[f32; O]; N]; M], accum5d, {M, N, O, P, Q});
+
+// 5d -> 2d
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<0, 1, 2>, [[f32; Q]; P], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<0, 1, 3>, [[f32; Q]; O], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<0, 1, 4>, [[f32; P]; O], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<0, 2, 3>, [[f32; Q]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<0, 2, 4>, [[f32; P]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<0, 3, 4>, [[f32; O]; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<1, 2, 3>, [[f32; Q]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<1, 2, 4>, [[f32; P]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<1, 3, 4>, [[f32; O]; M], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes3<2, 3, 4>, [[f32; N]; M], accum5d, {M, N, O, P, Q});
+
+// 5d -> 1d
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes4<0, 1, 2, 3>, [f32; Q], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes4<0, 1, 2, 4>, [f32; P], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes4<0, 1, 3, 4>, [f32; O], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes4<0, 2, 3, 4>, [f32; N], accum5d, {M, N, O, P, Q});
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes4<1, 2, 3, 4>, [f32; M], accum5d, {M, N, O, P, Q});
+
+// 5d -> 0d
+impl_reduce!([[[[[f32; Q]; P]; O]; N]; M], Axes5<0, 1, 2, 3, 4>, f32, accum5d, {M, N, O, P, Q});
+
+// 6d -> 5d
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axis<0>, [[[[[f32; R]; Q]; P]; O]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axis<1>, [[[[[f32; R]; Q]; P]; O]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axis<2>, [[[[[f32; R]; Q]; P]; N]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axis<3>, [[[[[f32; R]; Q]; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axis<4>, [[[[[f32; R]; P]; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axis<5>, [[[[[f32; Q]; P]; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+
+// 6d -> 4d
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<0, 1>, [[[[f32; R]; Q]; P]; O], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<0, 2>, [[[[f32; R]; Q]; P]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<0, 3>, [[[[f32; R]; Q]; O]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<0, 4>, [[[[f32; R]; P]; O]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<0, 5>, [[[[f32; Q]; P]; O]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<1, 2>, [[[[f32; R]; Q]; P]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<1, 3>, [[[[f32; R]; Q]; O]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<1, 4>, [[[[f32; R]; P]; O]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<1, 5>, [[[[f32; Q]; P]; O]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<2, 3>, [[[[f32; R]; Q]; N]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<2, 4>, [[[[f32; R]; P]; N]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<2, 5>, [[[[f32; Q]; P]; N]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<3, 4>, [[[[f32; R]; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<3, 5>, [[[[f32; Q]; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes2<4, 5>, [[[[f32; P]; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+
+// 6d -> 3d
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 1, 2>, [[[f32; R]; Q]; P], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 1, 3>, [[[f32; R]; Q]; O], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 1, 4>, [[[f32; R]; P]; O], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 1, 5>, [[[f32; Q]; P]; O], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 2, 3>, [[[f32; R]; Q]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 2, 4>, [[[f32; R]; P]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 2, 5>, [[[f32; Q]; P]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 3, 4>, [[[f32; R]; O]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 3, 5>, [[[f32; Q]; O]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<0, 4, 5>, [[[f32; P]; O]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<1, 2, 3>, [[[f32; R]; Q]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<1, 2, 4>, [[[f32; R]; P]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<1, 2, 5>, [[[f32; Q]; P]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<1, 3, 4>, [[[f32; R]; O]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<1, 3, 5>, [[[f32; Q]; O]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<1, 4, 5>, [[[f32; P]; O]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<2, 3, 4>, [[[f32; R]; N]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<2, 3, 5>, [[[f32; Q]; N]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<2, 4, 5>, [[[f32; P]; N]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes3<3, 4, 5>, [[[f32; O]; N]; M], accum6d, {M, N, O, P, Q, R});
+
+// 6d -> 2d
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 1, 2, 3>, [[f32; R]; Q], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 1, 2, 4>, [[f32; R]; P], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 1, 2, 5>, [[f32; Q]; P], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 1, 3, 4>, [[f32; R]; O], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 1, 3, 5>, [[f32; Q]; O], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 1, 4, 5>, [[f32; P]; O], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 2, 3, 4>, [[f32; R]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 2, 3, 5>, [[f32; Q]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 2, 4, 5>, [[f32; P]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<0, 3, 4, 5>, [[f32; O]; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<1, 2, 3, 4>, [[f32; R]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<1, 2, 3, 5>, [[f32; Q]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<1, 2, 4, 5>, [[f32; P]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<1, 3, 4, 5>, [[f32; O]; M], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes4<2, 3, 4, 5>, [[f32; N]; M], accum6d, {M, N, O, P, Q, R});
+
+// 6d -> 1d
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes5<0, 1, 2, 3, 4>, [f32; R], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes5<0, 1, 2, 3, 5>, [f32; Q], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes5<0, 1, 2, 4, 5>, [f32; P], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes5<0, 1, 3, 4, 5>, [f32; O], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes5<0, 2, 3, 4, 5>, [f32; N], accum6d, {M, N, O, P, Q, R});
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes5<1, 2, 3, 4, 5>, [f32; M], accum6d, {M, N, O, P, Q, R});
+
+// 6d -> 0d
+impl_reduce!([[[[[[f32; R]; Q]; P]; O]; N]; M], Axes6<0, 1, 2, 3, 4, 5>, f32, accum6d, {M, N, O, P, Q, R});
+
 impl DeviceReduce<f32, AllAxes> for Cpu {
     type Reduced = f32;
     fn reduce_into_no_reset<A: Accumulator<f32>>(r: &mut Self::Reduced, t: &f32) {
@@ -187,6 +303,51 @@ mod tests {
         let mut r = 0.0;
         <Cpu as DeviceReduce<_, AllAxes>>::reduce_into::<MulAccum>(&mut r, &t);
         assert_eq!(r, 1.0);
+    }
+
+    #[test]
+    fn test_reduce_all_4d() {
+        let t = [
+            [
+                [[-1., 2.], [1., -2.]]
+            ],
+            [
+                [[-2., 1.], [-1., -2.]]
+            ],
+        ];
+        let mut r = 0.0;
+        <Cpu as DeviceReduce<_, AllAxes>>::reduce_into::<MulAccum>(&mut r, &t);
+        assert_eq!(r, -16.0);
+    }
+
+    #[test]
+    fn test_reduce_all_5d() {
+        let t = [
+            [[
+                [[-1., 2.], [1., -2.]]
+            ],
+            [
+                [[-2., 1.], [-1., -2.]]
+            ]],
+        ];
+        let mut r = 0.0;
+        <Cpu as DeviceReduce<_, AllAxes>>::reduce_into::<MulAccum>(&mut r, &t);
+        assert_eq!(r, -16.0);
+    }
+
+    #[test]
+    fn test_reduce_all_6d() {
+        let t = [[
+            [[
+                [[-1., 2.], [1., -2.]]
+            ],
+            [
+                [[-2., 1.], [-1., -2.]]
+            ]],
+        ]];
+        let mut r = 0.0;
+        <Cpu as DeviceReduce<_, AllAxes>>::reduce_into::<MulAccum>(&mut r, &t);
+        assert_eq!(r, -16.0);
     }
 
     #[test]

--- a/src/devices/permute.rs
+++ b/src/devices/permute.rs
@@ -18,7 +18,7 @@
 //! this looping logic, but only differ in what they do with the indices.
 
 use super::Cpu;
-use crate::arrays::{Axes2, Axes3, Axes4};
+use crate::arrays::{Axes2, Axes3, Axes4, Axes5, Axes6};
 
 /// Permutes axes of `A` resulting in `B`.
 pub trait DevicePermute<A, B, Axes> {
@@ -28,7 +28,7 @@ pub trait DevicePermute<A, B, Axes> {
 
 /// Expands to the const generic for a specific axis. This is purely convention only.
 #[rustfmt::skip]
-macro_rules! axis { (0) => { M }; (1) => { N }; (2) => { O }; (3) => { P }; }
+macro_rules! axis { (0) => { M }; (1) => { N }; (2) => { O }; (3) => { P }; (4) => { Q }; (5) => { R }; }
 
 /// Expands to a array type using the axes passed in.
 /// E.g. `array!(2, 0, 1)` expands to `[[[f32; N]; M]; O]`
@@ -38,6 +38,8 @@ macro_rules! array {
     ($Ax0:tt, $Ax1:tt) => { [[f32; axis!($Ax1)]; axis!($Ax0)] };
     ($Ax0:tt, $Ax1:tt, $Ax2:tt) => { [[[f32; axis!($Ax2)]; axis!($Ax1)]; axis!($Ax0)] };
     ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt) => { [[[[f32; axis!($Ax3)]; axis!($Ax2)]; axis!($Ax1)]; axis!($Ax0)] };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt) => { [[[[[f32; axis!($Ax4)]; axis!($Ax3)]; axis!($Ax2)]; axis!($Ax1)]; axis!($Ax0)] };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt) => { [[[[[[f32; axis!($Ax5)]; axis!($Ax4)]; axis!($Ax3)]; axis!($Ax2)]; axis!($Ax1)]; axis!($Ax0)] };
 }
 
 /// Concrete implementations for the permute and inverse permute functions.
@@ -90,6 +92,46 @@ impl<const M: usize, const N: usize, const O: usize, const P: usize>
         permuted_loop4::<M, N, O, P, $Ax0, $Ax1, $Ax2, $Ax3, _>(
             &mut |[m, n, o, p], [i, j, k, l]| {
                 a[m][n][o][p] = b[i][j][k][l];
+            },
+        );
+    }
+}
+    };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4: tt) => {
+impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize>
+    DevicePermute<array!(0,1,2,3,4), array!($Ax0,$Ax1,$Ax2,$Ax3,$Ax4), Axes5<$Ax0,$Ax1,$Ax2,$Ax3,$Ax4>> for Cpu
+{
+    fn permute(a: &array!(0, 1, 2, 3, 4), b: &mut array!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4)) {
+        permuted_loop5::<M, N, O, P, Q, $Ax0, $Ax1, $Ax2, $Ax3, $Ax4, _>(
+            &mut |[m, n, o, p, q], [i, j, k, l, e]| {
+                b[i][j][k][l][e] = a[m][n][o][p][q];
+            },
+        );
+    }
+    fn inverse_permute(a: &mut array!(0, 1, 2, 3, 4), b: &array!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4)) {
+        permuted_loop5::<M, N, O, P, Q, $Ax0, $Ax1, $Ax2, $Ax3, $Ax4, _>(
+            &mut |[m, n, o, p, q], [i, j, k, l, e]| {
+                a[m][n][o][p][q] = b[i][j][k][l][e];
+            },
+        );
+    }
+}
+    };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4: tt, $Ax5: tt) => {
+impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize, const R: usize>
+    DevicePermute<array!(0,1,2,3,4,5), array!($Ax0,$Ax1,$Ax2,$Ax3,$Ax4,$Ax5), Axes6<$Ax0,$Ax1,$Ax2,$Ax3,$Ax4,$Ax5>> for Cpu
+{
+    fn permute(a: &array!(0, 1, 2, 3, 4, 5), b: &mut array!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5)) {
+        permuted_loop6::<M, N, O, P, Q, R, $Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5, _>(
+            &mut |[m, n, o, p, q, r], [i, j, k, l, e, f]| {
+                b[i][j][k][l][e][f] = a[m][n][o][p][q][r];
+            },
+        );
+    }
+    fn inverse_permute(a: &mut array!(0, 1, 2, 3, 4, 5), b: &array!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5)) {
+        permuted_loop6::<M, N, O, P, Q, R, $Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5, _>(
+            &mut |[m, n, o, p, q, r], [i, j, k, l, e, f]| {
+                a[m][n][o][p][q][r] = b[i][j][k][l][e][f];
             },
         );
     }
@@ -176,6 +218,81 @@ fn permuted_loop4<
     }
 }
 
+/// Apply a function `f` to two sets of 2d indices.
+fn permuted_loop5<
+    const M: usize,
+    const N: usize,
+    const O: usize,
+    const P: usize,
+    const Q: usize,
+    const I: isize,
+    const J: isize,
+    const K: isize,
+    const L: isize,
+    const D: isize,
+    F: FnMut([usize; 5], [usize; 5]),
+>(
+    f: &mut F,
+) {
+    for m in 0..M {
+        for n in 0..N {
+            for o in 0..O {
+                for p in 0..P {
+                    for q in 0..Q {
+                        let indices = [m, n, o, p, q];
+                        let i = const_idx::<I, 5>(&indices);
+                        let j = const_idx::<J, 5>(&indices);
+                        let k = const_idx::<K, 5>(&indices);
+                        let l = const_idx::<L, 5>(&indices);
+                        let d = const_idx::<D, 5>(&indices);
+                        f(indices, [i, j, k, l, d]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Apply a function `f` to two sets of 2d indices.
+fn permuted_loop6<
+    const M: usize,
+    const N: usize,
+    const O: usize,
+    const P: usize,
+    const Q: usize,
+    const R: usize,
+    const I: isize,
+    const J: isize,
+    const K: isize,
+    const L: isize,
+    const D: isize,
+    const E: isize,
+    F: FnMut([usize; 6], [usize; 6]),
+>(
+    f: &mut F,
+) {
+    for m in 0..M {
+        for n in 0..N {
+            for o in 0..O {
+                for p in 0..P {
+                    for q in 0..Q {
+                        for r in 0..R {
+                            let indices = [m, n, o, p, q ,r];
+                            let i = const_idx::<I, 6>(&indices);
+                            let j = const_idx::<J, 6>(&indices);
+                            let k = const_idx::<K, 6>(&indices);
+                            let l = const_idx::<L, 6>(&indices);
+                            let d = const_idx::<D, 6>(&indices);
+                            let e = const_idx::<E, 6>(&indices);
+                            f(indices, [i, j, k, l, d, e]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Expand out all the possible permutations for 2-4d
 macro_rules! permutations {
     ([$Ax0:tt, $Ax1:tt]) => {
@@ -208,11 +325,67 @@ macro_rules! permutations {
         impl_permute!($Ax0, $Ax1, $Ax2, $Ax3);
         impl_permute!($Ax0, $Ax1, $Ax3, $Ax2);
     };
+
+    ([$Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt]) => {
+        permutations!($Ax0, [$Ax1, $Ax2, $Ax3, $Ax4]);
+        permutations!($Ax1, [$Ax0, $Ax2, $Ax3, $Ax4]);
+        permutations!($Ax2, [$Ax0, $Ax1, $Ax3, $Ax4]);
+        permutations!($Ax3, [$Ax0, $Ax1, $Ax2, $Ax4]);
+        permutations!($Ax4, [$Ax0, $Ax1, $Ax2, $Ax3]);
+    };
+    ($Ax0:tt, [$Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt]) => {
+        permutations!($Ax0, $Ax1, [$Ax2, $Ax3, $Ax4]);
+        permutations!($Ax0, $Ax2, [$Ax1, $Ax3, $Ax4]);
+        permutations!($Ax0, $Ax3, [$Ax1, $Ax2, $Ax4]);
+        permutations!($Ax0, $Ax4, [$Ax1, $Ax2, $Ax3]);
+    };
+    ($Ax0:tt, $Ax1:tt, [$Ax2:tt, $Ax3:tt, $Ax4:tt]) => {
+        permutations!($Ax0, $Ax1, $Ax2, [$Ax3, $Ax4]);
+        permutations!($Ax0, $Ax1, $Ax3, [$Ax2, $Ax4]);
+        permutations!($Ax0, $Ax1, $Ax4, [$Ax2, $Ax3]);
+    };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, [$Ax3:tt, $Ax4:tt]) => {
+        impl_permute!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4);
+        impl_permute!($Ax0, $Ax1, $Ax2, $Ax4, $Ax3);
+    };
+
+    ([$Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt]) => {
+        permutations!($Ax0, [$Ax1, $Ax2, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax1, [$Ax0, $Ax2, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax2, [$Ax0, $Ax1, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax3, [$Ax0, $Ax1, $Ax2, $Ax4, $Ax5]);
+        permutations!($Ax4, [$Ax0, $Ax1, $Ax2, $Ax3, $Ax5]);
+        permutations!($Ax5, [$Ax0, $Ax1, $Ax2, $Ax3, $Ax4]);
+    };
+    ($Ax0:tt, [$Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt]) => {
+        permutations!($Ax0, $Ax1, [$Ax2, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax2, [$Ax1, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax3, [$Ax1, $Ax2, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax4, [$Ax1, $Ax2, $Ax3, $Ax5]);
+        permutations!($Ax0, $Ax5, [$Ax1, $Ax2, $Ax3, $Ax4]);
+    };
+    ($Ax0:tt, $Ax1:tt, [$Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt]) => {
+        permutations!($Ax0, $Ax1, $Ax2, [$Ax3, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax3, [$Ax2, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax4, [$Ax2, $Ax3, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax5, [$Ax2, $Ax3, $Ax4]);
+    };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, [$Ax3:tt, $Ax4:tt, $Ax5:tt]) => {
+        permutations!($Ax0, $Ax1, $Ax2, $Ax3, [$Ax4, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax2, $Ax4, [$Ax3, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax2, $Ax5, [$Ax3, $Ax4]);
+    };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, [$Ax4:tt, $Ax5:tt]) => {
+        impl_permute!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5);
+        impl_permute!($Ax0, $Ax1, $Ax2, $Ax3, $Ax5, $Ax4);
+    };
 }
 
 permutations!([0, 1]);
 permutations!([0, 1, 2]);
 permutations!([0, 1, 2, 3]);
+permutations!([0, 1, 2, 3, 4]);
+permutations!([0, 1, 2, 3, 4, 5]);
 
 #[cfg(test)]
 mod tests {
@@ -256,6 +429,38 @@ mod tests {
 
         let mut c = [[[[0.0; 9]; 7]; 5]; 3];
         <Cpu as DevicePermute<_, _, Axes4<2, 3, 1, 0>>>::inverse_permute(&mut c, &b);
+
+        assert_eq!(a, c);
+    }
+
+    #[test]
+    fn test_5d_permute() {
+        let mut rng = thread_rng();
+        let mut a = [[[[[0.0; 9]; 7]; 5]; 3]; 4];
+        Cpu::fill(&mut a, &mut |v| *v = rng.gen());
+
+        let mut b = [[[[[0.0; 9]; 4]; 3]; 7]; 5];
+        <Cpu as DevicePermute<_, _, Axes5<2, 3, 1, 0, 4>>>::permute(&a, &mut b);
+        assert_ne!(b, [[[[[0.0; 9]; 4]; 3]; 7]; 5]);
+
+        let mut c = [[[[[0.0; 9]; 7]; 5]; 3]; 4];
+        <Cpu as DevicePermute<_, _, Axes5<2, 3, 1, 0, 4>>>::inverse_permute(&mut c, &b);
+
+        assert_eq!(a, c);
+    }
+
+    #[test]
+    fn test_6d_permute() {
+        let mut rng = thread_rng();
+        let mut a = [[[[[[0.0; 9]; 7]; 5]; 3]; 4]; 2];
+        Cpu::fill(&mut a, &mut |v| *v = rng.gen());
+
+        let mut b = [[[[[[0.0; 9]; 7]; 2]; 4]; 5]; 3];
+        <Cpu as DevicePermute<_, _, Axes6<2, 3, 1, 0, 4, 5>>>::permute(&a, &mut b);
+        assert_ne!(b, [[[[[[0.0; 9]; 7]; 2]; 4]; 5]; 3]);
+
+        let mut c = [[[[[[0.0; 9]; 7]; 5]; 3]; 4]; 2];
+        <Cpu as DevicePermute<_, _, Axes6<2, 3, 1, 0, 4, 5>>>::inverse_permute(&mut c, &b);
 
         assert_eq!(a, c);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ pub mod unique_id;
 
 /// Contains all public exports.
 pub mod prelude {
-    pub use crate::arrays::{AllAxes, Axes2, Axes3, Axes4, Axis, HasArrayData};
+    pub use crate::arrays::{AllAxes, Axes2, Axes3, Axes4, Axes5, Axes6, Axis, HasArrayData};
     pub use crate::devices::HasDevice;
     pub use crate::gradients::{NoneTape, OwnedTape};
     pub use crate::losses::*;

--- a/src/tensor_ops/arith_scalar.rs
+++ b/src/tensor_ops/arith_scalar.rs
@@ -147,6 +147,8 @@ scalar_ops_impl!(Tensor1D, [N]);
 scalar_ops_impl!(Tensor2D, [M, N]);
 scalar_ops_impl!(Tensor3D, [M, N, O]);
 scalar_ops_impl!(Tensor4D, [M, N, O, P]);
+scalar_ops_impl!(Tensor5D, [M, N, O, P, Q]);
+scalar_ops_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_add.rs
+++ b/src/tensor_ops/impl_add.rs
@@ -41,6 +41,8 @@ binary_ops_impl!(Tensor1D, [N]);
 binary_ops_impl!(Tensor2D, [M, N]);
 binary_ops_impl!(Tensor3D, [M, N, O]);
 binary_ops_impl!(Tensor4D, [M, N, O, P]);
+binary_ops_impl!(Tensor5D, [M, N, O, P, Q]);
+binary_ops_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_broadcast_reduce.rs
+++ b/src/tensor_ops/impl_broadcast_reduce.rs
@@ -233,6 +233,18 @@ mod tests {
         let _: Tensor4D<3, 5, 7, 9> = Tensor3D::<3, 7, 9>::zeros().broadcast();
         let _: Tensor4D<3, 5, 7, 9> = Tensor3D::<3, 5, 9>::zeros().broadcast();
         let _: Tensor4D<3, 5, 7, 9> = Tensor3D::<3, 5, 7>::zeros().broadcast();
+
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor4D::<5, 7, 9, 11>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor4D::<3, 7, 9, 11>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor4D::<3, 5, 9, 11>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor4D::<3, 5, 7, 11>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor4D::<3, 5, 7, 9>::zeros().broadcast();
+
+        let _: Tensor6D<3, 5, 7, 9, 11, 13> = Tensor5D::<5, 7, 9, 11, 13>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 9, 11, 13> = Tensor5D::<3, 7, 9, 11, 13>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 9, 11, 13> = Tensor5D::<3, 5, 9, 11, 13>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 9, 11, 13> = Tensor5D::<3, 5, 7, 11, 13>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 9, 11, 13> = Tensor5D::<3, 5, 7, 9, 11>::zeros().broadcast();
     }
 
     #[test]
@@ -250,7 +262,29 @@ mod tests {
         let _: Tensor4D<3, 5, 7, 9> = Tensor2D::<5, 9>::zeros().broadcast();
         let _: Tensor4D<3, 5, 7, 9> = Tensor2D::<7, 9>::zeros().broadcast();
 
-        // let _: Tensor5D<3, 5, 7, 9, 8> = Tensor2D::<3, 5>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 8, 9> = Tensor3D::<3, 5, 7>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 8, 9> = Tensor3D::<3, 5, 8>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 8, 9> = Tensor3D::<3, 5, 9>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 8, 9> = Tensor3D::<3, 7, 8>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 8, 9> = Tensor3D::<3, 7, 9>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 8, 9> = Tensor3D::<3, 8, 9>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 8, 9> = Tensor3D::<5, 7, 8>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 8, 9> = Tensor3D::<5, 7, 9>::zeros().broadcast();
+
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<3, 5, 7, 9>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<3, 5, 7, 11>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<3, 5, 9, 11>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<3, 5, 8, 9>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<3, 5, 8, 11>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<3, 5, 9, 11>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<3, 7, 8, 9>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<3, 7, 8, 11>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<3, 7, 9, 11>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<5, 7, 8, 9>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<5, 7, 8, 11>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<5, 7, 9, 11>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<5, 8, 9, 11>::zeros().broadcast();
+        let _: Tensor6D<3, 5, 7, 8, 9, 11> = Tensor4D::<7, 8, 9, 11>::zeros().broadcast();
     }
 
     #[test]
@@ -261,6 +295,17 @@ mod tests {
         let _: Tensor4D<3, 5, 7, 9> = Tensor1D::<5>::zeros().broadcast();
         let _: Tensor4D<3, 5, 7, 9> = Tensor1D::<7>::zeros().broadcast();
         let _: Tensor4D<3, 5, 7, 9> = Tensor1D::<9>::zeros().broadcast();
+
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor2D::<3, 5>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor2D::<3, 7>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor2D::<3, 9>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor2D::<3, 11>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor2D::<5, 7>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor2D::<5, 9>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor2D::<5, 11>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor2D::<7, 9>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor2D::<7, 11>::zeros().broadcast();
+        let _: Tensor5D<3, 5, 7, 9, 11> = Tensor2D::<9, 11>::zeros().broadcast();
     }
 
     #[test]

--- a/src/tensor_ops/impl_broadcast_reduce.rs
+++ b/src/tensor_ops/impl_broadcast_reduce.rs
@@ -1,5 +1,5 @@
 use super::utils::move_tape_and_add_backward_op;
-use crate::arrays::{AllAxes, Axes2, Axes3, Axis, HasArrayType};
+use crate::arrays::{AllAxes, Axes2, Axes3, Axes5, Axis, HasArrayType};
 use crate::devices::{AddAccum, CopyAccum, Cpu, DeviceReduce};
 use crate::gradients::Tape;
 use crate::prelude::*;
@@ -19,6 +19,12 @@ pub trait BroadcastTo<T, Axes> {
     ///
     /// // broadcast axes 1, 2, 3
     /// let _: Tensor4D<3, 5, 7, 9> = Tensor1D::<3>::zeros().broadcast();
+    ///
+    /// // broadcast axes 1, 2, 3, 4
+    /// let _: Tensor5D<3, 5, 7, 9, 6> = Tensor1D::<3>::zeros().broadcast();
+    ///
+    /// // broadcast axes 1, 2, 3, 4, 5
+    /// let _: Tensor6D<3, 5, 7, 9, 6, 8> = Tensor1D::<3>::zeros().broadcast();
     /// ```
     fn broadcast(self) -> T;
 }
@@ -78,6 +84,8 @@ impl_broadcast_reduce!(Tensor0D<H>, AllAxes, Tensor1D<M, H>, {M});
 impl_broadcast_reduce!(Tensor0D<H>, AllAxes, Tensor2D<M, N, H>, {M, N});
 impl_broadcast_reduce!(Tensor0D<H>, AllAxes, Tensor3D<M, N, O, H>, {M, N, O});
 impl_broadcast_reduce!(Tensor0D<H>, AllAxes, Tensor4D<M, N, O, P, H>, {M, N, O, P});
+impl_broadcast_reduce!(Tensor0D<H>, AllAxes, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor0D<H>, AllAxes, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
 
 // 1d -> Nd
 impl_broadcast_reduce!(Tensor1D<M, H>, Axis<1>, Tensor2D<M, N, H>, {M, N});
@@ -89,6 +97,17 @@ impl_broadcast_reduce!(Tensor1D<M, H>, Axes3<1, 2, 3>, Tensor4D<M, N, O, P, H>, 
 impl_broadcast_reduce!(Tensor1D<N, H>, Axes3<0, 2, 3>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor1D<O, H>, Axes3<0, 1, 3>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor1D<P, H>, Axes3<0, 1, 2>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
+impl_broadcast_reduce!(Tensor1D<M, H>, Axes4<1, 2, 3, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor1D<N, H>, Axes4<0, 2, 3, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor1D<O, H>, Axes4<0, 1, 3, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor1D<P, H>, Axes4<0, 1, 2, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor1D<Q, H>, Axes4<0, 1, 2, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor1D<M, H>, Axes5<1, 2, 3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor1D<N, H>, Axes5<0, 2, 3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor1D<O, H>, Axes5<0, 1, 3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor1D<P, H>, Axes5<0, 1, 2, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor1D<Q, H>, Axes5<0, 1, 2, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor1D<R, H>, Axes5<0, 1, 2, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
 
 // 2d -> Nd
 impl_broadcast_reduce!(Tensor2D<M, N, H>, Axis<2>, Tensor3D<M, N, O, H>, {M, N, O});
@@ -100,12 +119,97 @@ impl_broadcast_reduce!(Tensor2D<M, P, H>, Axes2<1, 2>, Tensor4D<M, N, O, P, H>, 
 impl_broadcast_reduce!(Tensor2D<N, O, H>, Axes2<0, 3>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor2D<N, P, H>, Axes2<0, 2>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor2D<O, P, H>, Axes2<0, 1>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
+impl_broadcast_reduce!(Tensor2D<M, N, H>, Axes3<2, 3, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<M, O, H>, Axes3<1, 3, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<M, P, H>, Axes3<1, 2, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<M, Q, H>, Axes3<1, 2, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<N, O, H>, Axes3<0, 3, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<N, P, H>, Axes3<0, 2, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<N, Q, H>, Axes3<0, 2, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<O, P, H>, Axes3<0, 1, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<O, Q, H>, Axes3<0, 1, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<P, Q, H>, Axes3<0, 1, 2>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor2D<M, N, H>, Axes4<2, 3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<M, O, H>, Axes4<1, 3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<M, P, H>, Axes4<1, 2, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<M, Q, H>, Axes4<1, 2, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<M, R, H>, Axes4<1, 2, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<N, O, H>, Axes4<0, 3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<N, P, H>, Axes4<0, 2, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<N, Q, H>, Axes4<0, 2, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<N, R, H>, Axes4<0, 2, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<O, P, H>, Axes4<0, 1, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<O, Q, H>, Axes4<0, 1, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<O, R, H>, Axes4<0, 1, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<P, Q, H>, Axes4<0, 1, 2, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<P, R, H>, Axes4<0, 1, 2, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor2D<Q, R, H>, Axes4<0, 1, 2, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
 
-// 3d -> 4d
+// 3d -> Nd
 impl_broadcast_reduce!(Tensor3D<M, N, O, H>, Axis<3>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor3D<M, N, P, H>, Axis<2>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor3D<M, O, P, H>, Axis<1>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
 impl_broadcast_reduce!(Tensor3D<N, O, P, H>, Axis<0>, Tensor4D<M, N, O, P, H>, {M, N, O, P});
+impl_broadcast_reduce!(Tensor3D<M, N, O, H>, Axes2<3, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<M, N, P, H>, Axes2<2, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<M, N, Q, H>, Axes2<2, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<M, O, P, H>, Axes2<1, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<M, O, Q, H>, Axes2<1, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<M, P, Q, H>, Axes2<1, 2>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<N, O, P, H>, Axes2<0, 4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<N, O, Q, H>, Axes2<0, 3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<N, P, Q, H>, Axes2<0, 2>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<O, P, Q, H>, Axes2<0, 1>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor3D<M, N, O, H>, Axes3<3, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<M, N, P, H>, Axes3<2, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<M, N, Q, H>, Axes3<2, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<M, N, R, H>, Axes3<2, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<M, O, P, H>, Axes3<1, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<M, O, Q, H>, Axes3<1, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<M, O, R, H>, Axes3<1, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<M, P, Q, H>, Axes3<1, 2, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<M, P, R, H>, Axes3<1, 2, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<M, Q, R, H>, Axes3<1, 2, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<N, O, P, H>, Axes3<0, 4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<N, O, Q, H>, Axes3<0, 3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<N, O, R, H>, Axes3<0, 3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<N, P, Q, H>, Axes3<0, 2, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<N, P, R, H>, Axes3<0, 2, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<N, Q, R, H>, Axes3<0, 2, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<O, P, Q, H>, Axes3<0, 1, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<O, P, R, H>, Axes3<0, 1, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<O, Q, R, H>, Axes3<0, 1, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor3D<P, Q, R, H>, Axes3<0, 1, 2>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+
+// 4d -> Nd
+impl_broadcast_reduce!(Tensor4D<M, N, O, P, H>, Axis<4>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor4D<M, N, O, Q, H>, Axis<3>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor4D<M, N, P, Q, H>, Axis<2>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor4D<M, O, P, Q, H>, Axis<1>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor4D<N, O, P, Q, H>, Axis<0>, Tensor5D<M, N, O, P, Q, H>, {M, N, O, P, Q});
+impl_broadcast_reduce!(Tensor4D<M, N, O, P, H>, Axes2<4, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<M, N, O, Q, H>, Axes2<3, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<M, N, O, R, H>, Axes2<3, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<M, N, P, Q, H>, Axes2<2, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<M, N, P, R, H>, Axes2<2, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<M, N, Q, R, H>, Axes2<2, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<M, O, P, Q, H>, Axes2<1, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<M, O, P, R, H>, Axes2<1, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<M, O, Q, R, H>, Axes2<1, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<M, P, Q, R, H>, Axes2<1, 2>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<N, O, P, Q, H>, Axes2<0, 5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<N, O, P, R, H>, Axes2<0, 4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<N, O, Q, R, H>, Axes2<0, 3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<N, P, Q, R, H>, Axes2<0, 2>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor4D<O, P, Q, R, H>, Axes2<0, 1>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+
+// 5d -> 6d
+impl_broadcast_reduce!(Tensor5D<M, N, O, P, Q, H>, Axis<5>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor5D<M, N, O, P, R, H>, Axis<4>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor5D<M, N, O, Q, R, H>, Axis<3>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor5D<M, N, P, Q, R, H>, Axis<2>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor5D<M, O, P, Q, R, H>, Axis<1>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
+impl_broadcast_reduce!(Tensor5D<N, O, P, Q, R, H>, Axis<0>, Tensor6D<M, N, O, P, Q, R, H>, {M, N, O, P, Q, R});
 
 #[cfg(test)]
 mod tests {
@@ -145,6 +249,8 @@ mod tests {
         let _: Tensor4D<3, 5, 7, 9> = Tensor2D::<5, 7>::zeros().broadcast();
         let _: Tensor4D<3, 5, 7, 9> = Tensor2D::<5, 9>::zeros().broadcast();
         let _: Tensor4D<3, 5, 7, 9> = Tensor2D::<7, 9>::zeros().broadcast();
+
+        // let _: Tensor5D<3, 5, 7, 9, 8> = Tensor2D::<3, 5>::zeros().broadcast();
     }
 
     #[test]

--- a/src/tensor_ops/impl_clamp.rs
+++ b/src/tensor_ops/impl_clamp.rs
@@ -34,6 +34,8 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_div.rs
+++ b/src/tensor_ops/impl_div.rs
@@ -45,6 +45,8 @@ binary_ops_impl!(Tensor1D, [N]);
 binary_ops_impl!(Tensor2D, [M, N]);
 binary_ops_impl!(Tensor3D, [M, N, O]);
 binary_ops_impl!(Tensor4D, [M, N, O, P]);
+binary_ops_impl!(Tensor5D, [M, N, O, P, Q]);
+binary_ops_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_dropout.rs
+++ b/src/tensor_ops/impl_dropout.rs
@@ -77,6 +77,8 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+tensor_impl!(Tensor6D, [M, N, O, P, Q, K]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_mask.rs
+++ b/src/tensor_ops/impl_mask.rs
@@ -48,6 +48,8 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_max.rs
+++ b/src/tensor_ops/impl_max.rs
@@ -55,6 +55,8 @@ max_axis_impl!(Tensor1D, [M]);
 max_axis_impl!(Tensor2D, [M, N]);
 max_axis_impl!(Tensor3D, [M, N, O]);
 max_axis_impl!(Tensor4D, [M, N, O, P]);
+max_axis_impl!(Tensor5D, [M, N, O, P, Q]);
+max_axis_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_maximum.rs
+++ b/src/tensor_ops/impl_maximum.rs
@@ -63,6 +63,8 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_mean.rs
+++ b/src/tensor_ops/impl_mean.rs
@@ -48,6 +48,8 @@ mean_axis_impl!(Tensor1D, [M]);
 mean_axis_impl!(Tensor2D, [M, N]);
 mean_axis_impl!(Tensor3D, [M, N, O]);
 mean_axis_impl!(Tensor4D, [M, N, O, P]);
+mean_axis_impl!(Tensor5D, [M, N, O, P, Q]);
+mean_axis_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_min.rs
+++ b/src/tensor_ops/impl_min.rs
@@ -55,6 +55,8 @@ min_axis_impl!(Tensor1D, [M]);
 min_axis_impl!(Tensor2D, [M, N]);
 min_axis_impl!(Tensor3D, [M, N, O]);
 min_axis_impl!(Tensor4D, [M, N, O, P]);
+min_axis_impl!(Tensor5D, [M, N, O, P, Q]);
+min_axis_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_minimum.rs
+++ b/src/tensor_ops/impl_minimum.rs
@@ -63,6 +63,8 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_mul.rs
+++ b/src/tensor_ops/impl_mul.rs
@@ -41,6 +41,8 @@ binary_ops_impl!(Tensor1D, [N]);
 binary_ops_impl!(Tensor2D, [M, N]);
 binary_ops_impl!(Tensor3D, [M, N, O]);
 binary_ops_impl!(Tensor4D, [M, N, O, P]);
+binary_ops_impl!(Tensor5D, [M, N, O, P, Q]);
+binary_ops_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_nans.rs
+++ b/src/tensor_ops/impl_nans.rs
@@ -36,6 +36,8 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_normalize.rs
+++ b/src/tensor_ops/impl_normalize.rs
@@ -45,6 +45,8 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_pow.rs
+++ b/src/tensor_ops/impl_pow.rs
@@ -55,6 +55,8 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_reshape.rs
+++ b/src/tensor_ops/impl_reshape.rs
@@ -31,6 +31,8 @@ macro_rules! impl_all_reshapes {
         tensor_impl!($src_ty, [$($SrcVs),*], Tensor2D, [M, N], $assert_lhs, (M * N));
         tensor_impl!($src_ty, [$($SrcVs),*], Tensor3D, [M, N, O], $assert_lhs, (M * N * O));
         tensor_impl!($src_ty, [$($SrcVs),*], Tensor4D, [M, N, O, P], $assert_lhs, (M * N * O * P));
+        tensor_impl!($src_ty, [$($SrcVs),*], Tensor5D, [M, N, O, P, Q], $assert_lhs, (M * N * O * P * Q));
+        tensor_impl!($src_ty, [$($SrcVs),*], Tensor6D, [M, N, O, P, Q, R], $assert_lhs, (M * N * O * P * Q * R));
     };
 }
 
@@ -39,6 +41,8 @@ impl_all_reshapes!(Tensor1D, [A], (A));
 impl_all_reshapes!(Tensor2D, [A, B], (A * B));
 impl_all_reshapes!(Tensor3D, [A, B, C], (A * B * C));
 impl_all_reshapes!(Tensor4D, [A, B, C, D], (A * B * C * D));
+impl_all_reshapes!(Tensor5D, [A, B, C, D, E], (A * B * C * D * E ));
+impl_all_reshapes!(Tensor6D, [A, B, C, D, E, F], (A * B * C * D * E * F));
 
 /// Reshapes `T` into `R`'s shape. This is unsafe because there are no compile
 /// time guaruntees that `T` and `R` have the same number of elements.

--- a/src/tensor_ops/impl_softmax.rs
+++ b/src/tensor_ops/impl_softmax.rs
@@ -106,6 +106,8 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_stddev.rs
+++ b/src/tensor_ops/impl_stddev.rs
@@ -73,6 +73,8 @@ impl_std_and_var!(Tensor1D, [M]);
 impl_std_and_var!(Tensor2D, [M, N]);
 impl_std_and_var!(Tensor3D, [M, N, O]);
 impl_std_and_var!(Tensor4D, [M, N, O, P]);
+impl_std_and_var!(Tensor5D, [M, N, O, P, Q]);
+impl_std_and_var!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_sub.rs
+++ b/src/tensor_ops/impl_sub.rs
@@ -41,6 +41,8 @@ binary_ops_impl!(Tensor1D, [N]);
 binary_ops_impl!(Tensor2D, [M, N]);
 binary_ops_impl!(Tensor3D, [M, N, O]);
 binary_ops_impl!(Tensor4D, [M, N, O, P]);
+binary_ops_impl!(Tensor5D, [M, N, O, P, Q]);
+binary_ops_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/impl_sum.rs
+++ b/src/tensor_ops/impl_sum.rs
@@ -52,6 +52,8 @@ sum_axis_impl!(Tensor1D, [M]);
 sum_axis_impl!(Tensor2D, [M, N]);
 sum_axis_impl!(Tensor3D, [M, N, O]);
 sum_axis_impl!(Tensor4D, [M, N, O, P]);
+sum_axis_impl!(Tensor5D, [M, N, O, P, Q]);
+sum_axis_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/map.rs
+++ b/src/tensor_ops/map.rs
@@ -253,6 +253,8 @@ tensor_impl!(Tensor1D, [M]);
 tensor_impl!(Tensor2D, [M, N]);
 tensor_impl!(Tensor3D, [M, N, O]);
 tensor_impl!(Tensor4D, [M, N, O, P]);
+tensor_impl!(Tensor5D, [M, N, O, P, Q]);
+tensor_impl!(Tensor6D, [M, N, O, P, Q, R]);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/mod.rs
+++ b/src/tensor_ops/mod.rs
@@ -19,9 +19,11 @@
 //! 3. `Tensor2D`: `Axis<0>`, `Axis<1>`
 //! 4. `Tensor3D`: `Axis<0>`, `Axis<1>`, `Axis<2>`,
 //! 5. `Tensor4D`: `Axis<0>`, `Axis<1>`, `Axis<2>`, `Axis<3>`
+//! 5. `Tensor5D`: `Axis<0>`, `Axis<1>`, `Axis<2>`, `Axis<3>`, `Axis<4>`
+//! 5. `Tensor6D`: `Axis<0>`, `Axis<1>`, `Axis<2>`, `Axis<3>`, `Axis<4>`, `Axis<5>`
 //!
 //! Additionally `AllAxes` is valid for all tensors.
-//! To specify multiple axes you can use `Axes2`, `Axes3`, and `Axes4`
+//! To specify multiple axes you can use `Axes2`, `Axes3`, `Axes4` and `Axes5`
 //!
 //! # Reductions
 //!
@@ -99,6 +101,21 @@
 //! let t: Tensor4D<2, 3, 4, 5> = TensorCreator::zeros();
 //! let _: Tensor4D<3, 5, 2, 4> = t.permute();
 //! ```
+//!
+//! 5D version:
+//! ```rust
+//! # use dfdx::prelude::*;
+//! let t: Tensor5D<2, 3, 4, 5, 6> = TensorCreator::zeros();
+//! let _: Tensor5D<3, 5, 2, 6, 4> = t.permute();
+//! ```
+//!
+//! 6D version:
+//! ```rust
+//! # use dfdx::prelude::*;
+//! let t: Tensor6D<2, 3, 4, 5, 6, 7> = TensorCreator::zeros();
+//! let _: Tensor6D<3, 5, 2, 6, 7, 4> = t.permute();
+//! ```
+//!
 //!
 //! # Selects/Indexing
 //!

--- a/src/tensor_ops/permute.rs
+++ b/src/tensor_ops/permute.rs
@@ -326,6 +326,26 @@ mod tests {
     }
 
     #[test]
+    fn test_permute_5d_backwards() {
+        let mut rng = thread_rng();
+        let t: Tensor5D<3, 6, 9, 11, 13> = TensorCreator::randn(&mut rng);
+        let r: Tensor5D<6, 3, 11, 13, 9, _> = t.trace().permute();
+        let g1 = backward(r.exp().sum());
+        let g2 = backward(t.trace().exp().sum());
+        assert_eq!(g1.ref_gradient(&t), g2.ref_gradient(&t));
+    }
+
+    #[test]
+    fn test_permute_6d_backwards() {
+        let mut rng = thread_rng();
+        let t: Tensor6D<3, 6, 7, 9, 11, 13> = TensorCreator::randn(&mut rng);
+        let r: Tensor6D<6, 7, 3, 11, 13, 9, _> = t.trace().permute();
+        let g1 = backward(r.exp().sum());
+        let g2 = backward(t.trace().exp().sum());
+        assert_eq!(g1.ref_gradient(&t), g2.ref_gradient(&t));
+    }
+
+    #[test]
     fn test_valid_permutations() {
         let _ = <Tensor2D<3, 5> as PermuteTo<_, Axes2<0, 1>>>::permute;
         let _ = <Tensor2D<3, 5> as PermuteTo<_, Axes2<1, 0>>>::permute;
@@ -361,5 +381,127 @@ mod tests {
         let _ = <Tensor4D<3, 5, 7, 9> as PermuteTo<_, Axes4<3, 1, 2, 0>>>::permute;
         let _ = <Tensor4D<3, 5, 7, 9> as PermuteTo<_, Axes4<3, 2, 0, 1>>>::permute;
         let _ = <Tensor4D<3, 5, 7, 9> as PermuteTo<_, Axes4<3, 2, 1, 0>>>::permute;
+
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 1, 2, 3, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 1, 2, 4, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 1, 3, 2, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 1, 3, 4, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 1, 4, 2, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 1, 4, 3, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 2, 1, 3, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 2, 1, 4, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 2, 3, 1, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 2, 3, 4, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 2, 4, 1, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 2, 4, 3, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 3, 1, 2, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 3, 1, 4, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 3, 2, 1, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 3, 2, 4, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 3, 4, 1, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 3, 4, 2, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 4, 1, 2, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 4, 1, 3, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 4, 2, 1, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 4, 2, 3, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 4, 3, 1, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<0, 4, 3, 2, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 0, 2, 3, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 0, 2, 4, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 0, 3, 2, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 0, 3, 4, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 0, 4, 2, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 0, 4, 3, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 2, 0, 3, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 2, 0, 4, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 2, 3, 0, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 2, 3, 4, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 2, 4, 0, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 2, 4, 3, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 3, 0, 2, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 3, 0, 4, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 3, 2, 0, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 3, 2, 4, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 3, 4, 0, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 3, 4, 2, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 4, 0, 2, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 4, 0, 3, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 4, 2, 0, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 4, 2, 3, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 4, 3, 0, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<1, 4, 3, 2, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 0, 1, 3, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 0, 1, 4, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 0, 3, 1, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 0, 3, 4, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 0, 4, 1, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 0, 4, 3, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 1, 0, 3, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 1, 0, 4, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 1, 3, 0, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 1, 3, 4, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 1, 4, 0, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 1, 4, 3, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 3, 0, 1, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 3, 0, 4, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 3, 1, 0, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 3, 1, 4, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 3, 4, 0, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 3, 4, 1, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 4, 0, 1, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 4, 0, 3, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 4, 1, 0, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 4, 1, 3, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 4, 3, 0, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<2, 4, 3, 1, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 0, 1, 2, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 0, 1, 4, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 0, 2, 1, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 0, 2, 4, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 0, 4, 1, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 0, 4, 2, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 1, 0, 2, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 1, 0, 4, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 1, 2, 0, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 1, 2, 4, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 1, 4, 0, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 1, 4, 2, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 2, 0, 1, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 2, 0, 4, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 2, 1, 0, 4>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 2, 1, 4, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 2, 4, 0, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 2, 4, 1, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 4, 0, 1, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 4, 0, 2, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 4, 1, 0, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 4, 1, 2, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 4, 2, 0, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<3, 4, 2, 1, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 0, 1, 2, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 0, 1, 3, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 0, 2, 1, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 0, 2, 3, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 0, 3, 1, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 0, 3, 2, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 1, 0, 2, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 1, 0, 3, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 1, 2, 0, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 1, 2, 3, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 1, 3, 0, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 1, 3, 2, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 2, 0, 1, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 2, 0, 3, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 2, 1, 0, 3>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 2, 1, 3, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 2, 3, 0, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 2, 3, 1, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 3, 0, 1, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 3, 0, 2, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 3, 1, 0, 2>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 3, 1, 2, 0>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 3, 2, 0, 1>>>::permute;
+        let _ = <Tensor5D<3, 5, 7, 9, 11> as PermuteTo<_, Axes5<4, 3, 2, 1, 0>>>::permute;
+
     }
 }

--- a/src/tensor_ops/permute.rs
+++ b/src/tensor_ops/permute.rs
@@ -13,13 +13,15 @@ pub trait PermuteTo<T, Axes> {
     /// let _: Tensor2D<3, 2> = Tensor2D::<2, 3>::zeros().permute();
     /// let _: Tensor3D<3, 4, 2> = Tensor3D::<2, 3, 4>::zeros().permute();
     /// let _: Tensor4D<3, 4, 5, 2> = Tensor4D::<2, 3, 4, 5>::zeros().permute();
+    /// let _: Tensor5D<3, 4, 5, 2, 1> = Tensor5D::<1, 2, 3, 4, 5>::zeros().permute();
+    /// let _: Tensor6D<3, 4, 5, 2, 6, 1> = Tensor6D::<1, 2, 3, 4, 5, 6>::zeros().permute();
     /// ```
     fn permute(self) -> T;
 }
 
 /// Returns const generic for a specific axis.
 #[rustfmt::skip]
-macro_rules! axis { (0) => { M }; (1) => { N }; (2) => { O }; (3) => { P }; }
+macro_rules! axis { (0) => { M }; (1) => { N }; (2) => { O }; (3) => { P }; (4) => { Q }; (5) => { R }; }
 
 /// Helper macro that creates a tensor based on axes passed in.
 /// E.g. `tensor!(2, 0, 1)` returns `Tensor3D<O, M, N, H>`
@@ -29,9 +31,11 @@ macro_rules! tensor {
     ($Ax0:tt, $Ax1:tt) => { Tensor2D<axis!($Ax0), axis!($Ax1), H> };
     ($Ax0:tt, $Ax1:tt, $Ax2:tt) => { Tensor3D<axis!($Ax0), axis!($Ax1), axis!($Ax2), H> };
     ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt) => { Tensor4D<axis!($Ax0), axis!($Ax1), axis!($Ax2), axis!($Ax3), H> };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt) => { Tensor5D<axis!($Ax0), axis!($Ax1), axis!($Ax2), axis!($Ax3), axis!($Ax4), H> };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt) => { Tensor6D<axis!($Ax0), axis!($Ax1), axis!($Ax2), axis!($Ax3), axis!($Ax4), axis!($Ax5), H> };
 }
 
-/// Concrete implementations of permute for 2-4d tensors. These just call device level permute & inverse permute
+/// Concrete implementations of permute for 2-6d tensors. These just call device level permute & inverse permute
 /// functions.
 #[rustfmt::skip]
 macro_rules! impl_permute {
@@ -80,6 +84,36 @@ PermuteTo<tensor!($Ax0, $Ax1, $Ax2, $Ax3), Axes4<$Ax0, $Ax1, $Ax2, $Ax3>> for te
     }
 }
     };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt) => {
+impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize, H: Tape>
+PermuteTo<tensor!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4), Axes5<$Ax0, $Ax1, $Ax2, $Ax3, $Ax4>> for tensor!(0, 1, 2, 3, 4)
+{
+    fn permute(self) -> tensor!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4) {
+        let mut result: <tensor!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4) as Tensor>::NoTape = TensorCreator::zeros();
+        <Cpu as DevicePermute<_, _, Axes5<$Ax0, $Ax1, $Ax2, $Ax3, $Ax4>>>::permute(self.data(), result.mut_data());
+        move_tape_and_add_backward_op(self, result, move |mut t, result, grads| {
+            let (t_grad, result_grad) = grads.mut_and_ref(&t, &result);
+            <Cpu as DevicePermute<_, _, Axes5<$Ax0, $Ax1, $Ax2, $Ax3, $Ax4>>>::inverse_permute(t.mut_data(), result_grad);
+            Cpu::add(t_grad, t.data());
+        })
+    }
+}
+    };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt) => {
+impl<const M: usize, const N: usize, const O: usize, const P: usize, const Q: usize, const R: usize, H: Tape>
+PermuteTo<tensor!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5), Axes6<$Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5>> for tensor!(0, 1, 2, 3, 4, 5)
+{
+    fn permute(self) -> tensor!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5) {
+        let mut result: <tensor!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5) as Tensor>::NoTape = TensorCreator::zeros();
+        <Cpu as DevicePermute<_, _, Axes6<$Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5>>>::permute(self.data(), result.mut_data());
+        move_tape_and_add_backward_op(self, result, move |mut t, result, grads| {
+            let (t_grad, result_grad) = grads.mut_and_ref(&t, &result);
+            <Cpu as DevicePermute<_, _, Axes6<$Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5>>>::inverse_permute(t.mut_data(), result_grad);
+            Cpu::add(t_grad, t.data());
+        })
+    }
+}
+    };
 }
 
 /// Expands all the possible permutations of 2-4 elements.
@@ -115,11 +149,67 @@ macro_rules! permutations {
         impl_permute!($Ax0, $Ax1, $Ax2, $Ax3);
         impl_permute!($Ax0, $Ax1, $Ax3, $Ax2);
     };
+
+    ([$Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt]) => {
+        permutations!($Ax0, [$Ax1, $Ax2, $Ax3, $Ax4]);
+        permutations!($Ax1, [$Ax0, $Ax2, $Ax3, $Ax4]);
+        permutations!($Ax2, [$Ax0, $Ax1, $Ax3, $Ax4]);
+        permutations!($Ax3, [$Ax0, $Ax1, $Ax2, $Ax4]);
+        permutations!($Ax4, [$Ax0, $Ax1, $Ax2, $Ax3]);
+    };
+    ($Ax0:tt, [$Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt]) => {
+        permutations!($Ax0, $Ax1, [$Ax2, $Ax3, $Ax4]);
+        permutations!($Ax0, $Ax2, [$Ax1, $Ax3, $Ax4]);
+        permutations!($Ax0, $Ax3, [$Ax1, $Ax2, $Ax4]);
+        permutations!($Ax0, $Ax4, [$Ax1, $Ax2, $Ax3]);
+    };
+    ($Ax0:tt, $Ax1:tt, [$Ax2:tt, $Ax3:tt, $Ax4:tt]) => {
+        permutations!($Ax0, $Ax1, $Ax2, [$Ax3, $Ax4]);
+        permutations!($Ax0, $Ax1, $Ax3, [$Ax2, $Ax4]);
+        permutations!($Ax0, $Ax1, $Ax4, [$Ax2, $Ax3]);
+    };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, [$Ax3:tt, $Ax4:tt]) => {
+        impl_permute!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4);
+        impl_permute!($Ax0, $Ax1, $Ax2, $Ax4, $Ax3);
+    };
+
+    ([$Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt]) => {
+        permutations!($Ax0, [$Ax1, $Ax2, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax1, [$Ax0, $Ax2, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax2, [$Ax0, $Ax1, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax3, [$Ax0, $Ax1, $Ax2, $Ax4, $Ax5]);
+        permutations!($Ax4, [$Ax0, $Ax1, $Ax2, $Ax3, $Ax5]);
+        permutations!($Ax5, [$Ax0, $Ax1, $Ax2, $Ax3, $Ax4]);
+    };
+    ($Ax0:tt, [$Ax1:tt, $Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt]) => {
+        permutations!($Ax0, $Ax1, [$Ax2, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax2, [$Ax1, $Ax3, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax3, [$Ax1, $Ax2, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax4, [$Ax1, $Ax2, $Ax3, $Ax5]);
+        permutations!($Ax0, $Ax5, [$Ax1, $Ax2, $Ax3, $Ax4]);
+    };
+    ($Ax0:tt, $Ax1:tt, [$Ax2:tt, $Ax3:tt, $Ax4:tt, $Ax5:tt]) => {
+        permutations!($Ax0, $Ax1, $Ax2, [$Ax3, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax3, [$Ax2, $Ax4, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax4, [$Ax2, $Ax3, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax5, [$Ax2, $Ax3, $Ax4]);
+    };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, [$Ax3:tt, $Ax4:tt, $Ax5:tt]) => {
+        permutations!($Ax0, $Ax1, $Ax2, $Ax3, [$Ax4, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax2, $Ax4, [$Ax3, $Ax5]);
+        permutations!($Ax0, $Ax1, $Ax2, $Ax5, [$Ax3, $Ax4]);
+    };
+    ($Ax0:tt, $Ax1:tt, $Ax2:tt, $Ax3:tt, [$Ax4:tt, $Ax5:tt]) => {
+        impl_permute!($Ax0, $Ax1, $Ax2, $Ax3, $Ax4, $Ax5);
+        impl_permute!($Ax0, $Ax1, $Ax2, $Ax3, $Ax5, $Ax4);
+    };
 }
 
 permutations!([0, 1]);
 permutations!([0, 1, 2]);
 permutations!([0, 1, 2, 3]);
+permutations!([0, 1, 2, 3, 4]);
+permutations!([0, 1, 2, 3, 4, 5]);
 
 #[cfg(test)]
 mod tests {
@@ -162,6 +252,44 @@ mod tests {
                 for k in 0..7 {
                     for l in 0..9 {
                         assert_eq!(r.data()[j][l][i][k], t.data()[i][j][k][l]);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_permute_5d() {
+        let mut rng = thread_rng();
+        let t: Tensor5D<3, 5, 7, 9, 2> = TensorCreator::randn(&mut rng);
+        let r: Tensor5D<5, 9, 2, 3, 7> = t.clone().permute();
+        for i in 0..3 {
+            for j in 0..5 {
+                for k in 0..7 {
+                    for l in 0..9 {
+                        for h in 0..2 {
+                            assert_eq!(r.data()[j][l][h][i][k], t.data()[i][j][k][l][h]);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_permute_6d() {
+        let mut rng = thread_rng();
+        let t: Tensor6D<3, 5, 7, 9, 2, 1> = TensorCreator::randn(&mut rng);
+        let r: Tensor6D<5, 1, 9, 2, 3, 7> = t.clone().permute();
+        for i in 0..3 {
+            for j in 0..5 {
+                for k in 0..7 {
+                    for l in 0..9 {
+                        for h in 0..2 {
+                            for n in 0..1 {
+                                assert_eq!(r.data()[j][n][l][h][i][k], t.data()[i][j][k][l][h][n]);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
fixed #284 - implemented Tensor5D and Tensor6D broadcasting, reduction, permutation and additional tensor_ops. I added tests where I felt it wouldn't harm the readability of the entire file (for example, checking all possible permutations of Tensor6D is 720 lines of code... I assume it's undesired).