### PR TITLE
Add tests for binary broadcasted add and fix bugs to allow them to pass.

### DIFF
--- a/src/tensor/cuda/device.rs
+++ b/src/tensor/cuda/device.rs
@@ -115,7 +115,7 @@ impl DeviceStorage for Cuda {
         storage: &Self::Storage<S, E>,
     ) -> Result<Self::Storage<S, E>, Self::Err> {
         let numel = storage.shape.num_elements();
-        let strides: S::Concrete = storage.shape.strides();
+        let strides: S::Concrete = storage.strides;
         Ok(Self::Storage {
             data: Arc::new(self.dev.take_async(std::vec![Default::default(); numel])?),
             shape: storage.shape,

--- a/src/tensor_ops/add/mod.rs
+++ b/src/tensor_ops/add/mod.rs
@@ -128,6 +128,44 @@ mod tests {
     }
 
     #[test]
+    fn test_add_broadcast_bottom() {
+        let dev: TestDevice = Default::default();
+        let a = dev.tensor([[0.6570, 0.1708, 0.1500], [0.5658, 0.7010, 0.8342]]);
+        let b = dev.tensor([[0.5199, 0.3844, 0.3759], [0.8259, 0.3682, 0.0388]]);
+
+        let a2: Tensor3D<2, 3, 4, TestDevice> = a.broadcast();
+        let b2: Tensor3D<2, 3, 4, TestDevice> = b.broadcast();
+
+        let r = a2.trace() + b2.clone();
+        assert_eq!(
+            r.array(),
+            [[[1.1769f32; 4], [0.5552; 4], [0.5259; 4]], [[1.3917; 4], [1.0692; 4], [0.873; 4]]]
+        );
+        let g = r.mean().backward();
+        assert_eq!(g.get(&a2).array(), [[[1.0 / 6.0; 4]; 3]; 2]);
+        assert_eq!(g.get(&b2).array(), [[[1.0 / 6.0; 4]; 3]; 2]);
+    }
+
+    #[test]
+    fn test_add_broadcast_top() {
+        let dev: TestDevice = Default::default();
+        let a = dev.tensor([[0.6570, 0.1708, 0.1500], [0.5658, 0.7010, 0.8342]]);
+        let b = dev.tensor([[0.5199, 0.3844, 0.3759], [0.8259, 0.3682, 0.0388]]);
+
+        let a2: Tensor3D<4, 2, 3, TestDevice> = a.broadcast();
+        let b2: Tensor3D<4, 2, 3, TestDevice> = b.broadcast();
+
+        let r = a2.trace() + b2.clone();
+        assert_eq!(
+            r.array(),
+            [[[1.1769f32, 0.5552, 0.5259], [1.3917, 1.0692, 0.873]]; 4]
+        );
+        let g = r.mean().backward();
+        assert_eq!(g.get(&a2).array(), [[[1.0 / 6.0; 3]; 2]; 4]);
+        assert_eq!(g.get(&b2).array(), [[[1.0 / 6.0; 3]; 2]; 4]);
+    }
+
+    #[test]
     fn test_scalar_add_0d() {
         let dev: TestDevice = Default::default();
         let x = dev.tensor(0.0);

--- a/src/tensor_ops/cuda_kernels.rs
+++ b/src/tensor_ops/cuda_kernels.rs
@@ -146,7 +146,7 @@ impl<K: BinaryOpCudaKernel + AsKernelParam> BinaryKernel<K, f32> for Cuda {
         grad_out: &Self::Storage<S, f32>,
     ) -> Result<(), Self::Err> {
         let bwd_fn = self.dev.get_func(K::MODULE_NAME, K::BWD_FN_NAME).unwrap();
-        let numel = lhs.shape.num_elements();
+        let numel = grad_out.shape.num_elements();
 
         let dims: CudaSlice<usize> = self.dev.take_async(lhs.shape.concrete().into())?;
         let lhs_strides: CudaSlice<usize> = self.dev.take_async(lhs.strides.into())?;

--- a/src/tensor_ops/cuda_kernels.rs
+++ b/src/tensor_ops/cuda_kernels.rs
@@ -146,7 +146,7 @@ impl<K: BinaryOpCudaKernel + AsKernelParam> BinaryKernel<K, f32> for Cuda {
         grad_out: &Self::Storage<S, f32>,
     ) -> Result<(), Self::Err> {
         let bwd_fn = self.dev.get_func(K::MODULE_NAME, K::BWD_FN_NAME).unwrap();
-        let numel = grad_out.shape.num_elements();
+        let numel = lhs.shape.num_elements();
 
         let dims: CudaSlice<usize> = self.dev.take_async(lhs.shape.concrete().into())?;
         let lhs_strides: CudaSlice<usize> = self.dev.take_async(lhs.strides.into())?;


### PR DESCRIPTION
Implements tests for binary addition on broadcasted tensors and fixes two bugs which caused them to fail with gpu tensors. Works towards #349.