### PR TITLE
Add select and gather cuda kernels.

### DIFF
--- a/src/tensor_ops/select_and_gather/cuda_kernel.rs
+++ b/src/tensor_ops/select_and_gather/cuda_kernel.rs
@@ -1,54 +1,199 @@
 #![allow(clippy::needless_range_loop)]
 
-use crate::shapes::{Axes, Dtype, RemoveDimTo, ReplaceDimTo, Shape};
-use crate::tensor::Cuda;
+use crate::{
+    shapes::{Axes, Dtype, RemoveDimTo, ReplaceDimTo, Shape},
+    tensor::cuda::{Cuda, CudaArray},
+    tensor_ops::ops::{BinaryKernel, UnaryKernel},
+};
+use cudarc::device::{AsKernelParam, CudaSlice, LaunchAsync, LaunchConfig, ValidAsZeroBits};
+use std::sync::Arc;
 
-impl<E: Dtype> super::ReplaceDimKernel<E> for Cuda {
+const GATHER_PTX_SRC: &str = include_str!(concat!(env!("OUT_DIR"), "/gather.ptx"));
+const GATHER_MODULE_NAME: &str = "gather";
+const GATHER_FWD_FN_NAME: &str = "gather_forward";
+const GATHER_BWD_FN_NAME: &str = "gather_backward";
+const GATHER_ALL_FN_NAMES: [&str; 2] = [GATHER_FWD_FN_NAME, GATHER_BWD_FN_NAME];
+
+impl super::ReplaceDimKernel<f32> for Cuda {
     fn forward<Src: Shape, Dst: Shape, Idx: Shape>(
         &self,
-        inp: &Self::Storage<Src, E>,
+        inp: &Self::Storage<Src, f32>,
         idx: &Self::Storage<Idx, usize>,
-    ) -> Result<Self::Storage<Dst, E>, Self::Err>
+    ) -> Result<Self::Storage<Dst, f32>, Self::Err>
     where
         Src: ReplaceDimTo<Dst, Idx>,
     {
-        todo!()
+        if !self.dev.has_func(GATHER_MODULE_NAME, GATHER_FWD_FN_NAME) {
+            self.dev
+                .load_ptx(GATHER_PTX_SRC.into(), GATHER_MODULE_NAME, &GATHER_ALL_FN_NAMES)?;
+        }
+
+        let dst = inp.shape.replace(idx.shape);
+        let numel = dst.num_elements();
+        let mut storage = self.dev.alloc_zeros_async::<f32>(numel)?;
+
+        let inp_dims: CudaSlice<usize> = self.dev.take_async(inp.shape.concrete().into())?;
+        let idx_dims: CudaSlice<usize> = self.dev.take_async(idx.shape.concrete().into())?;
+        let dst_dims: CudaSlice<usize> = self.dev.take_async(dst.concrete().into())?;
+        let inp_strides: CudaSlice<usize> = self.dev.take_async(inp.strides.into())?;
+        let idx_strides: CudaSlice<usize> = self.dev.take_async(idx.strides.into())?;
+        let dst_strides: CudaSlice<usize> = self.dev.take_async(dst.strides().into())?;
+
+        let fwd_fn = self.dev.get_func(GATHER_MODULE_NAME, GATHER_FWD_FN_NAME).unwrap();
+        let cfg = LaunchConfig::for_num_elems(numel as u32);
+        let params = (
+            numel,             // const size_t numel,
+            inp.data.as_ref(), // const float *inp,
+            Src::NUM_DIMS,     // const size_t inp_num_dims,
+            &inp_dims,         // const size_t *inp_dims,
+            &inp_strides,      // const size_t *inp_strides,
+            idx.data.as_ref(), // const float *idx,
+            Idx::NUM_DIMS,     // const size_t idx_num_dims,
+            &idx_dims,         // const size_t *idx_dims,
+            &idx_strides,      // const size_t *idx_strides,
+            &mut storage,      // float *out,
+            &dst_dims,         // const size_t *out_dims,
+            &dst_strides       // const size_t *out_strides
+        );
+        unsafe { fwd_fn.launch_async(cfg, params) }?;
+
+        Ok(CudaArray {
+            data: Arc::new(storage),
+            shape: dst,
+            strides: dst.strides(),
+        })
     }
 
     fn backward<Src: Shape, Dst: Shape, Idx: Shape>(
         &self,
-        grad_inp: &mut Self::Storage<Src, E>,
+        grad_inp: &mut Self::Storage<Src, f32>,
         idx: &Self::Storage<Idx, usize>,
-        grad_out: &Self::Storage<Dst, E>,
+        grad_out: &Self::Storage<Dst, f32>,
     ) -> Result<(), Self::Err>
     where
         Src: ReplaceDimTo<Dst, Idx>,
     {
-        todo!()
+        let bwd_fn = self.dev.get_func(GATHER_MODULE_NAME, GATHER_BWD_FN_NAME).unwrap();
+        let numel = grad_out.data.len();
+
+        let inp_dims: CudaSlice<usize> = self.dev.take_async(grad_inp.shape.concrete().into())?;
+        let idx_dims: CudaSlice<usize> = self.dev.take_async(idx.shape.concrete().into())?;
+        let out_dims: CudaSlice<usize> = self.dev.take_async(grad_out.shape.concrete().into())?;
+        let inp_strides: CudaSlice<usize> = self.dev.take_async(grad_inp.strides.into())?;
+        let idx_strides: CudaSlice<usize> = self.dev.take_async(idx.strides.into())?;
+        let out_strides: CudaSlice<usize> = self.dev.take_async(grad_out.strides.into())?;
+
+        let cfg = LaunchConfig::for_num_elems(numel as u32);
+        let params = (
+            numel,                             // const size_t numel,
+            Arc::make_mut(&mut grad_inp.data), // float *grad_inp,
+            Src::NUM_DIMS,                     // const size_t inp_num_dims,
+            &inp_dims,                         // const size_t *inp_dims,
+            &inp_strides,                      // const size_t *inp_strides,
+            idx.data.as_ref(),                 // const float *idx,
+            Idx::NUM_DIMS,                     // const size_t idx_num_dims,
+            &idx_dims,                         // const size_t *idx_dims,
+            &idx_strides,                      // const size_t *idx_strides,
+            grad_out.data.as_ref(),            // const float *grad_out,
+            &out_dims,                         // const size_t *out_dims,
+            &out_strides,                      // const size_t *out_strides
+        );
+        unsafe { bwd_fn.launch_async(cfg, params) }?;
+        Ok(())
     }
 }
 
