### PR TITLE
Adding Unit and HasUnitType. Reducing bounds for Dtype

### DIFF
--- a/src/shapes/mod.rs
+++ b/src/shapes/mod.rs
@@ -18,5 +18,5 @@ pub(crate) use same_numel::HasSameNumelAs;
 
 pub use axes::{Axes2, Axes3, Axes4, Axes5, Axes6, Axis, HasAxes};
 pub use shape::{Const, Dim, Dyn};
-pub use shape::{Dtype, HasDtype};
+pub use shape::{Dtype, HasDtype, HasUnitType, Unit};
 pub use shape::{HasShape, Rank0, Rank1, Rank2, Rank3, Rank4, Rank5, Rank6, Shape};

--- a/src/shapes/shape.rs
+++ b/src/shapes/shape.rs
@@ -1,15 +1,23 @@
 use super::{axes::*, ReduceShapeTo};
 
+/// Represents a unit type, but no arithmetic.
+pub trait Unit:
+    'static + Copy + Clone + Default + std::fmt::Debug + PartialOrd + Send + Sync
+{
+}
+impl Unit for f32 {}
+impl Unit for f64 {}
+impl Unit for usize {}
+impl Unit for bool {}
+
+/// Represents something that has a [Unit].
+pub trait HasUnitType {
+    type Unit: Unit;
+}
+
 /// Represents a data type or element of an array.
 pub trait Dtype:
-    'static
-    + Copy
-    + Clone
-    + Default
-    + std::fmt::Debug
-    + PartialOrd
-    + Send
-    + Sync
+    Unit
     + std::ops::Add<Self, Output = Self>
     + std::ops::Sub<Self, Output = Self>
     + std::ops::Mul<Self, Output = Self>

