### PR TITLE
Simplify cuda kernels for binary tensor operations.

### DIFF
--- a/src/tensor_ops/add/binary_add.cu
+++ b/src/tensor_ops/add/binary_add.cu
@@ -1,71 +1,38 @@
 struct BinaryAddOp {};
 
-__device__ unsigned int get_strided_index(
-    unsigned int idx,
-    const size_t num_dims,
-    const size_t *dims,
-    const size_t *strides
-) {
-    unsigned int strided_i = 0;
-    for (unsigned int d = 0; d < num_dims; d++) {
-        unsigned int dim_idx = num_dims - 1 - d;
-        strided_i += (idx % dims[dim_idx]) * strides[dim_idx];
-        idx /= dims[dim_idx];
-    }
-    return strided_i;
-}
-
 extern "C" __global__ void binary_add_forward(
     const BinaryAddOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
-    const size_t *lhs_strides,
     const float *rhs,
-    const size_t *rhs_strides,
-    float *out,
-    const size_t *out_strides
+    float *out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
-
-    out[out_i] = lhs[lhs_i] + rhs[rhs_i];
+    out[i] = lhs[i] + rhs[i];
 }
 
 extern "C" __global__ void binary_add_backward(
     const BinaryAddOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
     float *grad_lhs,
-    const size_t *lhs_strides,
     const float *rhs,
     float *grad_rhs,
-    const size_t *rhs_strides,
-    const float *grad_out,
-    const size_t *out_strides
+    const float *grad_out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
+    auto x = lhs[i];
+    auto y = rhs[i];
+    auto go = grad_out[i];
 
-    auto x = lhs[lhs_i];
-    auto y = rhs[rhs_i];
-    auto go = grad_out[out_i];
-
-    atomicAdd(grad_lhs + lhs_i, go);
-    atomicAdd(grad_rhs + rhs_i, go);
+    grad_lhs[i] += go;
+    grad_rhs[i] += go;
 }

--- a/src/tensor_ops/bce/bce.cu
+++ b/src/tensor_ops/bce/bce.cu
@@ -1,77 +1,44 @@
 struct BCEKernelOp {};
 
-__device__ unsigned int get_strided_index(
-    unsigned int idx,
-    const size_t num_dims,
-    const size_t *dims,
-    const size_t *strides
-) {
-    unsigned int strided_i = 0;
-    for (unsigned int d = 0; d < num_dims; d++) {
-        unsigned int dim_idx = num_dims - 1 - d;
-        strided_i += (idx % dims[dim_idx]) * strides[dim_idx];
-        idx /= dims[dim_idx];
-    }
-    return strided_i;
-}
-
 extern "C" __global__ void bce_forward(
     const BCEKernelOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
-    const size_t *lhs_strides,
     const float *rhs,
-    const size_t *rhs_strides,
-    float *out,
-    const size_t *out_strides
+    float *out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
+    float logit = lhs[i];
+    float prob = rhs[i];
 
-    float logit = lhs[lhs_i];
-    float prob = rhs[rhs_i];
-
-    out[out_i] = fmaxf(logit, 0.0) - logit * prob + logf(1.0 + expf(-fabsf(logit)));
+    out[i] = fmaxf(logit, 0.0) - logit * prob + logf(1.0 + expf(-fabsf(logit)));
 }
 
 extern "C" __global__ void bce_backward(
     const BCEKernelOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
     float *grad_lhs,
-    const size_t *lhs_strides,
     const float *rhs,
     float *grad_rhs,
-    const size_t *rhs_strides,
-    const float *grad_out,
-    const size_t *out_strides
+    const float *grad_out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
-
-    auto logit = lhs[lhs_i];
-    auto prob = rhs[rhs_i];
-    auto go = grad_out[out_i];
+    auto logit = lhs[i];
+    auto prob = rhs[i];
+    auto go = grad_out[i];
 
     float dfdx = 1.0 - prob - 1 / (1.0 + expf(logit));
-    atomicAdd(grad_lhs + lhs_i, dfdx * go);
+    grad_lhs[i] += dfdx * go;
 
     float dfdy = -logit;
-    atomicAdd(grad_rhs + rhs_i, dfdy * go);
+    grad_rhs[i] += dfdy * go;
 }

--- a/src/tensor_ops/div/binary_div.cu
+++ b/src/tensor_ops/div/binary_div.cu
@@ -1,74 +1,41 @@
 struct BinaryDivOp {};
 