-impl<E: Dtype> super::RemoveDimKernel<E> for Cuda {
+const SELECT_PTX_SRC: &str = include_str!(concat!(env!("OUT_DIR"), "/select.ptx"));
+const SELECT_MODULE_NAME: &str = "select";
+const SELECT_FWD_FN_NAME: &str = "select_forward";
+const SELECT_BWD_FN_NAME: &str = "select_backward";
+const SELECT_ALL_FN_NAMES: [&str; 2] = [SELECT_FWD_FN_NAME, SELECT_BWD_FN_NAME];
+
+impl super::RemoveDimKernel<f32> for Cuda {
     fn forward<Src: Shape, Dst: Shape, Idx: Shape>(
         &self,
-        inp: &Self::Storage<Src, E>,
+        inp: &Self::Storage<Src, f32>,
         idx: &Self::Storage<Idx, usize>,
-    ) -> Result<Self::Storage<Dst, E>, Self::Err>
+    ) -> Result<Self::Storage<Dst, f32>, Self::Err>
     where
         Src: RemoveDimTo<Dst, Idx>,
     {
-        todo!()
+        if !self.dev.has_func(SELECT_MODULE_NAME, SELECT_FWD_FN_NAME) {
+            self.dev
+                .load_ptx(SELECT_PTX_SRC.into(), SELECT_MODULE_NAME, &SELECT_ALL_FN_NAMES)?;
+        }
+
+        let dst = inp.shape.remove(idx.shape);
+        let numel = dst.num_elements();
+        let mut storage = self.dev.alloc_zeros_async::<f32>(numel)?;
+
+        let inp_dims: CudaSlice<usize> = self.dev.take_async(inp.shape.concrete().into())?;
+        let idx_dims: CudaSlice<usize> = self.dev.take_async(idx.shape.concrete().into())?;
+        let dst_dims: CudaSlice<usize> = self.dev.take_async(dst.concrete().into())?;
+        let inp_strides: CudaSlice<usize> = self.dev.take_async(inp.strides.into())?;
+        let idx_strides: CudaSlice<usize> = self.dev.take_async(idx.strides.into())?;
+        let dst_strides: CudaSlice<usize> = self.dev.take_async(dst.strides().into())?;
+
+        let fwd_fn = self.dev.get_func(SELECT_MODULE_NAME, SELECT_FWD_FN_NAME).unwrap();
+        let cfg = LaunchConfig::for_num_elems(numel as u32);
+        let params = (
+            numel,             // const size_t numel,
+            inp.data.as_ref(), // const float *inp,
+            Src::NUM_DIMS,     // const size_t inp_num_dims,
+            &inp_dims,         // const size_t *inp_dims,
+            &inp_strides,      // const size_t *inp_strides,
+            idx.data.as_ref(), // const float *idx,
+            Idx::NUM_DIMS,     // const size_t idx_num_dims,
+            &idx_dims,         // const size_t *idx_dims,
+            &idx_strides,      // const size_t *idx_strides,
+            &mut storage,      // float *out,
+            &dst_dims,         // const size_t *out_dims,
+            &dst_strides       // const size_t *out_strides
+        );
+        unsafe { fwd_fn.launch_async(cfg, params) }?;
+
+        Ok(CudaArray {
+            data: Arc::new(storage),
+            shape: dst,
+            strides: dst.strides(),
+        })
     }
 
     fn backward<Src: Shape, Dst: Shape, Idx: Shape>(
         &self,
-        grad_inp: &mut Self::Storage<Src, E>,
+        grad_inp: &mut Self::Storage<Src, f32>,
         idx: &Self::Storage<Idx, usize>,
-        grad_out: &Self::Storage<Dst, E>,
+        grad_out: &Self::Storage<Dst, f32>,
     ) -> Result<(), Self::Err>
     where
         Src: RemoveDimTo<Dst, Idx>,
     {
-        todo!()
+        let bwd_fn = self.dev.get_func(SELECT_MODULE_NAME, SELECT_BWD_FN_NAME).unwrap();
+        let numel = grad_out.data.len();
+
+        let inp_dims: CudaSlice<usize> = self.dev.take_async(grad_inp.shape.concrete().into())?;
+        let idx_dims: CudaSlice<usize> = self.dev.take_async(idx.shape.concrete().into())?;
+        let out_dims: CudaSlice<usize> = self.dev.take_async(grad_out.shape.concrete().into())?;
+        let inp_strides: CudaSlice<usize> = self.dev.take_async(grad_inp.strides.into())?;
+        let idx_strides: CudaSlice<usize> = self.dev.take_async(idx.strides.into())?;
+        let out_strides: CudaSlice<usize> = self.dev.take_async(grad_out.strides.into())?;
+
+        let cfg = LaunchConfig::for_num_elems(numel as u32);
+        let params = (
+            numel,                             // const size_t numel,
+            Arc::make_mut(&mut grad_inp.data), // float *grad_inp,
+            Src::NUM_DIMS,                     // const size_t inp_num_dims,
+            &inp_dims,                         // const size_t *inp_dims,
+            &inp_strides,                      // const size_t *inp_strides,
+            idx.data.as_ref(),                 // const float *idx,
+            Idx::NUM_DIMS,                     // const size_t idx_num_dims,
+            &idx_dims,                         // const size_t *idx_dims,
+            &idx_strides,                      // const size_t *idx_strides,
+            grad_out.data.as_ref(),            // const float *grad_out,
+            &out_dims,                         // const size_t *out_dims,
+            &out_strides,                      // const size_t *out_strides
+        );
+        unsafe { bwd_fn.launch_async(cfg, params) }?;
+        Ok(())
     }
 }