--- a/src/tensor/cpu/device.rs
+++ b/src/tensor/cpu/device.rs
@@ -1,4 +1,4 @@
-use crate::shapes::{Dtype, HasDtype, HasShape, Shape};
+use crate::shapes::{Dtype, HasDtype, HasShape, HasUnitType, Shape, Unit};
 use crate::tensor::storage_traits::*;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{
@@ -35,8 +35,8 @@ impl Cpu {
 
 /// The storage for the cpu device
 #[derive(Debug, Clone)]
-pub struct StridedArray<S: Shape, Elem> {
-    pub(crate) data: Arc<Vec<Elem>>,
+pub struct StridedArray<S: Shape, E> {
+    pub(crate) data: Arc<Vec<E>>,
     pub(crate) shape: S,
     pub(crate) strides: S::Concrete,
 }
@@ -66,6 +66,10 @@ impl<S: Shape, E> HasShape for StridedArray<S, E> {
     }
 }
 
+impl<S: Shape, E: Unit> HasUnitType for StridedArray<S, E> {
+    type Unit = E;
+}
+
 impl<S: Shape, E: Dtype> HasDtype for StridedArray<S, E> {
     type Dtype = E;
 }
@@ -75,7 +79,7 @@ impl HasErr for Cpu {
 }
 
 impl DeviceStorage for Cpu {
-    type Storage<S: Shape, E: Dtype> = StridedArray<S, E>;
+    type Storage<S: Shape, E: Unit> = StridedArray<S, E>;
 
     fn try_alloc_grad<S: Shape, E: Dtype>(
         &self,

--- a/src/tensor/cpu/index.rs
+++ b/src/tensor/cpu/index.rs
@@ -1,5 +1,5 @@
 use super::device::StridedArray;
-use crate::shapes::{Dtype, Shape};
+use crate::shapes::Shape;
 use std::sync::Arc;
 
 fn index_to_i<S: Shape>(shape: &S, strides: &S::Concrete, index: S::Concrete) -> usize {
@@ -16,7 +16,7 @@ fn index_to_i<S: Shape>(shape: &S, strides: &S::Concrete, index: S::Concrete) ->
         .sum()
 }
 
-impl<S: Shape, E: Dtype> std::ops::Index<S::Concrete> for StridedArray<S, E> {
+impl<S: Shape, E> std::ops::Index<S::Concrete> for StridedArray<S, E> {
     type Output = E;
     #[inline(always)]
     fn index(&self, index: S::Concrete) -> &Self::Output {
@@ -25,7 +25,7 @@ impl<S: Shape, E: Dtype> std::ops::Index<S::Concrete> for StridedArray<S, E> {
     }
 }
 
-impl<S: Shape, E: Dtype> std::ops::IndexMut<S::Concrete> for StridedArray<S, E> {
+impl<S: Shape, E: Clone> std::ops::IndexMut<S::Concrete> for StridedArray<S, E> {
     #[inline(always)]
     fn index_mut(&mut self, index: S::Concrete) -> &mut Self::Output {
         let i = index_to_i(&self.shape, &self.strides, index);

--- a/src/tensor/cpu/iterate.rs
+++ b/src/tensor/cpu/iterate.rs
@@ -1,5 +1,5 @@
 use super::device::StridedArray;
-use crate::shapes::{BroadcastStridesTo, Dtype, Shape};
+use crate::shapes::{BroadcastStridesTo, Shape};
 use std::sync::Arc;
 use std::vec::Vec;
 
@@ -64,57 +64,57 @@ impl<S: Shape> NdIndex<S> {
     }
 }
 
-pub(crate) struct StridedRefIter<'a, S: Shape, Elem> {
-    data: &'a Vec<Elem>,
+pub(crate) struct StridedRefIter<'a, S: Shape, E> {
+    data: &'a Vec<E>,
     index: NdIndex<S>,
 }
 
-pub(crate) struct StridedMutIter<'a, S: Shape, Elem> {
-    data: &'a mut Vec<Elem>,
+pub(crate) struct StridedMutIter<'a, S: Shape, E> {
+    data: &'a mut Vec<E>,
     index: NdIndex<S>,
 }
 
-pub(crate) struct StridedRefIndexIter<'a, S: Shape, Elem> {
-    data: &'a Vec<Elem>,
+pub(crate) struct StridedRefIndexIter<'a, S: Shape, E> {
+    data: &'a Vec<E>,
     index: NdIndex<S>,
 }
 
-pub(crate) struct StridedMutIndexIter<'a, S: Shape, Elem> {
-    data: &'a mut Vec<Elem>,
+pub(crate) struct StridedMutIndexIter<'a, S: Shape, E> {
+    data: &'a mut Vec<E>,
     index: NdIndex<S>,
 }
 
-impl<S: Shape, Elem: Dtype> StridedArray<S, Elem> {
-    pub(crate) fn buf_iter(&self) -> std::slice::Iter<'_, Elem> {
+impl<S: Shape, E: Clone> StridedArray<S, E> {
+    pub(crate) fn buf_iter(&self) -> std::slice::Iter<'_, E> {
         self.data.iter()
     }
 
-    pub(crate) fn buf_iter_mut(&mut self) -> std::slice::IterMut<'_, Elem> {
+    pub(crate) fn buf_iter_mut(&mut self) -> std::slice::IterMut<'_, E> {
         std::sync::Arc::make_mut(&mut self.data).iter_mut()
     }
 
-    pub(crate) fn iter(&self) -> StridedRefIter<S, Elem> {
+    pub(crate) fn iter(&self) -> StridedRefIter<S, E> {
         StridedRefIter {
             data: self.data.as_ref(),
             index: NdIndex::new(self.shape, self.strides),
         }
     }
 
-    pub(crate) fn iter_mut(&mut self) -> StridedMutIter<S, Elem> {
+    pub(crate) fn iter_mut(&mut self) -> StridedMutIter<S, E> {
         StridedMutIter {
             data: std::sync::Arc::make_mut(&mut self.data),
             index: NdIndex::new(self.shape, self.strides),
         }
     }
 
-    pub(crate) fn iter_with_index(&self) -> StridedRefIndexIter<S, Elem> {
+    pub(crate) fn iter_with_index(&self) -> StridedRefIndexIter<S, E> {
         StridedRefIndexIter {
             data: self.data.as_ref(),
             index: NdIndex::new(self.shape, self.strides),
         }
     }
 
-    pub(crate) fn iter_mut_with_index(&mut self) -> StridedMutIndexIter<S, Elem> {
+    pub(crate) fn iter_mut_with_index(&mut self) -> StridedMutIndexIter<S, E> {
         StridedMutIndexIter {
             data: std::sync::Arc::make_mut(&mut self.data),
             index: NdIndex::new(self.shape, self.strides),
@@ -122,8 +122,8 @@ impl<S: Shape, Elem: Dtype> StridedArray<S, Elem> {
     }
 }
 
-impl<S: Shape, Elem: Dtype> StridedArray<S, Elem> {
-    pub(crate) fn iter_as<Axes, Dst: Shape>(&self, dst: &Dst) -> StridedRefIter<Dst, Elem>
+impl<S: Shape, E: Clone> StridedArray<S, E> {
+    pub(crate) fn iter_as<Axes, Dst: Shape>(&self, dst: &Dst) -> StridedRefIter<Dst, E>
     where
         S: BroadcastStridesTo<Dst, Axes>,
     {
@@ -133,7 +133,7 @@ impl<S: Shape, Elem: Dtype> StridedArray<S, Elem> {
         }
     }
 
-    pub(crate) fn iter_mut_as<Axes, Dst: Shape>(&mut self, dst: &Dst) -> StridedMutIter<Dst, Elem>
+    pub(crate) fn iter_mut_as<Axes, Dst: Shape>(&mut self, dst: &Dst) -> StridedMutIter<Dst, E>
     where
         S: BroadcastStridesTo<Dst, Axes>,
     {

--- a/src/tensor/cpu/views.rs
+++ b/src/tensor/cpu/views.rs
@@ -1,16 +1,16 @@
 #![allow(dead_code)]
 
 use super::StridedArray;
-use crate::shapes::{Const, Dim, Dtype, Shape};
+use crate::shapes::{Const, Dim, Shape};
 
 #[derive(Clone, Copy)]
-pub(crate) struct View<'a, S: Shape, E: Dtype> {
+pub(crate) struct View<'a, S: Shape, E> {
     pub(crate) data: &'a [E],
     pub(crate) shape: S,
     pub(crate) strides: S::Concrete,
 }
 
-impl<'a, S: Shape, E: Dtype> View<'a, S, E> {
+impl<'a, S: Shape, E> View<'a, S, E> {
     #[inline(always)]
     pub(crate) fn new(data: &'a [E], shape: S) -> Self {
         Self {
@@ -26,13 +26,13 @@ impl<'a, S: Shape, E: Dtype> View<'a, S, E> {
     }
 }
 
-pub(crate) struct ViewMut<'a, S: Shape, E: Dtype> {
+pub(crate) struct ViewMut<'a, S: Shape, E> {
     pub(crate) data: &'a mut [E],
     pub(crate) shape: S,
     pub(crate) strides: S::Concrete,
 }
 
-impl<'a, S: Shape, E: Dtype> ViewMut<'a, S, E> {
+impl<'a, S: Shape, E> ViewMut<'a, S, E> {
     #[inline(always)]
     pub(crate) fn new(data: &'a mut [E], shape: S) -> Self {
         Self {
@@ -48,7 +48,7 @@ impl<'a, S: Shape, E: Dtype> ViewMut<'a, S, E> {
     }
 }
 
-impl<S: Shape, E: Dtype> StridedArray<S, E> {
+impl<S: Shape, E> StridedArray<S, E> {
     #[inline(always)]
     pub(crate) fn view(&self) -> View<S, E> {
         View {
@@ -57,7 +57,9 @@ impl<S: Shape, E: Dtype> StridedArray<S, E> {
             strides: self.strides,
         }
     }
+}
 
+impl<S: Shape, E: Clone> StridedArray<S, E> {
     #[inline(always)]
     pub(crate) fn view_mut(&mut self) -> ViewMut<S, E> {
         ViewMut {
@@ -68,7 +70,7 @@ impl<S: Shape, E: Dtype> StridedArray<S, E> {
     }
 }
 
-impl<'a, D1: Dim, E: Dtype> View<'a, (D1,), E> {
+impl<'a, D1: Dim, E> View<'a, (D1,), E> {
     #[inline(always)]
     pub(crate) fn br0(self) -> View<'a, (Const<1>, D1), E> {
         View {
@@ -87,7 +89,7 @@ impl<'a, D1: Dim, E: Dtype> View<'a, (D1,), E> {
     }
 }
 
-impl<'a, D1: Dim, E: Dtype> ViewMut<'a, (D1,), E> {
+impl<'a, D1: Dim, E> ViewMut<'a, (D1,), E> {
     #[inline(always)]
     pub(crate) fn br0(self) -> ViewMut<'a, (Const<1>, D1), E> {
         ViewMut {
@@ -106,7 +108,7 @@ impl<'a, D1: Dim, E: Dtype> ViewMut<'a, (D1,), E> {
     }
 }
 
-impl<'a, D1: Dim, D2: Dim, E: Dtype> View<'a, (D1, D2), E> {
+impl<'a, D1: Dim, D2: Dim, E> View<'a, (D1, D2), E> {
     #[inline(always)]
     pub(crate) fn tr(self) -> View<'a, (D2, D1), E> {
         View {
@@ -117,20 +119,20 @@ impl<'a, D1: Dim, D2: Dim, E: Dtype> View<'a, (D1, D2), E> {
     }
 }
 
-impl<'a, D1: Dim, E: Dtype> View<'a, (D1,), E> {
+impl<'a, D1: Dim, E> View<'a, (D1,), E> {
     #[inline(always)]
     pub(crate) fn idx(&'a self, index: usize) -> &'a E {
         &self.data[index * self.strides[0]]
     }
 }
-impl<'a, D1: Dim, E: Dtype> ViewMut<'a, (D1,), E> {
+impl<'a, D1: Dim, E> ViewMut<'a, (D1,), E> {
     #[inline(always)]
     pub(crate) fn idx_mut(&'a mut self, index: usize) -> &'a mut E {
         &mut self.data[index * self.strides[0]]
     }
 }
 
-impl<'a, D1: Dim, D2: Dim, E: Dtype> View<'a, (D1, D2), E> {
+impl<'a, D1: Dim, D2: Dim, E> View<'a, (D1, D2), E> {
     #[inline(always)]
     pub(crate) fn idx<'b>(&'b self, index: usize) -> View<'b, (D2,), E>
     where
@@ -144,7 +146,7 @@ impl<'a, D1: Dim, D2: Dim, E: Dtype> View<'a, (D1, D2), E> {
     }
 }
 
-impl<'a, D1: Dim, D2: Dim, E: Dtype> ViewMut<'a, (D1, D2), E> {
+impl<'a, D1: Dim, D2: Dim, E> ViewMut<'a, (D1, D2), E> {
     #[inline(always)]
     pub(crate) fn idx_mut<'b>(&'b mut self, index: usize) -> ViewMut<'b, (D2,), E>
     where
@@ -158,7 +160,7 @@ impl<'a, D1: Dim, D2: Dim, E: Dtype> ViewMut<'a, (D1, D2), E> {
     }
 }
 
-impl<'a, D1: Dim, D2: Dim, D3: Dim, E: Dtype> View<'a, (D1, D2, D3), E> {
+impl<'a, D1: Dim, D2: Dim, D3: Dim, E> View<'a, (D1, D2, D3), E> {
     #[inline(always)]
     pub(crate) fn idx<'b>(&'b self, index: usize) -> View<'b, (D2, D3), E>
     where
@@ -172,7 +174,7 @@ impl<'a, D1: Dim, D2: Dim, D3: Dim, E: Dtype> View<'a, (D1, D2, D3), E> {
     }
 }
 
-impl<'a, D1: Dim, D2: Dim, D3: Dim, E: Dtype> ViewMut<'a, (D1, D2, D3), E> {
+impl<'a, D1: Dim, D2: Dim, D3: Dim, E> ViewMut<'a, (D1, D2, D3), E> {
     #[inline(always)]
     pub(crate) fn idx_mut<'b>(&'b mut self, index: usize) -> ViewMut<'b, (D2, D3), E>
     where
@@ -186,7 +188,7 @@ impl<'a, D1: Dim, D2: Dim, D3: Dim, E: Dtype> ViewMut<'a, (D1, D2, D3), E> {
     }
 }
 
-impl<'a, D1: Dim, D2: Dim, D3: Dim, D4: Dim, E: Dtype> View<'a, (D1, D2, D3, D4), E> {
+impl<'a, D1: Dim, D2: Dim, D3: Dim, D4: Dim, E> View<'a, (D1, D2, D3, D4), E> {
     #[inline(always)]
     pub(crate) fn idx<'b>(&'b self, index: usize) -> View<'b, (D2, D3, D4), E>
     where
@@ -200,7 +202,7 @@ impl<'a, D1: Dim, D2: Dim, D3: Dim, D4: Dim, E: Dtype> View<'a, (D1, D2, D3, D4)
     }
 }
 
-impl<'a, D1: Dim, D2: Dim, D3: Dim, D4: Dim, E: Dtype> ViewMut<'a, (D1, D2, D3, D4), E> {
+impl<'a, D1: Dim, D2: Dim, D3: Dim, D4: Dim, E> ViewMut<'a, (D1, D2, D3, D4), E> {
     #[inline(always)]
     pub(crate) fn idx_mut<'b>(&'b mut self, index: usize) -> ViewMut<'b, (D2, D3, D4), E>
     where
@@ -214,7 +216,7 @@ impl<'a, D1: Dim, D2: Dim, D3: Dim, D4: Dim, E: Dtype> ViewMut<'a, (D1, D2, D3, 
     }
 }
 
-impl<'a, D1: Dim, D2: Dim, D3: Dim, D4: Dim, D5: Dim, E: Dtype> View<'a, (D1, D2, D3, D4, D5), E> {
+impl<'a, D1: Dim, D2: Dim, D3: Dim, D4: Dim, D5: Dim, E> View<'a, (D1, D2, D3, D4, D5), E> {
     #[inline(always)]
     pub(crate) fn idx<'b>(&'b self, index: usize) -> View<'b, (D2, D3, D4, D5), E>
     where
@@ -233,9 +235,7 @@ impl<'a, D1: Dim, D2: Dim, D3: Dim, D4: Dim, D5: Dim, E: Dtype> View<'a, (D1, D2
     }
 }
 
-impl<'a, D1: Dim, D2: Dim, D3: Dim, D4: Dim, D5: Dim, E: Dtype>
-    ViewMut<'a, (D1, D2, D3, D4, D5), E>
-{
+impl<'a, D1: Dim, D2: Dim, D3: Dim, D4: Dim, D5: Dim, E> ViewMut<'a, (D1, D2, D3, D4, D5), E> {
     #[inline(always)]
     pub(crate) fn idx_mut<'b>(&'b mut self, index: usize) -> ViewMut<'b, (D2, D3, D4, D5), E>
     where

--- a/src/tensor/tensor_impls.rs
+++ b/src/tensor/tensor_impls.rs
@@ -30,7 +30,7 @@ use crate::{
 /// type C = Tensor<Rank3<4, 2, 3>, usize, Cpu, NoneTape>;
 /// ```
 #[derive(Debug, Clone)]
-pub struct Tensor<S: Shape, E: Dtype, D: DeviceStorage = Cpu, T = NoneTape> {
+pub struct Tensor<S: Shape, E: Unit, D: DeviceStorage = Cpu, T = NoneTape> {
     pub(crate) id: UniqueId,
     pub(crate) storage: D::Storage<S, E>,
     pub(crate) device: D,
@@ -43,6 +43,10 @@ impl<S: Shape, E: Dtype, D: DeviceStorage, T> HasShape for Tensor<S, E, D, T> {
     fn shape(&self) -> &Self::Shape {
         self.storage.shape()
     }
+}
+
+impl<S: Shape, E: Unit, D: DeviceStorage, T> HasUnitType for Tensor<S, E, D, T> {
+    type Unit = E;
 }
 
 impl<S: Shape, E: Dtype, D: DeviceStorage, T> HasDtype for Tensor<S, E, D, T> {


### PR DESCRIPTION
Needed for #306 - Right now Dtype requires Add/Sub/etc, but you can't do that for bool.

Therefore this is adding an intermediate trait `Unit` which doesn't have arithmetic traits implemented. Tensors can be created with `Unit` type, but you can't track gradients with `Unit`