### PR TITLE
Add cuda implementations for unary and binary tensor operations in #341 and #334

### DIFF
--- a/src/tensor_ops/abs/abs.cu
+++ b/src/tensor_ops/abs/abs.cu
@@ -25,6 +25,6 @@ extern "C" __global__ void abs_backward(
         return;
     }
     // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
+    float dx = inp[i] == 0.0 ? 0.0 : copysignf(1.0, inp[i]);
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/abs/abs.cu
+++ b/src/tensor_ops/abs/abs.cu
@@ -10,7 +10,7 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = fabsf(inp[i]);
 }
 
 extern "C" __global__ void abs_backward(

--- a/src/tensor_ops/add/binary_add.cu
+++ b/src/tensor_ops/add/binary_add.cu
@@ -1,4 +1,4 @@
-struct BinaryDivOp {};
+struct BinaryAddOp {};
 
 __device__ unsigned int get_strided_index(
     unsigned int idx,
@@ -15,8 +15,8 @@ __device__ unsigned int get_strided_index(
     return strided_i;
 }
 
-extern "C" __global__ void binary_div_forward(
-    const BinaryDivOp op,
+extern "C" __global__ void binary_add_forward(
+    const BinaryAddOp op,
     const size_t numel,
     const size_t num_dims,
     const size_t *dims,
@@ -36,11 +36,11 @@ extern "C" __global__ void binary_div_forward(
     unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
     unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
 
-    out[out_i] = lhs[lhs_i] / rhs[rhs_i];
+    out[out_i] = lhs[lhs_i] + rhs[rhs_i];
 }
 
-extern "C" __global__ void binary_div_backward(
-    const BinaryDivOp op,
+extern "C" __global__ void binary_add_backward(
+    const BinaryAddOp op,
     const size_t numel,
     const size_t num_dims,
     const size_t *dims,
@@ -66,9 +66,9 @@ extern "C" __global__ void binary_div_backward(
     auto y = rhs[rhs_i];
     auto go = grad_out[out_i];
 
-    float dfdx = 1.0 / y;
+    float dfdx = 1.0;
     grad_lhs[lhs_i] += dfdx * go;
 
-    float dfdy = -x / (y * y);
+    float dfdy = 1.0;
     grad_rhs[rhs_i] += dfdy * go;
 }

--- a/src/tensor_ops/add/cuda_kernel.rs
+++ b/src/tensor_ops/add/cuda_kernel.rs
@@ -1,46 +1,18 @@
-use crate::{
-    shapes::Shape,
-    tensor::Cuda,
-    tensor_ops::ops::{BinaryKernel, UnaryKernel},
-};
+use crate::tensor_ops::cuda_kernels::{BinaryOpCudaKernel, UnaryOpCudaKernel};
 
-impl UnaryKernel<super::ScalarAddKernelOp<f32>, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::ScalarAddKernelOp<f32>,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::ScalarAddKernelOp<f32>,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::ScalarAddKernelOp<f32> {}
+unsafe impl cudarc::device::AsKernelParam for super::BinaryAddKernelOp {}
+
+impl UnaryOpCudaKernel for super::ScalarAddKernelOp<f32> {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/scalar_add.ptx"));
+    const MODULE_NAME: &'static str = "scalar_add";
+    const FWD_FN_NAME: &'static str = "scalar_add_forward";
+    const BWD_FN_NAME: &'static str = "scalar_add_backward";
 }
 
-impl BinaryKernel<super::BinaryAddKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::BinaryAddKernelOp,
-        lhs: &Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::BinaryAddKernelOp,
-        lhs: &Self::Storage<S, f32>,
-        grad_lhs: &mut Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-        grad_rhs: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+impl BinaryOpCudaKernel for super::BinaryAddKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/binary_add.ptx"));
+    const MODULE_NAME: &'static str = "binary_add";
+    const FWD_FN_NAME: &'static str = "binary_add_forward";
+    const BWD_FN_NAME: &'static str = "binary_add_backward";
 }

--- a/src/tensor_ops/add/scalar_add.cu
+++ b/src/tensor_ops/add/scalar_add.cu
@@ -1,7 +1,9 @@
-struct AbsKernelOp {};
+struct ScalarAddKernelOp {
+    float scalar;
+};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void scalar_add_forward(
+    const ScalarAddKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +12,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = inp[i] + op.scalar;
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void scalar_add_backward(
+    const ScalarAddKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +26,6 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
-    grad_inp[i] += dx * grad_out[i];
+    float df = 1.0;
+    grad_inp[i] += df * grad_out[i];
 }

--- a/src/tensor_ops/bce/bce.cu
+++ b/src/tensor_ops/bce/bce.cu
@@ -1,4 +1,4 @@
-struct BinaryDivOp {};
+struct BCEKernelOp {};
 
 __device__ unsigned int get_strided_index(
     unsigned int idx,
@@ -15,8 +15,8 @@ __device__ unsigned int get_strided_index(
     return strided_i;
 }
 
-extern "C" __global__ void binary_div_forward(
-    const BinaryDivOp op,
+extern "C" __global__ void bce_forward(
+    const BCEKernelOp op,
     const size_t numel,
     const size_t num_dims,
     const size_t *dims,
@@ -36,11 +36,14 @@ extern "C" __global__ void binary_div_forward(
     unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
     unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
 
-    out[out_i] = lhs[lhs_i] / rhs[rhs_i];
+    float logit = lhs[lhs_i];
+    float prob = rhs[rhs_i];
+
+    out[out_i] = max(logit, 0.0) - logit * prob + logf(1.0 + expf(-abs(logit)));
 }
 
-extern "C" __global__ void binary_div_backward(
-    const BinaryDivOp op,
+extern "C" __global__ void bce_backward(
+    const BCEKernelOp op,
     const size_t numel,
     const size_t num_dims,
     const size_t *dims,
@@ -62,13 +65,13 @@ extern "C" __global__ void binary_div_backward(
     unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
     unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
 
-    auto x = lhs[lhs_i];
-    auto y = rhs[rhs_i];
+    auto logit = lhs[lhs_i];
+    auto prob = rhs[rhs_i];
     auto go = grad_out[out_i];
 
-    float dfdx = 1.0 / y;
+    float dfdx = 1.0 - prob - 1 / (1.0 + expf(logit));
     grad_lhs[lhs_i] += dfdx * go;
 
-    float dfdy = -x / (y * y);
+    float dfdy = -logit;
     grad_rhs[rhs_i] += dfdy * go;
 }

--- a/src/tensor_ops/bce/bce.cu
+++ b/src/tensor_ops/bce/bce.cu
@@ -39,7 +39,7 @@ extern "C" __global__ void bce_forward(
     float logit = lhs[lhs_i];
     float prob = rhs[rhs_i];
 
-    out[out_i] = max(logit, 0.0) - logit * prob + logf(1.0 + expf(-abs(logit)));
+    out[out_i] = fmaxf(logit, 0.0) - logit * prob + logf(1.0 + expf(-fabsf(logit)));
 }
 
 extern "C" __global__ void bce_backward(

--- a/src/tensor_ops/bce/cuda_kernel.rs
+++ b/src/tensor_ops/bce/cuda_kernel.rs
@@ -1,23 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::BinaryKernel};
+use crate::tensor_ops::cuda_kernels::BinaryOpCudaKernel;
 
-impl BinaryKernel<super::BCEKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::BCEKernelOp,
-        lhs: &Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::BCEKernelOp,
-        lhs: &Self::Storage<S, f32>,
-        grad_lhs: &mut Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-        grad_rhs: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::BCEKernelOp {}
+
+impl BinaryOpCudaKernel for super::BCEKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/bce.ptx"));
+    const MODULE_NAME: &'static str = "bce";
+    const FWD_FN_NAME: &'static str = "bce_forward";
+    const BWD_FN_NAME: &'static str = "bce_backward";
 }

--- a/src/tensor_ops/clamp/clamp.cu
+++ b/src/tensor_ops/clamp/clamp.cu
@@ -1,7 +1,10 @@
-struct AbsKernelOp {};
+struct ClampKernelOp {
+    float min;
+    float max;
+};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void clamp_forward(
+    const ClampKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +13,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = max(min(inp[i], op.max), op.min);
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void clamp_backward(
+    const ClampKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +27,6 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
+    float dx = inp[i] <= op.max && inp[i] >= op.min ? 1.0 : 0.0;
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/clamp/clamp.cu
+++ b/src/tensor_ops/clamp/clamp.cu
@@ -13,7 +13,7 @@ extern "C" __global__ void clamp_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = max(min(inp[i], op.max), op.min);
+    out[i] = fmaxf(fminf(inp[i], op.max), op.min);
 }
 
 extern "C" __global__ void clamp_backward(

--- a/src/tensor_ops/clamp/cuda_kernel.rs
+++ b/src/tensor_ops/clamp/cuda_kernel.rs
@@ -1,20 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::UnaryKernel};
+use crate::tensor_ops::cuda_kernels::UnaryOpCudaKernel;
 
-impl UnaryKernel<super::ClampKernelOp<f32>, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::ClampKernelOp<f32>,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::ClampKernelOp<f32>,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::ClampKernelOp<f32> {}
+
+impl UnaryOpCudaKernel for super::ClampKernelOp<f32> {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/clamp.ptx"));
+    const MODULE_NAME: &'static str = "clamp";
+    const FWD_FN_NAME: &'static str = "clamp_forward";
+    const BWD_FN_NAME: &'static str = "clamp_backward";
 }

--- a/src/tensor_ops/clamp/mod.rs
+++ b/src/tensor_ops/clamp/mod.rs
@@ -43,18 +43,18 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<ClampKernelOp<E>, E>, T: Tape<D>> Tensor
 
 #[cfg(test)]
 mod tests {
-    use crate::{tensor::*, tensor_ops::*, tests::TestDevice};
+    use crate::{tensor::*, tensor_ops::*, tests::*};
 
     #[test]
     fn test_clamp() {
         let dev: TestDevice = Default::default();
         let t = dev.tensor([[-1.0, 0.0, 1.0], [-2.0, 2.0, 1.1]]);
         let r = t.trace().clamp(-1.0, 1.0);
-        assert_eq!(r.array(), [[-1.0, 0.0, 1.0], [-1.0, 1.0, 1.0]]);
+        assert_close(&r.array(), &[[-1.0, 0.0, 1.0], [-1.0, 1.0, 1.0]]);
         let g = r.exp().mean().backward();
-        assert_eq!(
-            g.get(&t).array(),
-            [[0.06131324, 0.16666667, 0.45304698], [0.0; 3]]
+        assert_close(
+            &g.get(&t).array(),
+            &[[0.06131324, 0.16666667, 0.45304698], [0.0; 3]]
         );
     }
 }

--- a/src/tensor_ops/cos/cos.cu
+++ b/src/tensor_ops/cos/cos.cu
@@ -1,7 +1,7 @@
-struct AbsKernelOp {};
+struct CosKernelOp {};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void cos_forward(
+    const CosKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +10,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = cosf(inp[i]);
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void cos_backward(
+    const CosKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +24,6 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
+    float dx = -sinf(inp[i]);
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/cos/cuda_kernel.rs
+++ b/src/tensor_ops/cos/cuda_kernel.rs
@@ -1,20 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::UnaryKernel};
+use crate::tensor_ops::cuda_kernels::UnaryOpCudaKernel;
 
-impl UnaryKernel<super::CosKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::CosKernelOp,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::CosKernelOp,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::CosKernelOp {}
+
+impl UnaryOpCudaKernel for super::CosKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/cos.ptx"));
+    const MODULE_NAME: &'static str = "cos";
+    const FWD_FN_NAME: &'static str = "cos_forward";
+    const BWD_FN_NAME: &'static str = "cos_backward";
 }

--- a/src/tensor_ops/cuda_kernels.rs
+++ b/src/tensor_ops/cuda_kernels.rs
@@ -91,10 +91,10 @@ pub trait BinaryOpCudaKernel {
     const ALL_FN_NAMES: [&'static str; 2] = [Self::FWD_FN_NAME, Self::BWD_FN_NAME];
 }
 
-impl<K: BinaryOpCudaKernel> BinaryKernel<K, f32> for Cuda {
+impl<K: BinaryOpCudaKernel + AsKernelParam> BinaryKernel<K, f32> for Cuda {
     fn forward<S: Shape>(
         &self,
-        _: K,
+        op: K,
         lhs: &Self::Storage<S, f32>,
         rhs: &Self::Storage<S, f32>,
     ) -> Result<Self::Storage<S, f32>, Self::Err> {
@@ -117,6 +117,7 @@ impl<K: BinaryOpCudaKernel> BinaryKernel<K, f32> for Cuda {
         let fwd_fn = self.dev.get_func(K::MODULE_NAME, K::FWD_FN_NAME).unwrap();
         let cfg = LaunchConfig::for_num_elems(numel as u32);
         let params = (
+            op,
             numel,             // const size_t numel,
             S::NUM_DIMS,       // const size_t num_dims,
             &dims,             // const size_t *dims,
@@ -137,7 +138,7 @@ impl<K: BinaryOpCudaKernel> BinaryKernel<K, f32> for Cuda {
 
     fn backward<S: Shape>(
         &self,
-        _: K,
+        op: K,
         lhs: &Self::Storage<S, f32>,
         grad_lhs: &mut Self::Storage<S, f32>,
         rhs: &Self::Storage<S, f32>,
@@ -154,6 +155,7 @@ impl<K: BinaryOpCudaKernel> BinaryKernel<K, f32> for Cuda {
 
         let cfg = LaunchConfig::for_num_elems(numel as u32);
         let params = (
+            op,
             numel,                             // const size_t numel,
             S::NUM_DIMS,                       // const size_t num_dims,
             &dims,                             // const size_t *dims,

--- a/src/tensor_ops/div/cuda_kernel.rs
+++ b/src/tensor_ops/div/cuda_kernel.rs
@@ -1,6 +1,7 @@
 use crate::tensor_ops::cuda_kernels::{BinaryOpCudaKernel, UnaryOpCudaKernel};
 
 unsafe impl cudarc::device::AsKernelParam for super::ScalarDivKernelOp<f32> {}
+unsafe impl cudarc::device::AsKernelParam for super::BinaryDivKernelOp {}
 
 impl UnaryOpCudaKernel for super::ScalarDivKernelOp<f32> {
     const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/scalar_div.ptx"));

--- a/src/tensor_ops/exp/exp.cu
+++ b/src/tensor_ops/exp/exp.cu
@@ -10,7 +10,7 @@ extern "C" __global__ void exp_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = exp(inp[i]);
+    out[i] = expf(inp[i]);
 }
 
 extern "C" __global__ void exp_backward(
@@ -24,5 +24,5 @@ extern "C" __global__ void exp_backward(
     if (i >= numel) {
         return;
     }
-    grad_inp[i] += exp(inp[i]) * grad_out[i];
+    grad_inp[i] += expf(inp[i]) * grad_out[i];
 }

--- a/src/tensor_ops/huber_error/cuda_kernel.rs
+++ b/src/tensor_ops/huber_error/cuda_kernel.rs
@@ -1,23 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::BinaryKernel};
+use crate::tensor_ops::cuda_kernels::BinaryOpCudaKernel;
 
-impl BinaryKernel<super::HuberErrorKernelOp<f32>, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::HuberErrorKernelOp<f32>,
-        lhs: &Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::HuberErrorKernelOp<f32>,
-        lhs: &Self::Storage<S, f32>,
-        grad_lhs: &mut Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-        grad_rhs: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::HuberErrorKernelOp<f32> {}
+
+impl BinaryOpCudaKernel for super::HuberErrorKernelOp<f32> {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/huber_error.ptx"));
+    const MODULE_NAME: &'static str = "huber_error";
+    const FWD_FN_NAME: &'static str = "huber_error_forward";
+    const BWD_FN_NAME: &'static str = "huber_error_backward";
 }

--- a/src/tensor_ops/huber_error/huber_error.cu
+++ b/src/tensor_ops/huber_error/huber_error.cu
@@ -40,10 +40,10 @@ extern "C" __global__ void huber_error_forward(
 
     float a = lhs[lhs_i] - rhs[rhs_i];
 
-    if (abs(a) < op.delta) {
+    if (fabsf(a) < op.delta) {
         out[out_i] = a * a * 0.5;
     } else {
-        out[out_i] = op.delta * (abs(a) - 0.5 * op.delta);
+        out[out_i] = op.delta * (fabsf(a) - 0.5 * op.delta);
     }
 }
 
@@ -77,10 +77,10 @@ extern "C" __global__ void huber_error_backward(
 
     if (a == 0.0) {
         dfdx = 0.0;
-    } else if (abs(a) < op.delta) {
+    } else if (fabsf(a) < op.delta) {
         dfdx = a;
     } else {
-        dfdx = copysign(op.delta, a);
+        dfdx = copysignf(op.delta, a);
     }
 
     dfdy = -dfdx;

--- a/src/tensor_ops/huber_error/mod.rs
+++ b/src/tensor_ops/huber_error/mod.rs
@@ -56,3 +56,34 @@ impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<D>> Tensor<S, E, D, T> {
         try_binary_op(HuberErrorKernelOp { delta }, self, rhs)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        tensor::*,
+        tests::{assert_close, TestDevice},
+    };
+
+    #[test]
+    fn test_huber_error() {
+        let dev: TestDevice = Default::default();
+        let a = dev.tensor([
+            [-0.84240317, 0.63094819, 1.04164326],
+            [1.32522500, 0.58402753, 1.91676331],
+        ]);
+        let b = dev.tensor([
+            [0.52022195, 0.57880402, 0.17535722],
+            [0.75429636, 0.66566986, 0.61827511],
+        ]);
+        let r1 = a.trace().huber_error(b.trace(), 1.0);
+        let r2 = a.trace().huber_error(b.trace(), 100.0);
+        assert_close(
+            &r1.array(),
+            &[
+                [0.8626251, 0.0013595072, 0.37522575],
+                [0.16297975, 0.003332735, 0.79848814]
+            ],
+        );
+        assert_close(&r2.array(), &((a.clone() - b.clone()).square() / 2.0).array());
+    }
+}

--- a/src/tensor_ops/ln/cuda_kernel.rs
+++ b/src/tensor_ops/ln/cuda_kernel.rs
@@ -1,20 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::UnaryKernel};
+use crate::tensor_ops::cuda_kernels::UnaryOpCudaKernel;
 
-impl UnaryKernel<super::LnKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::LnKernelOp,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::LnKernelOp,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::LnKernelOp {}
+
+impl UnaryOpCudaKernel for super::LnKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/ln.ptx"));
+    const MODULE_NAME: &'static str = "ln";
+    const FWD_FN_NAME: &'static str = "ln_forward";
+    const BWD_FN_NAME: &'static str = "ln_backward";
 }

--- a/src/tensor_ops/ln/ln.cu
+++ b/src/tensor_ops/ln/ln.cu
@@ -1,7 +1,7 @@
-struct AbsKernelOp {};
+struct LnKernelOp {};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void ln_forward(
+    const LnKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +10,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = logf(inp[i]);
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void ln_backward(
+    const LnKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +24,6 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
+    float dx = 1.0 / inp[i];
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/maximum/cuda_kernel.rs
+++ b/src/tensor_ops/maximum/cuda_kernel.rs
@@ -1,23 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::BinaryKernel};
+use crate::tensor_ops::cuda_kernels::BinaryOpCudaKernel;
 
-impl BinaryKernel<super::MaximumKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::MaximumKernelOp,
-        lhs: &Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::MaximumKernelOp,
-        lhs: &Self::Storage<S, f32>,
-        grad_lhs: &mut Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-        grad_rhs: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::MaximumKernelOp {}
+
+impl BinaryOpCudaKernel for super::MaximumKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/maximum.ptx"));
+    const MODULE_NAME: &'static str = "maximum";
+    const FWD_FN_NAME: &'static str = "maximum_forward";
+    const BWD_FN_NAME: &'static str = "maximum_backward";
 }

--- a/src/tensor_ops/maximum/maximum.cu
+++ b/src/tensor_ops/maximum/maximum.cu
@@ -36,7 +36,7 @@ extern "C" __global__ void maximum_forward(
     unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
     unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
 
-    out[out_i] = max(lhs[lhs_i], rhs[rhs_i]);
+    out[out_i] = fmaxf(lhs[lhs_i], rhs[rhs_i]);
 }
 
 extern "C" __global__ void maximum_backward(

--- a/src/tensor_ops/maximum/maximum.cu
+++ b/src/tensor_ops/maximum/maximum.cu
@@ -1,4 +1,4 @@
-struct BinaryDivOp {};
+struct MaximumKernalOp {};
 
 __device__ unsigned int get_strided_index(
     unsigned int idx,
@@ -15,8 +15,8 @@ __device__ unsigned int get_strided_index(
     return strided_i;
 }
 
-extern "C" __global__ void binary_div_forward(
-    const BinaryDivOp op,
+extern "C" __global__ void maximum_forward(
+    const MaximumKernalOp op,
     const size_t numel,
     const size_t num_dims,
     const size_t *dims,
@@ -36,11 +36,11 @@ extern "C" __global__ void binary_div_forward(
     unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
     unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
 
-    out[out_i] = lhs[lhs_i] / rhs[rhs_i];
+    out[out_i] = max(lhs[lhs_i], rhs[rhs_i]);
 }
 
-extern "C" __global__ void binary_div_backward(
-    const BinaryDivOp op,
+extern "C" __global__ void maximum_backward(
+    const MaximumKernalOp op,
     const size_t numel,
     const size_t num_dims,
     const size_t *dims,
@@ -66,9 +66,19 @@ extern "C" __global__ void binary_div_backward(
     auto y = rhs[rhs_i];
     auto go = grad_out[out_i];
 
-    float dfdx = 1.0 / y;
-    grad_lhs[lhs_i] += dfdx * go;
+    float dfdx, dfdy;
 
-    float dfdy = -x / (y * y);
+    if (x > y) {
+        dfdx = 1.0;
+        dfdy = 0.0;
+    } else if (x < y) {
+        dfdx = 0.0;
+        dfdy = 1.0;
+    } else {
+        dfdx = 0.5;
+        dfdy = 0.5;
+    }
+
+    grad_lhs[lhs_i] += dfdx * go;
     grad_rhs[rhs_i] += dfdy * go;
 }

--- a/src/tensor_ops/minimum/cuda_kernel.rs
+++ b/src/tensor_ops/minimum/cuda_kernel.rs
@@ -1,23 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::BinaryKernel};
+use crate::tensor_ops::cuda_kernels::BinaryOpCudaKernel;
 
-impl BinaryKernel<super::MinimumKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::MinimumKernelOp,
-        lhs: &Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::MinimumKernelOp,
-        lhs: &Self::Storage<S, f32>,
-        grad_lhs: &mut Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-        grad_rhs: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::MinimumKernelOp {}
+
+impl BinaryOpCudaKernel for super::MinimumKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/minimum.ptx"));
+    const MODULE_NAME: &'static str = "minimum";
+    const FWD_FN_NAME: &'static str = "minimum_forward";
+    const BWD_FN_NAME: &'static str = "minimum_backward";
 }

--- a/src/tensor_ops/minimum/minimum.cu
+++ b/src/tensor_ops/minimum/minimum.cu
@@ -36,7 +36,7 @@ extern "C" __global__ void minimum_forward(
     unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
     unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
 
-    out[out_i] = min(lhs[lhs_i], rhs[rhs_i]);
+    out[out_i] = fminf(lhs[lhs_i], rhs[rhs_i]);
 }
 
 extern "C" __global__ void minimum_backward(

--- a/src/tensor_ops/minimum/minimum.cu
+++ b/src/tensor_ops/minimum/minimum.cu
@@ -1,4 +1,4 @@
-struct BinaryDivOp {};
+struct MinimumKernelOp {};
 
 __device__ unsigned int get_strided_index(
     unsigned int idx,
@@ -15,8 +15,8 @@ __device__ unsigned int get_strided_index(
     return strided_i;
 }
 
-extern "C" __global__ void binary_div_forward(
-    const BinaryDivOp op,
+extern "C" __global__ void minimum_forward(
+    const MinimumKernelOp op,
     const size_t numel,
     const size_t num_dims,
     const size_t *dims,
@@ -36,11 +36,11 @@ extern "C" __global__ void binary_div_forward(
     unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
     unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
 
-    out[out_i] = lhs[lhs_i] / rhs[rhs_i];
+    out[out_i] = min(lhs[lhs_i], rhs[rhs_i]);
 }
 
-extern "C" __global__ void binary_div_backward(
-    const BinaryDivOp op,
+extern "C" __global__ void minimum_backward(
+    const MinimumKernelOp op,
     const size_t numel,
     const size_t num_dims,
     const size_t *dims,
@@ -66,9 +66,19 @@ extern "C" __global__ void binary_div_backward(
     auto y = rhs[rhs_i];
     auto go = grad_out[out_i];
 
-    float dfdx = 1.0 / y;
-    grad_lhs[lhs_i] += dfdx * go;
+    float dfdx, dfdy;
 
-    float dfdy = -x / (y * y);
+    if (x < y) {
+        dfdx = 1.0;
+        dfdy = 0.0;
+    } else if (x > y) {
+        dfdx = 0.0;
+        dfdy = 1.0;
+    } else {
+        dfdx = 0.5;
+        dfdy = 0.5;
+    }
+
+    grad_lhs[lhs_i] += dfdx * go;
     grad_rhs[rhs_i] += dfdy * go;
 }

--- a/src/tensor_ops/mul/binary_mul.cu
+++ b/src/tensor_ops/mul/binary_mul.cu
@@ -1,4 +1,4 @@
-struct BinaryDivOp {};
+struct BinaryMulKernalOp {};
 
 __device__ unsigned int get_strided_index(
     unsigned int idx,
@@ -15,8 +15,8 @@ __device__ unsigned int get_strided_index(
     return strided_i;
 }
 
-extern "C" __global__ void binary_div_forward(
-    const BinaryDivOp op,
+extern "C" __global__ void binary_mul_forward(
+    const BinaryMulKernalOp op,
     const size_t numel,
     const size_t num_dims,
     const size_t *dims,
@@ -36,11 +36,11 @@ extern "C" __global__ void binary_div_forward(
     unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
     unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
 
-    out[out_i] = lhs[lhs_i] / rhs[rhs_i];
+    out[out_i] = lhs[lhs_i] * rhs[rhs_i];
 }
 
-extern "C" __global__ void binary_div_backward(
-    const BinaryDivOp op,
+extern "C" __global__ void binary_mul_backward(
+    const BinaryMulKernalOp op,
     const size_t numel,
     const size_t num_dims,
     const size_t *dims,
@@ -66,9 +66,9 @@ extern "C" __global__ void binary_div_backward(
     auto y = rhs[rhs_i];
     auto go = grad_out[out_i];
 
-    float dfdx = 1.0 / y;
+    float dfdx = y;
     grad_lhs[lhs_i] += dfdx * go;
 
-    float dfdy = -x / (y * y);
+    float dfdy = x;
     grad_rhs[rhs_i] += dfdy * go;
 }

--- a/src/tensor_ops/mul/cuda_kernel.rs
+++ b/src/tensor_ops/mul/cuda_kernel.rs
@@ -1,46 +1,18 @@
-use crate::{
-    shapes::Shape,
-    tensor::Cuda,
-    tensor_ops::ops::{BinaryKernel, UnaryKernel},
-};
+use crate::tensor_ops::cuda_kernels::{BinaryOpCudaKernel, UnaryOpCudaKernel};
 
-impl UnaryKernel<super::ScalarMulKernelOp<f32>, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::ScalarMulKernelOp<f32>,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::ScalarMulKernelOp<f32>,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::ScalarMulKernelOp<f32> {}
+unsafe impl cudarc::device::AsKernelParam for super::BinaryMulKernelOp {}
+
+impl UnaryOpCudaKernel for super::ScalarMulKernelOp<f32> {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/scalar_mul.ptx"));
+    const MODULE_NAME: &'static str = "scalar_mul";
+    const FWD_FN_NAME: &'static str = "scalar_mul_forward";
+    const BWD_FN_NAME: &'static str = "scalar_mul_backward";
 }
 
-impl BinaryKernel<super::BinaryMulKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::BinaryMulKernelOp,
-        lhs: &Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::BinaryMulKernelOp,
-        lhs: &Self::Storage<S, f32>,
-        grad_lhs: &mut Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-        grad_rhs: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+impl BinaryOpCudaKernel for super::BinaryMulKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/binary_mul.ptx"));
+    const MODULE_NAME: &'static str = "binary_mul";
+    const FWD_FN_NAME: &'static str = "binary_mul_forward";
+    const BWD_FN_NAME: &'static str = "binary_mul_backward";
 }

--- a/src/tensor_ops/mul/scalar_mul.cu
+++ b/src/tensor_ops/mul/scalar_mul.cu
@@ -1,7 +1,9 @@
-struct AbsKernelOp {};
+struct ScalarMulKernelOp {
+    float scalar;
+};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void scalar_mul_forward(
+    const ScalarMulKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +12,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = inp[i] * op.scalar;
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void scalar_mul_backward(
+    const ScalarMulKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +26,6 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
-    grad_inp[i] += dx * grad_out[i];
+    float df = op.scalar;
+    grad_inp[i] += df * grad_out[i];
 }

--- a/src/tensor_ops/nans_to/cuda_kernel.rs
+++ b/src/tensor_ops/nans_to/cuda_kernel.rs
@@ -1,20 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::UnaryKernel};
+use crate::tensor_ops::cuda_kernels::UnaryOpCudaKernel;
 
-impl UnaryKernel<super::NansToKernelOp<f32>, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::NansToKernelOp<f32>,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::NansToKernelOp<f32>,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::NansToKernelOp<f32> {}
+
+impl UnaryOpCudaKernel for super::NansToKernelOp<f32> {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/nans_to.ptx"));
+    const MODULE_NAME: &'static str = "nans_to";
+    const FWD_FN_NAME: &'static str = "nans_to_forward";
+    const BWD_FN_NAME: &'static str = "nans_to_backward";
 }

--- a/src/tensor_ops/nans_to/nans_to.cu
+++ b/src/tensor_ops/nans_to/nans_to.cu
@@ -1,7 +1,9 @@
-struct AbsKernelOp {};
+struct NansToKernelOp {
+    float x;
+};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void nans_to_forward(
+    const NansToKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +12,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = isnan(inp[i]) ? op.x : inp[i];
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void nans_to_backward(
+    const NansToKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +26,6 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
+    float dx = isnan(inp[i]) ? 0.0 : 1.0;
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/negate/cuda_kernel.rs
+++ b/src/tensor_ops/negate/cuda_kernel.rs
@@ -1,20 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::UnaryKernel};
+use crate::tensor_ops::cuda_kernels::UnaryOpCudaKernel;
 
-impl UnaryKernel<super::NegateKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::NegateKernelOp,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::NegateKernelOp,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::NegateKernelOp {}
+
+impl UnaryOpCudaKernel for super::NegateKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/negate.ptx"));
+    const MODULE_NAME: &'static str = "negate";
+    const FWD_FN_NAME: &'static str = "negate_forward";
+    const BWD_FN_NAME: &'static str = "negate_backward";
 }

--- a/src/tensor_ops/negate/negate.cu
+++ b/src/tensor_ops/negate/negate.cu
@@ -1,7 +1,7 @@
-struct AbsKernelOp {};
+struct NegateKernelOp {};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void negate_forward(
+    const NegateKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +10,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = -inp[i];
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void negate_backward(
+    const NegateKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +24,6 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
+    float dx = -1.0;
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/pow/cuda_kernel.rs
+++ b/src/tensor_ops/pow/cuda_kernel.rs
@@ -19,21 +19,13 @@ impl UnaryKernel<super::PowKernelOp<i32>, f32> for Cuda {
     }
 }
 
-impl UnaryKernel<super::PowKernelOp<f32>, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::PowKernelOp<f32>,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::PowKernelOp<f32>,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+use crate::tensor_ops::cuda_kernels::UnaryOpCudaKernel;
+
+unsafe impl cudarc::device::AsKernelParam for super::PowKernelOp<f32> {}
+
+impl UnaryOpCudaKernel for super::PowKernelOp<f32> {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/powf.ptx"));
+    const MODULE_NAME: &'static str = "powf";
+    const FWD_FN_NAME: &'static str = "powf_forward";
+    const BWD_FN_NAME: &'static str = "powf_backward";
 }

--- a/src/tensor_ops/pow/cuda_kernel.rs
+++ b/src/tensor_ops/pow/cuda_kernel.rs
@@ -1,24 +1,3 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::UnaryKernel};
-
-impl UnaryKernel<super::PowKernelOp<i32>, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::PowKernelOp<i32>,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::PowKernelOp<i32>,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
-}
-
 use crate::tensor_ops::cuda_kernels::UnaryOpCudaKernel;
 
 unsafe impl cudarc::device::AsKernelParam for super::PowKernelOp<f32> {}
@@ -28,4 +7,13 @@ impl UnaryOpCudaKernel for super::PowKernelOp<f32> {
     const MODULE_NAME: &'static str = "powf";
     const FWD_FN_NAME: &'static str = "powf_forward";
     const BWD_FN_NAME: &'static str = "powf_backward";
+}
+
+unsafe impl cudarc::device::AsKernelParam for super::PowKernelOp<i32> {}
+
+impl UnaryOpCudaKernel for super::PowKernelOp<i32> {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/powi.ptx"));
+    const MODULE_NAME: &'static str = "powi";
+    const FWD_FN_NAME: &'static str = "powi_forward";
+    const BWD_FN_NAME: &'static str = "powi_backward";
 }

--- a/src/tensor_ops/pow/powf.cu
+++ b/src/tensor_ops/pow/powf.cu
@@ -1,7 +1,9 @@
-struct AbsKernelOp {};
+struct PowFKernelOp {
+    float rhs;
+};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void powf_forward(
+    const PowFKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +12,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = powf(inp[i], op.rhs);
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void powf_backward(
+    const PowFKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +26,6 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
+    float dx = op.rhs * powf(inp[i], op.rhs - 1.0);
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/pow/powi.cu
+++ b/src/tensor_ops/pow/powi.cu
@@ -1,7 +1,9 @@
-struct SinKernelOp {};
+struct PowIKernelOp {
+    int rhs;
+};
 
-extern "C" __global__ void sin_forward(
-    const SinKernelOp op,
+extern "C" __global__ void powi_forward(
+    const PowIKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +12,13 @@ extern "C" __global__ void sin_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = sinf(inp[i]);
+    // Intentionally uses the 64 bit version of pow to ensure that the exponent
+    // isn't rounded
+    out[i] = pow(inp[i], op.rhs);
 }
 
-extern "C" __global__ void sin_backward(
-    const SinKernelOp op,
+extern "C" __global__ void powi_backward(
+    const PowIKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,6 +28,6 @@ extern "C" __global__ void sin_backward(
     if (i >= numel) {
         return;
     }
-    float dx = cosf(inp[i]);
+    float dx = op.rhs * pow(inp[i], op.rhs - 1);
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/relu/cuda_kernel.rs
+++ b/src/tensor_ops/relu/cuda_kernel.rs
@@ -1,20 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::UnaryKernel};
+use crate::tensor_ops::cuda_kernels::UnaryOpCudaKernel;
 
-impl UnaryKernel<super::ReLUKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::ReLUKernelOp,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::ReLUKernelOp,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::ReLUKernelOp {}
+
+impl UnaryOpCudaKernel for super::ReLUKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/relu.ptx"));
+    const MODULE_NAME: &'static str = "relu";
+    const FWD_FN_NAME: &'static str = "relu_forward";
+    const BWD_FN_NAME: &'static str = "relu_backward";
 }

--- a/src/tensor_ops/relu/relu.cu
+++ b/src/tensor_ops/relu/relu.cu
@@ -1,7 +1,7 @@
-struct AbsKernelOp {};
+struct ReLUKernelOp {};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void relu_forward(
+    const ReLUKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +10,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = max(inp[i], 0.0);
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void relu_backward(
+    const ReLUKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +24,6 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
+    float dx = inp[i] > 0.0 ? 1.0 : 0.0;
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/relu/relu.cu
+++ b/src/tensor_ops/relu/relu.cu
@@ -10,7 +10,7 @@ extern "C" __global__ void relu_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = max(inp[i], 0.0);
+    out[i] = fmaxf(inp[i], 0.0);
 }
 
 extern "C" __global__ void relu_backward(

--- a/src/tensor_ops/sigmoid/cuda_kernel.rs
+++ b/src/tensor_ops/sigmoid/cuda_kernel.rs
@@ -1,20 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::UnaryKernel};
+use crate::tensor_ops::cuda_kernels::UnaryOpCudaKernel;
 
-impl UnaryKernel<super::SigmoidKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::SigmoidKernelOp,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::SigmoidKernelOp,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::SigmoidKernelOp {}
+
+impl UnaryOpCudaKernel for super::SigmoidKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/sigmoid.ptx"));
+    const MODULE_NAME: &'static str = "sigmoid";
+    const FWD_FN_NAME: &'static str = "sigmoid_forward";
+    const BWD_FN_NAME: &'static str = "sigmoid_backward";
 }

--- a/src/tensor_ops/sigmoid/mod.rs
+++ b/src/tensor_ops/sigmoid/mod.rs
@@ -39,21 +39,21 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<SigmoidKernelOp, E>, T: Tape<D>> Tensor<
 
 #[cfg(test)]
 mod tests {
-    use crate::{tensor::*, tensor_ops::*, tests::TestDevice};
+    use crate::{tensor::*, tensor_ops::*, tests::*};
 
     #[test]
     fn test_sigmoid() {
         let dev: TestDevice = Default::default();
         let x = dev.tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
         let r = x.trace().sigmoid();
-        assert_eq!(
-            r.array(),
-            [0.11920292, 0.26894143, 0.5, 0.7310586, 0.880797]
+        assert_close(
+            &r.array(),
+            &[0.11920292, 0.26894143, 0.5, 0.7310586, 0.880797]
         );
         let g = r.mean().backward();
-        assert_eq!(
-            g.get(&x).array(),
-            [0.020998716, 0.039322387, 0.05, 0.039322387, 0.020998726]
+        assert_close(
+            &g.get(&x).array(),
+            &[0.020998716, 0.039322387, 0.05, 0.039322387, 0.020998726]
         );
     }
 }

--- a/src/tensor_ops/sigmoid/sigmoid.cu
+++ b/src/tensor_ops/sigmoid/sigmoid.cu
@@ -1,7 +1,7 @@
-struct AbsKernelOp {};
+struct SigmoidKernelOp {};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void sigmoid_forward(
+    const SigmoidKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +10,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = 1.0 / (1.0 + expf(-inp[i]));
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void sigmoid_backward(
+    const SigmoidKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +24,7 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
+    float fx = 1.0 / (1.0 + expf(-inp[i]));
+    float dx = fx * (1.0 - fx);
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/sin/cuda_kernel.rs
+++ b/src/tensor_ops/sin/cuda_kernel.rs
@@ -1,20 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::UnaryKernel};
+use crate::tensor_ops::cuda_kernels::UnaryOpCudaKernel;
 
-impl UnaryKernel<super::SinKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::SinKernelOp,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::SinKernelOp,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::SinKernelOp {}
+
+impl UnaryOpCudaKernel for super::SinKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/sin.ptx"));
+    const MODULE_NAME: &'static str = "sin";
+    const FWD_FN_NAME: &'static str = "sin_forward";
+    const BWD_FN_NAME: &'static str = "sin_backward";
 }

--- a/src/tensor_ops/sin/sin.cu
+++ b/src/tensor_ops/sin/sin.cu
@@ -1,7 +1,7 @@
-struct AbsKernelOp {};
+struct SinKernelOp {};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void sin_forward(
+    const SinKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +10,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = sin(inp[i]);
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void sin_backward(
+    const SinKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +24,6 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
+    float dx = cos(inp[i]);
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/sqrt/cuda_kernel.rs
+++ b/src/tensor_ops/sqrt/cuda_kernel.rs
@@ -1,20 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::UnaryKernel};
+use crate::tensor_ops::cuda_kernels::UnaryOpCudaKernel;
 
-impl UnaryKernel<super::SqrtKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::SqrtKernelOp,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::SqrtKernelOp,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::SqrtKernelOp {}
+
+impl UnaryOpCudaKernel for super::SqrtKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/sqrt.ptx"));
+    const MODULE_NAME: &'static str = "sqrt";
+    const FWD_FN_NAME: &'static str = "sqrt_forward";
+    const BWD_FN_NAME: &'static str = "sqrt_backward";
 }

--- a/src/tensor_ops/sqrt/sqrt.cu
+++ b/src/tensor_ops/sqrt/sqrt.cu
@@ -10,7 +10,7 @@ extern "C" __global__ void sqrt_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = sqrt(inp[i]);
+    out[i] = sqrtf(inp[i]);
 }
 
 extern "C" __global__ void sqrt_backward(
@@ -24,6 +24,6 @@ extern "C" __global__ void sqrt_backward(
     if (i >= numel) {
         return;
     }
-    float dx = 0.5 / sqrt(inp[i]);
+    float dx = 0.5 / sqrtf(inp[i]);
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/sqrt/sqrt.cu
+++ b/src/tensor_ops/sqrt/sqrt.cu
@@ -1,7 +1,7 @@
-struct AbsKernelOp {};
+struct SqrtKernelOp {};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void sqrt_forward(
+    const SqrtKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +10,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = sqrt(inp[i]);
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void sqrt_backward(
+    const SqrtKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +24,6 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
+    float dx = 0.5 / sqrt(inp[i]);
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/square/cuda_kernel.rs
+++ b/src/tensor_ops/square/cuda_kernel.rs
@@ -1,20 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::UnaryKernel};
+use crate::tensor_ops::cuda_kernels::UnaryOpCudaKernel;
 
-impl UnaryKernel<super::SquareKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::SquareKernelOp,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::SquareKernelOp,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::SquareKernelOp {}
+
+impl UnaryOpCudaKernel for super::SquareKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/square.ptx"));
+    const MODULE_NAME: &'static str = "square";
+    const FWD_FN_NAME: &'static str = "square_forward";
+    const BWD_FN_NAME: &'static str = "square_backward";
 }

--- a/src/tensor_ops/square/square.cu
+++ b/src/tensor_ops/square/square.cu
@@ -1,7 +1,7 @@
-struct AbsKernelOp {};
+struct SquareKernelOp {};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void square_forward(
+    const SquareKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +10,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = inp[i] * inp[i];
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void square_backward(
+    const SquareKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +24,6 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
+    float dx = 2.0 * inp[i];
     grad_inp[i] += dx * grad_out[i];
 }

--- a/src/tensor_ops/sub/binary_sub.cu
+++ b/src/tensor_ops/sub/binary_sub.cu
@@ -1,4 +1,4 @@
-struct BinaryDivOp {};
+struct BinarySubKernelOp {};
 
 __device__ unsigned int get_strided_index(
     unsigned int idx,
@@ -15,8 +15,8 @@ __device__ unsigned int get_strided_index(
     return strided_i;
 }
 
-extern "C" __global__ void binary_div_forward(
-    const BinaryDivOp op,
+extern "C" __global__ void binary_sub_forward(
+    const BinarySubKernelOp op,
     const size_t numel,
     const size_t num_dims,
     const size_t *dims,
@@ -36,11 +36,11 @@ extern "C" __global__ void binary_div_forward(
     unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
     unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
 
-    out[out_i] = lhs[lhs_i] / rhs[rhs_i];
+    out[out_i] = lhs[lhs_i] - rhs[rhs_i];
 }
 
-extern "C" __global__ void binary_div_backward(
-    const BinaryDivOp op,
+extern "C" __global__ void binary_sub_backward(
+    const BinarySubKernelOp op,
     const size_t numel,
     const size_t num_dims,
     const size_t *dims,
@@ -66,9 +66,9 @@ extern "C" __global__ void binary_div_backward(
     auto y = rhs[rhs_i];
     auto go = grad_out[out_i];
 
-    float dfdx = 1.0 / y;
+    float dfdx = 1.0;
     grad_lhs[lhs_i] += dfdx * go;
 
-    float dfdy = -x / (y * y);
+    float dfdy = -1.0;
     grad_rhs[rhs_i] += dfdy * go;
 }

--- a/src/tensor_ops/sub/cuda_kernel.rs
+++ b/src/tensor_ops/sub/cuda_kernel.rs
@@ -1,46 +1,18 @@
-use crate::{
-    shapes::Shape,
-    tensor::Cuda,
-    tensor_ops::ops::{BinaryKernel, UnaryKernel},
-};
+use crate::tensor_ops::cuda_kernels::{BinaryOpCudaKernel, UnaryOpCudaKernel};
 
-impl UnaryKernel<super::ScalarSubKernelOp<f32>, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::ScalarSubKernelOp<f32>,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::ScalarSubKernelOp<f32>,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::ScalarSubKernelOp<f32> {}
+unsafe impl cudarc::device::AsKernelParam for super::BinarySubKernelOp {}
+
+impl UnaryOpCudaKernel for super::ScalarSubKernelOp<f32> {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/scalar_sub.ptx"));
+    const MODULE_NAME: &'static str = "scalar_sub";
+    const FWD_FN_NAME: &'static str = "scalar_sub_forward";
+    const BWD_FN_NAME: &'static str = "scalar_sub_backward";
 }
 
-impl BinaryKernel<super::BinarySubKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::BinarySubKernelOp,
-        lhs: &Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::BinarySubKernelOp,
-        lhs: &Self::Storage<S, f32>,
-        grad_lhs: &mut Self::Storage<S, f32>,
-        rhs: &Self::Storage<S, f32>,
-        grad_rhs: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+impl BinaryOpCudaKernel for super::BinarySubKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/binary_sub.ptx"));
+    const MODULE_NAME: &'static str = "binary_sub";
+    const FWD_FN_NAME: &'static str = "binary_sub_forward";
+    const BWD_FN_NAME: &'static str = "binary_sub_backward";
 }

--- a/src/tensor_ops/sub/mod.rs
+++ b/src/tensor_ops/sub/mod.rs
@@ -75,7 +75,7 @@ where
 mod tests {
     use crate::tensor::*;
     use crate::tensor_ops::*;
-    use crate::tests::TestDevice;
+    use crate::tests::*;
 
     #[test]
     fn test_sub_0d() {
@@ -130,7 +130,7 @@ mod tests {
         let r = x.trace() - 1.0;
         assert_eq!(r.array(), -1.0);
         let g = r.exp().backward();
-        assert_eq!(g.get(&x).array(), (-1.0f32).exp());
+        assert_close(&[g.get(&x).array()], &[(-1.0f32).exp()]);
     }
 
     #[test]
@@ -138,9 +138,9 @@ mod tests {
         let dev: TestDevice = Default::default();
         let x = dev.tensor([0.0, 1.0, 2.0]);
         let r = x.trace() - 1.0;
-        assert_eq!(r.array(), [-1.0, 0.0, 1.0]);
+        assert_eq!(&r.array(), &[-1.0, 0.0, 1.0]);
         let g = r.exp().sum().backward();
-        assert_eq!(g.get(&x).array(), [0.36787945, 1.0, 2.7182817]);
+        assert_close(&g.get(&x).array(), &[0.36787945, 1.0, 2.7182817]);
     }
 
     #[test]
@@ -150,6 +150,6 @@ mod tests {
         let r = x.trace() - 1.0;
         assert_eq!(r.array(), [[-1.0; 2]; 3]);
         let g = r.exp().sum().backward();
-        assert_eq!(g.get(&x).array(), [[0.36787945; 2]; 3]);
+        assert_close(&g.get(&x).array(), &[[0.36787945; 2]; 3]);
     }
 }

--- a/src/tensor_ops/sub/scalar_sub.cu
+++ b/src/tensor_ops/sub/scalar_sub.cu
@@ -1,7 +1,9 @@
-struct AbsKernelOp {};
+struct ScalarSubKernelOp {
+    float scalar;
+};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void scalar_sub_forward(
+    const ScalarSubKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +12,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = inp[i] - op.scalar;
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void scalar_sub_backward(
+    const ScalarSubKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +26,6 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
-    grad_inp[i] += dx * grad_out[i];
+    float df = 1.0;
+    grad_inp[i] += df * grad_out[i];
 }

--- a/src/tensor_ops/tanh/cuda_kernel.rs
+++ b/src/tensor_ops/tanh/cuda_kernel.rs
@@ -1,20 +1,10 @@
-use crate::{shapes::Shape, tensor::Cuda, tensor_ops::ops::UnaryKernel};
+use crate::tensor_ops::cuda_kernels::UnaryOpCudaKernel;
 
-impl UnaryKernel<super::TanhKernelOp, f32> for Cuda {
-    fn forward<S: Shape>(
-        &self,
-        op: super::TanhKernelOp,
-        inp: &Self::Storage<S, f32>,
-    ) -> Result<Self::Storage<S, f32>, Self::Err> {
-        todo!()
-    }
-    fn backward<S: Shape>(
-        &self,
-        op: super::TanhKernelOp,
-        inp: &Self::Storage<S, f32>,
-        grad_inp: &mut Self::Storage<S, f32>,
-        grad_out: &Self::Storage<S, f32>,
-    ) -> Result<(), Self::Err> {
-        todo!()
-    }
+unsafe impl cudarc::device::AsKernelParam for super::TanhKernelOp {}
+
+impl UnaryOpCudaKernel for super::TanhKernelOp {
+    const PTX_SRC: &'static str = include_str!(concat!(env!("OUT_DIR"), "/tanh.ptx"));
+    const MODULE_NAME: &'static str = "tanh";
+    const FWD_FN_NAME: &'static str = "tanh_forward";
+    const BWD_FN_NAME: &'static str = "tanh_backward";
 }

--- a/src/tensor_ops/tanh/mod.rs
+++ b/src/tensor_ops/tanh/mod.rs
@@ -39,21 +39,21 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<TanhKernelOp, E>, T: Tape<D>> Tensor<S, 
 
 #[cfg(test)]
 mod tests {
-    use crate::{tensor::*, tensor_ops::*, tests::TestDevice};
+    use crate::{tensor::*, tensor_ops::*, tests::*};
 
     #[test]
     fn test_tanh() {
         let dev: TestDevice = Default::default();
         let x = dev.tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
         let r = x.trace().tanh();
-        assert_eq!(
-            r.array(),
-            [-0.9640276, -0.7615942, 0., 0.7615942, 0.9640276]
+        assert_close(
+            &r.array(),
+            &[-0.9640276, -0.7615942, 0., 0.7615942, 0.9640276]
         );
         let g = r.mean().backward();
-        assert_eq!(
-            g.get(&x).array(),
-            [0.014130163, 0.083994865, 0.2, 0.083994865, 0.014130163]
+        assert_close(
+            &g.get(&x).array(),
+            &[0.014130163, 0.083994865, 0.2, 0.083994865, 0.014130163]
         );
     }
 }

--- a/src/tensor_ops/tanh/tanh.cu
+++ b/src/tensor_ops/tanh/tanh.cu
@@ -1,7 +1,7 @@
-struct AbsKernelOp {};
+struct TanhKernelOp {};
 
-extern "C" __global__ void abs_forward(
-    const AbsKernelOp op,
+extern "C" __global__ void tanh_forward(
+    const TanhKernelOp op,
     const size_t numel,
     const float *inp,
     float *out
@@ -10,11 +10,11 @@ extern "C" __global__ void abs_forward(
     if (i >= numel) {
         return;
     }
-    out[i] = abs(inp[i]);
+    out[i] = tanhf(inp[i]);
 }
 
-extern "C" __global__ void abs_backward(
-    const AbsKernelOp op,
+extern "C" __global__ void tanh_backward(
+    const TanhKernelOp op,
     const size_t numel,
     const float *inp,
     float *grad_inp,
@@ -24,7 +24,7 @@ extern "C" __global__ void abs_backward(
     if (i >= numel) {
         return;
     }
-    // NOTE: signbit returns a non-zero value when its input is negative
-    float dx = inp[i] == 0.0 ? 0.0 : (signbit(inp[i]) ? -1.0 : 1.0);
+    float fx = tanhf(inp[i]);
+    float dx = 1 - fx * fx;
     grad_inp[i] += dx * grad_out[i];
 }


### PR DESCRIPTION
This commit adds cuda kernels for the operations listed in #341 and #334. It also adds tests for huber_error and adds an "op" parameter to the binary kernels to allow huber_error to pass it's delta value to its kernel. 