--- a/src/tensor_ops/select_and_gather/gather.cu
+++ b/src/tensor_ops/select_and_gather/gather.cu
@@ -1,0 +1,97 @@
+__device__ unsigned int get_strided_index(
+    unsigned int idx,
+    const size_t num_dims,
+    const size_t *dims,
+    const size_t *strides
+) {
+    unsigned int strided_i = 0;
+    for (unsigned int d = 0; d < num_dims; d++) {
+        unsigned int dim_idx = num_dims - 1 - d;
+        strided_i += (idx % dims[dim_idx]) * strides[dim_idx];
+        idx /= dims[dim_idx];
+    }
+    return strided_i;
+}
+
+__device__ unsigned int get_gathered_index(
+    const unsigned int index,
+    const size_t inp_num_dims,
+    const size_t *inp_dims,
+    const size_t *inp_strides,
+    const size_t *idx,
+    const size_t idx_num_dims,
+    const size_t *idx_dims,
+    const size_t *idx_strides
+) {
+    unsigned int elem_size = 1; // the size of each indexed element
+    unsigned int row_len = inp_dims[idx_num_dims - 1]; // the size of the indexed dimension
+
+    for (unsigned int d = 0; d < inp_num_dims - idx_num_dims; d++) {
+        unsigned int dim_idx = inp_num_dims - 1 - d;
+        elem_size *= inp_dims[dim_idx];
+    }
+
+    // location to find the index for the replaced dimension in "idx"
+    unsigned int idx_idx = get_strided_index(index / elem_size, idx_num_dims, idx_dims, idx_strides);
+
+    // indices for dimensions before, at, and after the indexed dimension
+    unsigned int idx_before = index / (elem_size * row_len);
+    unsigned int idx_mid = idx[idx_idx];
+    unsigned int idx_after = index % elem_size;
+
+    // recombine
+    unsigned int new_idx = (idx_before * row_len + idx_mid) * elem_size + idx_after;
+    return get_strided_index(new_idx, inp_num_dims, inp_dims, inp_strides);
+}
+
+extern "C" __global__ void gather_forward(
+    const size_t numel,
+    const float *inp,
+    const size_t inp_num_dims,
+    const size_t *inp_dims,
+    const size_t *inp_strides,
+    const size_t *idx,
+    const size_t idx_num_dims,
+    const size_t *idx_dims,
+    const size_t *idx_strides,
+    float *out,
+    const size_t *out_dims,
+    const size_t *out_strides
+) {
+    unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numel) {
+        return;
+    }
+
+    unsigned int out_i = get_strided_index(i, inp_num_dims, out_dims, out_strides);
+    unsigned int inp_i =
+        get_gathered_index(i, inp_num_dims, inp_dims, inp_strides, idx, idx_num_dims, idx_dims, idx_strides);
+
+    out[out_i] = inp[inp_i];
+}
+
+extern "C" __global__ void gather_backward(
+    const size_t numel,
+    float *grad_inp,
+    const size_t inp_num_dims,
+    const size_t *inp_dims,
+    const size_t *inp_strides,
+    const size_t *idx,
+    const size_t idx_num_dims,
+    const size_t *idx_dims,
+    const size_t *idx_strides,
+    const float *grad_out,
+    const size_t *out_dims,
+    const size_t *out_strides
+) {
+    unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numel) {
+        return;
+    }
+
+    unsigned int out_i = get_strided_index(i, inp_num_dims, out_dims, out_strides);
+    unsigned int inp_i =
+        get_gathered_index(i, inp_num_dims, inp_dims, inp_strides, idx, idx_num_dims, idx_dims, idx_strides);
+
+    atomicAdd(grad_inp + inp_i, grad_out[out_i]);
+}