-__device__ unsigned int get_strided_index(
-    unsigned int idx,
-    const size_t num_dims,
-    const size_t *dims,
-    const size_t *strides
-) {
-    unsigned int strided_i = 0;
-    for (unsigned int d = 0; d < num_dims; d++) {
-        unsigned int dim_idx = num_dims - 1 - d;
-        strided_i += (idx % dims[dim_idx]) * strides[dim_idx];
-        idx /= dims[dim_idx];
-    }
-    return strided_i;
-}
-
 extern "C" __global__ void binary_div_forward(
     const BinaryDivOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
-    const size_t *lhs_strides,
     const float *rhs,
-    const size_t *rhs_strides,
-    float *out,
-    const size_t *out_strides
+    float *out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
-
-    out[out_i] = lhs[lhs_i] / rhs[rhs_i];
+    out[i] = lhs[i] / rhs[i];
 }
 
 extern "C" __global__ void binary_div_backward(
     const BinaryDivOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
     float *grad_lhs,
-    const size_t *lhs_strides,
     const float *rhs,
     float *grad_rhs,
-    const size_t *rhs_strides,
-    const float *grad_out,
-    const size_t *out_strides
+    const float *grad_out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
-
-    auto x = lhs[lhs_i];
-    auto y = rhs[rhs_i];
-    auto go = grad_out[out_i];
+    auto x = lhs[i];
+    auto y = rhs[i];
+    auto go = grad_out[i];
 
     float dfdx = 1.0 / y;
-    atomicAdd(grad_lhs + lhs_i, dfdx * go);
+    grad_lhs[i] += dfdx * go;
 
     float dfdy = -x / (y * y);
-    atomicAdd(grad_rhs + rhs_i, dfdy * go);
+    grad_rhs[i] += dfdy * go;
 }

--- a/src/tensor_ops/huber_error/huber_error.cu
+++ b/src/tensor_ops/huber_error/huber_error.cu
@@ -2,76 +2,43 @@ struct HuberErrorOp {
     float delta;
 };
 