--- a/src/tensor_ops/select_and_gather/select.cu
+++ b/src/tensor_ops/select_and_gather/select.cu
@@ -1,0 +1,94 @@
+__device__ unsigned int get_strided_index(
+    unsigned int idx,
+    const size_t num_dims,
+    const size_t *dims,
+    const size_t *strides
+) {
+    unsigned int strided_i = 0;
+    for (unsigned int d = 0; d < num_dims; d++) {
+        unsigned int dim_idx = num_dims - 1 - d;
+        strided_i += (idx % dims[dim_idx]) * strides[dim_idx];
+        idx /= dims[dim_idx];
+    }
+    return strided_i;
+}
+
+__device__ unsigned int get_selected_index(
+    const unsigned int index,
+    const size_t inp_num_dims,
+    const size_t *inp_dims,
+    const size_t *inp_strides,
+    const size_t *idx,
+    const size_t idx_num_dims,
+    const size_t *idx_dims,
+    const size_t *idx_strides
+) {
+    unsigned int elem_size = 1; // the size of each indexed element
+    unsigned int row_len = inp_dims[idx_num_dims]; // the size of the indexed dimension
+
+    for (unsigned int d = 0; d < inp_num_dims - idx_num_dims - 1; d++) {
+        unsigned int dim_idx = inp_num_dims - 1 - d;
+        elem_size *= inp_dims[dim_idx];
+    }
+
+    // indices for dimensions before, at, and after the indexed dimension
+    unsigned int idx_before = index / elem_size;
+    unsigned int idx_mid = idx[get_strided_index(idx_before, idx_num_dims, idx_dims, idx_strides)];
+    unsigned int idx_after = index % elem_size;
+
+    // recombine
+    unsigned int new_idx = (idx_before * row_len + idx_mid) * elem_size + idx_after;
+    return get_strided_index(new_idx, inp_num_dims, inp_dims, inp_strides);
+}
+
+extern "C" __global__ void select_forward(
+    const size_t numel,
+    const float *inp,
+    const size_t inp_num_dims,
+    const size_t *inp_dims,
+    const size_t *inp_strides,
+    const size_t *idx,
+    const size_t idx_num_dims,
+    const size_t *idx_dims,
+    const size_t *idx_strides,
+    float *out,
+    const size_t *out_dims,
+    const size_t *out_strides
+) {
+    unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numel) {
+        return;
+    }
+
+    unsigned int out_i = get_strided_index(i, inp_num_dims - 1, out_dims, out_strides);
+    unsigned int inp_i =
+        get_selected_index(i, inp_num_dims, inp_dims, inp_strides, idx, idx_num_dims, idx_dims, idx_strides);
+
+    out[out_i] = inp[inp_i];
+}
+
+extern "C" __global__ void select_backward(
+    const size_t numel,
+    float *grad_inp,
+    const size_t inp_num_dims,
+    const size_t *inp_dims,
+    const size_t *inp_strides,
+    const size_t *idx,
+    const size_t idx_num_dims,
+    const size_t *idx_dims,
+    const size_t *idx_strides,
+    const float *grad_out,
+    const size_t *out_dims,
+    const size_t *out_strides
+) {
+    unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= numel) {
+        return;
+    }
+
+    unsigned int out_i = get_strided_index(i, inp_num_dims - 1, out_dims, out_strides);
+    unsigned int inp_i =
+        get_selected_index(i, inp_num_dims, inp_dims, inp_strides, idx, idx_num_dims, idx_dims, idx_strides);
+
+    atomicAdd(grad_inp + inp_i, grad_out[out_i]);
+}


### PR DESCRIPTION
Adds cuda kernels for the SelectTo and GatherTo operations. Note that striding logic is not used to compute out_i in the gather kernel because the output tensor is never broadcasted, and because cudarc does not support calling functions with more than 12 arguments. Resolves #338.