-__device__ unsigned int get_strided_index(
-    unsigned int idx,
-    const size_t num_dims,
-    const size_t *dims,
-    const size_t *strides
-) {
-    unsigned int strided_i = 0;
-    for (unsigned int d = 0; d < num_dims; d++) {
-        unsigned int dim_idx = num_dims - 1 - d;
-        strided_i += (idx % dims[dim_idx]) * strides[dim_idx];
-        idx /= dims[dim_idx];
-    }
-    return strided_i;
-}
-
 extern "C" __global__ void huber_error_forward(
     const HuberErrorOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
-    const size_t *lhs_strides,
     const float *rhs,
-    const size_t *rhs_strides,
-    float *out,
-    const size_t *out_strides
+    float *out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
-
-    float a = lhs[lhs_i] - rhs[rhs_i];
+    float a = lhs[i] - rhs[i];
 
     if (fabsf(a) < op.delta) {
-        out[out_i] = a * a * 0.5;
+        out[i] = a * a * 0.5;
     } else {
-        out[out_i] = op.delta * (fabsf(a) - 0.5 * op.delta);
+        out[i] = op.delta * (fabsf(a) - 0.5 * op.delta);
     }
 }
 
 extern "C" __global__ void huber_error_backward(
     const HuberErrorOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
     float *grad_lhs,
-    const size_t *lhs_strides,
     const float *rhs,
     float *grad_rhs,
-    const size_t *rhs_strides,
-    const float *grad_out,
-    const size_t *out_strides
+    const float *grad_out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
-
-    auto a = lhs[lhs_i] - rhs[rhs_i];
-    auto go = grad_out[out_i];
+    auto a = lhs[i] - rhs[i];
+    auto go = grad_out[i];
 
     float dfdx, dfdy;
 
@@ -85,6 +52,6 @@ extern "C" __global__ void huber_error_backward(
 
     dfdy = -dfdx;
 
-    atomicAdd(grad_lhs + lhs_i, dfdx * go);
-    atomicAdd(grad_rhs + rhs_i, dfdy * go);
+    grad_lhs[i] += dfdx * go;
+    grad_rhs[i] += dfdy * go;
 }

--- a/src/tensor_ops/maximum/maximum.cu
+++ b/src/tensor_ops/maximum/maximum.cu
@@ -1,70 +1,37 @@
 struct MaximumKernalOp {};
 
-__device__ unsigned int get_strided_index(
-    unsigned int idx,
-    const size_t num_dims,
-    const size_t *dims,
-    const size_t *strides
-) {
-    unsigned int strided_i = 0;
-    for (unsigned int d = 0; d < num_dims; d++) {
-        unsigned int dim_idx = num_dims - 1 - d;
-        strided_i += (idx % dims[dim_idx]) * strides[dim_idx];
-        idx /= dims[dim_idx];
-    }
-    return strided_i;
-}
-
 extern "C" __global__ void maximum_forward(
     const MaximumKernalOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
-    const size_t *lhs_strides,
     const float *rhs,
-    const size_t *rhs_strides,
-    float *out,
-    const size_t *out_strides
+    float *out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
-
-    out[out_i] = fmaxf(lhs[lhs_i], rhs[rhs_i]);
+    out[i] = fmaxf(lhs[i], rhs[i]);
 }
 
 extern "C" __global__ void maximum_backward(
     const MaximumKernalOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
     float *grad_lhs,
-    const size_t *lhs_strides,
     const float *rhs,
     float *grad_rhs,
-    const size_t *rhs_strides,
-    const float *grad_out,
-    const size_t *out_strides
+    const float *grad_out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
-
-    auto x = lhs[lhs_i];
-    auto y = rhs[rhs_i];
-    auto go = grad_out[out_i];
+    auto x = lhs[i];
+    auto y = rhs[i];
+    auto go = grad_out[i];
 
     float dfdx, dfdy;
 
@@ -79,6 +46,6 @@ extern "C" __global__ void maximum_backward(
         dfdy = 0.5;
     }
 
-    atomicAdd(grad_lhs + lhs_i, dfdx * go);
-    atomicAdd(grad_rhs + rhs_i, dfdy * go);
+    grad_lhs[i] += dfdx * go;
+    grad_rhs[i] += dfdy * go;
 }

--- a/src/tensor_ops/minimum/minimum.cu
+++ b/src/tensor_ops/minimum/minimum.cu
@@ -1,70 +1,37 @@
 struct MinimumKernelOp {};
 
-__device__ unsigned int get_strided_index(
-    unsigned int idx,
-    const size_t num_dims,
-    const size_t *dims,
-    const size_t *strides
-) {
-    unsigned int strided_i = 0;
-    for (unsigned int d = 0; d < num_dims; d++) {
-        unsigned int dim_idx = num_dims - 1 - d;
-        strided_i += (idx % dims[dim_idx]) * strides[dim_idx];
-        idx /= dims[dim_idx];
-    }
-    return strided_i;
-}
-
 extern "C" __global__ void minimum_forward(
     const MinimumKernelOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
-    const size_t *lhs_strides,
     const float *rhs,
-    const size_t *rhs_strides,
-    float *out,
-    const size_t *out_strides
+    float *out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
-
-    out[out_i] = fminf(lhs[lhs_i], rhs[rhs_i]);
+    out[i] = fminf(lhs[i], rhs[i]);
 }
 
 extern "C" __global__ void minimum_backward(
     const MinimumKernelOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
     float *grad_lhs,
-    const size_t *lhs_strides,
     const float *rhs,
     float *grad_rhs,
-    const size_t *rhs_strides,
-    const float *grad_out,
-    const size_t *out_strides
+    const float *grad_out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
-
-    auto x = lhs[lhs_i];
-    auto y = rhs[rhs_i];
-    auto go = grad_out[out_i];
+    auto x = lhs[i];
+    auto y = rhs[i];
+    auto go = grad_out[i];
 
     float dfdx, dfdy;
 
@@ -79,6 +46,6 @@ extern "C" __global__ void minimum_backward(
         dfdy = 0.5;
     }
 
-    atomicAdd(grad_lhs + lhs_i, dfdx * go);
-    atomicAdd(grad_rhs + rhs_i, dfdy * go);
+    grad_lhs[i] += dfdx * go;
+    grad_rhs[i] += dfdy * go;
 }

--- a/src/tensor_ops/mul/binary_mul.cu
+++ b/src/tensor_ops/mul/binary_mul.cu
@@ -1,71 +1,38 @@
 struct BinaryMulKernalOp {};
 
-__device__ unsigned int get_strided_index(
-    unsigned int idx,
-    const size_t num_dims,
-    const size_t *dims,
-    const size_t *strides
-) {
-    unsigned int strided_i = 0;
-    for (unsigned int d = 0; d < num_dims; d++) {
-        unsigned int dim_idx = num_dims - 1 - d;
-        strided_i += (idx % dims[dim_idx]) * strides[dim_idx];
-        idx /= dims[dim_idx];
-    }
-    return strided_i;
-}
-
 extern "C" __global__ void binary_mul_forward(
     const BinaryMulKernalOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
-    const size_t *lhs_strides,
     const float *rhs,
-    const size_t *rhs_strides,
-    float *out,
-    const size_t *out_strides
+    float *out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
-
-    out[out_i] = lhs[lhs_i] * rhs[rhs_i];
+    out[i] = lhs[i] * rhs[i];
 }
 
 extern "C" __global__ void binary_mul_backward(
     const BinaryMulKernalOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
     float *grad_lhs,
-    const size_t *lhs_strides,
     const float *rhs,
     float *grad_rhs,
-    const size_t *rhs_strides,
-    const float *grad_out,
-    const size_t *out_strides
+    const float *grad_out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
+    auto x = lhs[i];
+    auto y = rhs[i];
+    auto go = grad_out[i];
 
-    auto x = lhs[lhs_i];
-    auto y = rhs[rhs_i];
-    auto go = grad_out[out_i];
-
-    atomicAdd(grad_lhs + lhs_i, y * go);
-    atomicAdd(grad_rhs + rhs_i, x * go);
+    grad_lhs[i] += y * go;
+    grad_rhs[i] += x * go;
 }

--- a/src/tensor_ops/sub/binary_sub.cu
+++ b/src/tensor_ops/sub/binary_sub.cu
@@ -1,74 +1,41 @@
 struct BinarySubKernelOp {};
 
-__device__ unsigned int get_strided_index(
-    unsigned int idx,
-    const size_t num_dims,
-    const size_t *dims,
-    const size_t *strides
-) {
-    unsigned int strided_i = 0;
-    for (unsigned int d = 0; d < num_dims; d++) {
-        unsigned int dim_idx = num_dims - 1 - d;
-        strided_i += (idx % dims[dim_idx]) * strides[dim_idx];
-        idx /= dims[dim_idx];
-    }
-    return strided_i;
-}
-
 extern "C" __global__ void binary_sub_forward(
     const BinarySubKernelOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
-    const size_t *lhs_strides,
     const float *rhs,
-    const size_t *rhs_strides,
-    float *out,
-    const size_t *out_strides
+    float *out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
-
-    out[out_i] = lhs[lhs_i] - rhs[rhs_i];
+    out[i] = lhs[i] - rhs[i];
 }
 
 extern "C" __global__ void binary_sub_backward(
     const BinarySubKernelOp op,
     const size_t numel,
-    const size_t num_dims,
-    const size_t *dims,
     const float *lhs,
     float *grad_lhs,
-    const size_t *lhs_strides,
     const float *rhs,
     float *grad_rhs,
-    const size_t *rhs_strides,
-    const float *grad_out,
-    const size_t *out_strides
+    const float *grad_out
 ) {
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= numel) {
         return;
     }
 
-    unsigned int lhs_i = get_strided_index(i, num_dims, dims, lhs_strides);
-    unsigned int rhs_i = get_strided_index(i, num_dims, dims, rhs_strides);
-    unsigned int out_i = get_strided_index(i, num_dims, dims, out_strides);
-
-    auto x = lhs[lhs_i];
-    auto y = rhs[rhs_i];
-    auto go = grad_out[out_i];
+    auto x = lhs[i];
+    auto y = rhs[i];
+    auto go = grad_out[i];
 
     float dfdx = 1.0;
-    atomicAdd(grad_lhs + lhs_i, dfdx * go);
+    grad_lhs[i] += dfdx * go;
 
     float dfdy = -1.0;
-    atomicAdd(grad_rhs + rhs_i, dfdy * go);
+    grad_rhs[i] += dfdy * go;
 }


### PR DESCRIPTION
I realized that the math for calculating the stride indices in the binary operation cuda kernels was redundant, because the shape and strides of all input tensors are equivalent, and that the get_strided_index function ended up simply returning its input. I also changed the atomicAdds in the cuda kernels to normal adds, because each thread should modify exactly one value in grad_lhs and grad_rhs.