### PR TITLE
Simplifying `trait Conv2DKernel` and Cpu implementation

### DIFF
--- a/src/tensor_ops/conv2d/cpu_kernel.rs
+++ b/src/tensor_ops/conv2d/cpu_kernel.rs
@@ -2,7 +2,7 @@ use crate::shapes::Shape;
 use crate::tensor::cpu::*;
 use crate::tensor_ops::matmul::cpu_kernel::matmul;
 
-use super::{Conv2DKernel, ConvParams};
+use super::{Conv2DKernel, Conv2DOp};
 
 use std::sync::Arc;
 
@@ -10,7 +10,7 @@ impl Cpu {
     #[inline]
     fn conv2d_forward<P: Shape<Concrete = [usize; 5]>>(
         &self,
-        op: &ConvParams,
+        op: &Conv2DOp,
         img: &[f32],
         filters: &[f32],
         out: &mut [f32],
@@ -40,7 +40,7 @@ impl Cpu {
     #[inline]
     fn conv2d_backward<P: Shape<Concrete = [usize; 5]>>(
         &self,
-        op: &ConvParams,
+        op: &Conv2DOp,
         img: &[f32],
         grad_img: &mut [f32],
         filters_tr: &[f32],
@@ -104,9 +104,9 @@ impl Cpu {
 }
 
 impl Conv2DKernel<f32> for Cpu {
-    fn forward<L: crate::shapes::Shape, R: crate::shapes::Shape, O: crate::shapes::Shape>(
+    fn forward<L: Shape, R: Shape, O: Shape>(
         &self,
-        op: super::ConvParams,
+        op: Conv2DOp,
         lhs: &Self::Storage<L, f32>,
         rhs: &Self::Storage<R, f32>,
         out: &mut Self::Storage<O, f32>,
@@ -139,9 +139,9 @@ impl Conv2DKernel<f32> for Cpu {
         Ok(())
     }
 
-    fn backward<L: crate::shapes::Shape, R: crate::shapes::Shape, O: crate::shapes::Shape>(
+    fn backward<L: Shape, R: Shape, O: Shape>(
         &self,
-        op: super::ConvParams,
+        op: Conv2DOp,
         lhs: &Self::Storage<L, f32>,
         grad_lhs: &mut Self::Storage<L, f32>,
         rhs: &Self::Storage<R, f32>,

--- a/src/tensor_ops/conv2d/cpu_kernel.rs
+++ b/src/tensor_ops/conv2d/cpu_kernel.rs
@@ -1,76 +1,70 @@
-use crate::shapes::{Const, Dim, HasShape, Rank3, Rank4};
+use crate::shapes::Shape;
 use crate::tensor::cpu::*;
 use crate::tensor_ops::matmul::cpu_kernel::matmul;
 
-use super::{Conv2DBatchedKernel, Conv2DKernel};
+use super::{Conv2DKernel, ConvParams};
+
+use std::sync::Arc;
 
 impl Cpu {
-    fn conv2d_forward<C: Dim, H: Dim, W: Dim, O: Dim, K: Dim, OH: Dim, OW: Dim>(
+    #[inline]
+    fn conv2d_forward<P: Shape<Concrete = [usize; 5]>>(
         &self,
-        stride: usize,
-        padding: usize,
-        img: View<(C, H, W), f32>,
-        filters: View<(O, C, K, K), f32>,
-        out: &mut ViewMut<(O, OH, OW), f32>,
-        inp_patches_buf: &mut StridedArray<(C, K, K, OH, OW), f32>,
+        op: &ConvParams,
+        img: &[f32],
+        filters: &[f32],
+        out: &mut [f32],
+        inp_patches_buf: &mut StridedArray<P, f32>,
     ) -> Result<(), CpuError> {
-        let (chan, height, width) = img.shape;
-        let (out_chan, out_height, out_width) = out.shape;
-        let kernel = filters.shape.3;
-
         let mut patch_iter = inp_patches_buf.iter_mut_with_index();
         while let Some((p, [c, k1, k2, oh, ow])) = patch_iter.next() {
-            let y = (oh * stride + k1).wrapping_sub(padding);
-            let x = (ow * stride + k2).wrapping_sub(padding);
-            if y < height.size() && x < width.size() {
-                *p = *img.idx(c).idx(y).idx(x);
+            let y = (oh * op.stride + k1).wrapping_sub(op.padding);
+            let x = (ow * op.stride + k2).wrapping_sub(op.padding);
+            if y < op.height_in && x < op.width_in {
+                *p = img[c * (op.width_in * op.height_in) + y * op.width_in + x];
             }
         }
 
         // (O, C * K * K) * (C * K * K, OH * OW) = (O, OH * OW)
-        let m = out_chan;
-        let k = chan.size() * kernel.size() * kernel.size();
-        let n = out_width.size() * out_height.size();
+        let m = op.channels_out;
+        let k = op.channels_in * op.kernel_size * op.kernel_size;
+        let n = op.width_out * op.height_out;
         matmul(
-            View::new(filters.data, (m, k)),
+            View::new(filters, (m, k)),
             View::new(inp_patches_buf.view().data, (k, n)),
-            &mut ViewMut::new(out.data, (m, n)),
+            &mut ViewMut::new(out, (m, n)),
         );
         Ok(())
     }
 
-    fn conv2d_backward<C: Dim, H: Dim, W: Dim, O: Dim, K: Dim, OH: Dim, OW: Dim>(
+    #[inline]
+    fn conv2d_backward<P: Shape<Concrete = [usize; 5]>>(
         &self,
-        stride: usize,
-        padding: usize,
-        img: View<(C, H, W), f32>,
-        grad_img: &mut ViewMut<(C, H, W), f32>,
-        filters_tr: View<(C, O, K, K), f32>,
-        grad_filters_tr: &mut ViewMut<(C, O, K, K), f32>,
-        grad_out: View<(O, OH, OW), f32>,
-        out_patches_buf: &mut StridedArray<(O, K, K, H, W), f32>,
+        op: &ConvParams,
+        img: &[f32],
+        grad_img: &mut [f32],
+        filters_tr: &[f32],
+        grad_filters_tr: &mut [f32],
+        grad_out: &[f32],
+        out_patches_buf: &mut StridedArray<P, f32>,
     ) -> Result<(), CpuError> {
-        let (chan, height, width) = img.shape;
-        let (out_chan, out_height, out_width) = grad_out.shape;
-        let kernel = filters_tr.shape.3;
-
         {
-            let mut out_patches_buf = out_patches_buf.view_mut();
-            for o in 0..out_chan.size() {
-                for oh in 0..out_height.size() {
-                    for ow in 0..out_width.size() {
-                        let g = *grad_out.idx(o).idx(oh).idx(ow);
-                        for k1 in 0..kernel.size() {
-                            for k2 in 0..kernel.size() {
-                                let y = (oh * stride + k1).wrapping_sub(padding);
-                                let x = (ow * stride + k2).wrapping_sub(padding);
-                                if y < height.size() && x < width.size() {
-                                    *out_patches_buf
-                                        .idx_mut(o)
-                                        .idx_mut(k1)
-                                        .idx_mut(k2)
-                                        .idx_mut(y)
-                                        .idx_mut(x) = g;
+            let out_patches_buf = out_patches_buf.view_mut();
+            for o in 0..op.channels_out {
+                for oh in 0..op.height_out {
+                    for ow in 0..op.width_out {
+                        let g =
+                            grad_out[o * (op.height_out * op.width_out) + oh * op.width_out + ow];
+                        for k1 in 0..op.kernel_size {
+                            for k2 in 0..op.kernel_size {
+                                let y = (oh * op.stride + k1).wrapping_sub(op.padding);
+                                let x = (ow * op.stride + k2).wrapping_sub(op.padding);
+                                if y < op.height_in && x < op.width_in {
+                                    out_patches_buf.data[o * out_patches_buf.strides[0]
+                                        + k1 * out_patches_buf.strides[1]
+                                        + k2 * out_patches_buf.strides[2]
+                                        + y * out_patches_buf.strides[3]
+                                        + x * out_patches_buf.strides[4]] = g;
                                 }
                             }
                         }
@@ -82,26 +76,26 @@ impl Cpu {
         {
             // img_g += filters^T * unfold(grad_out)
             // (C, H * W) += (C, O * K * K) * (O * K * K, H * W)
-            let m = chan;
-            let k = out_chan.size() * kernel.size() * kernel.size();
-            let n = height.size() * width.size();
+            let m = op.channels_in;
+            let k = op.channels_out * op.kernel_size * op.kernel_size;
+            let n = op.height_in * op.width_in;
             matmul(
-                View::new(filters_tr.data, (m, k)),
+                View::new(filters_tr, (m, k)),
                 View::new(out_patches_buf.view().data, (k, n)),
-                &mut ViewMut::new(grad_img.data, (m, n)),
+                &mut ViewMut::new(grad_img, (m, n)),
             );
         }
 
         {
             // weight_g^T += img * patches^T
             // (C, O * K * K) += (C, H * W) * (H * W, O * K * K)
-            let m = chan;
-            let k = height.size() * width.size();
-            let n = out_chan.size() * kernel.size() * kernel.size();
+            let m = op.channels_in;
+            let k = op.height_in * op.width_in;
+            let n = op.channels_out * op.kernel_size * op.kernel_size;
             matmul(
-                View::new(img.data, (m, k)),
+                View::new(img, (m, k)),
                 View::new(out_patches_buf.view().data, (n, k)).tr(),
-                &mut ViewMut::new(grad_filters_tr.data, (m, n)),
+                &mut ViewMut::new(grad_filters_tr, (m, n)),
             );
         }
 
@@ -109,150 +103,119 @@ impl Cpu {
     }
 }
 
-impl<const K: usize, const S: usize, const P: usize, const C: usize, const O: usize>
-    Conv2DKernel<f32, C, O, K, S, P> for Cpu
-{
-    fn forward<const H: usize, const W: usize>(
+impl Conv2DKernel<f32> for Cpu {
+    fn forward<L: crate::shapes::Shape, R: crate::shapes::Shape, O: crate::shapes::Shape>(
         &self,
-        lhs: &Self::Storage<Rank3<C, H, W>, f32>,
-        rhs: &Self::Storage<Rank4<O, C, K, K>, f32>,
-    ) -> Result<
-        Self::Storage<Rank3<O, { (H + 2 * P - K) / S + 1 }, { (W + 2 * P - K) / S + 1 }>, f32>,
-        Self::Err,
-    > {
-        let mut out: StridedArray<_, f32> = StridedArray::new(Default::default())?;
-        let mut patches: StridedArray<_, f32> = StridedArray::new(Default::default())?;
-        self.conv2d_forward(
-            S,
-            P,
-            lhs.view(),
-            rhs.view(),
-            &mut out.view_mut(),
-            &mut patches,
-        )?;
-        Ok(out)
-    }
-
-    fn backward<const H: usize, const W: usize>(
-        &self,
-        lhs: &Self::Storage<Rank3<C, H, W>, f32>,
-        grad_lhs: &mut Self::Storage<Rank3<C, H, W>, f32>,
-        rhs: &Self::Storage<Rank4<O, C, K, K>, f32>,
-        grad_rhs: &mut Self::Storage<Rank4<O, C, K, K>, f32>,
-        grad_out: &Self::Storage<
-            Rank3<O, { (H + 2 * P - K) / S + 1 }, { (W + 2 * P - K) / S + 1 }>,
-            f32,
-        >,
+        op: super::ConvParams,
+        lhs: &Self::Storage<L, f32>,
+        rhs: &Self::Storage<R, f32>,
+        out: &mut Self::Storage<O, f32>,
     ) -> Result<(), Self::Err> {
-        let mut patches: StridedArray<_, f32> = StridedArray::new(Default::default())?;
-        let mut f1023: StridedArray<Rank4<C, O, K, K>, f32> =
-            StridedArray::new(Default::default())?;
-        let mut grad_f1023: StridedArray<_, f32> = StridedArray::new(Default::default())?;
-
-        {
-            let rhs_view = rhs.view();
-            let mut f_iter = f1023.iter_mut_with_index();
-            while let Some((f, [c, o, k1, k2])) = f_iter.next() {
-                *f = *rhs_view.idx(o).idx(c).idx(k1).idx(k2);
-            }
+        let mut patches: StridedArray<_, f32> = StridedArray::new((
+            op.channels_in,
+            op.kernel_size,
+            op.kernel_size,
+            op.height_out,
+            op.width_out,
+        ))?;
+        let [lstride, ostride] = if L::NUM_DIMS == 3 {
+            [0; 2]
+        } else {
+            debug_assert_eq!(L::NUM_DIMS, 4);
+            [lhs.strides[0], out.strides[0]]
+        };
+        let lhs = lhs.data.as_ref();
+        let rhs = rhs.data.as_ref();
+        let out = Arc::make_mut(&mut out.data);
+        for i_batch in 0..op.batch_size {
+            self.conv2d_forward(
+                &op,
+                &lhs[i_batch * lstride..],
+                &rhs,
+                &mut out[i_batch * ostride..],
+                &mut patches,
+            )?;
         }
-
-        self.conv2d_backward(
-            S,
-            P,
-            lhs.view(),
-            &mut grad_lhs.view_mut(),
-            f1023.view(),
-            &mut grad_f1023.view_mut(),
-            grad_out.view(),
-            &mut patches,
-        )?;
-
-        {
-            let grad_f1023 = grad_f1023.view();
-            let mut iter = grad_rhs.iter_mut_with_index();
-            while let Some((f, [o, c, k1, k2])) = iter.next() {
-                *f += *grad_f1023.idx(c).idx(o).idx(k1).idx(k2);
-            }
-        }
-
         Ok(())
     }
-}
 
-impl<const K: usize, const S: usize, const P: usize, const C: usize, const O: usize>
-    Conv2DBatchedKernel<f32, C, O, K, S, P> for Cpu
-{
-    #[rustfmt::skip]
-    fn forward<B: Dim, const H: usize, const W: usize>(
+    fn backward<L: crate::shapes::Shape, R: crate::shapes::Shape, O: crate::shapes::Shape>(
         &self,
-        lhs: &Self::Storage<(B, Const<C>, Const<H>, Const<W>), f32>,
-        rhs: &Self::Storage<Rank4<O, C, K, K>, f32>,
-    ) -> Result<
-        Self::Storage<
-            (B, Const<O>, Const<{ (H + 2 * P - K) / S + 1 }>, Const<{ (W + 2 * P - K) / S + 1 }>),
-            f32,
-        >,
-        Self::Err,
-    > {
-        let batch = lhs.shape.0;
-        let mut patches: StridedArray<_, f32> = StridedArray::new(Default::default())?;
-        let mut out: StridedArray<_, f32> = StridedArray::new((batch, Const, Const, Const))?;
-        {
-            let lhs = lhs.view();
-            let rhs = rhs.view();
-            let mut out = out.view_mut();
-            for b in 0..batch.size() {
-                self.conv2d_forward(S, P, lhs.idx(b), rhs, &mut out.idx_mut(b), &mut patches)?;
-            }
-        }
-        Ok(out)
-    }
-    #[rustfmt::skip]
-    fn backward<B: Dim, const H: usize, const W: usize>(
-        &self,
-        lhs: &Self::Storage<(B, Const<C>, Const<H>, Const<W>), f32>,
-        grad_lhs: &mut Self::Storage<(B, Const<C>, Const<H>, Const<W>), f32>,
-        rhs: &Self::Storage<Rank4<O, C, K, K>, f32>,
-        grad_rhs: &mut Self::Storage<Rank4<O, C, K, K>, f32>,
-        grad_out: &Self::Storage<
-            (B, Const<O>, Const<{ (H + 2 * P - K) / S + 1 }>, Const<{ (W + 2 * P - K) / S + 1 }>),
-            f32,
-        >,
+        op: super::ConvParams,
+        lhs: &Self::Storage<L, f32>,
+        grad_lhs: &mut Self::Storage<L, f32>,
+        rhs: &Self::Storage<R, f32>,
+        grad_rhs: &mut Self::Storage<R, f32>,
+        grad_out: &Self::Storage<O, f32>,
     ) -> Result<(), Self::Err> {
-        let (batch, _, _, _) = lhs.shape();
-        let mut patches: StridedArray<_, f32> = StridedArray::new(Default::default())?;
-        let mut filters_1023: StridedArray<Rank4<C, O, K, K>, f32> =
-            StridedArray::new(Default::default())?;
-        let mut grad_filters_1023: StridedArray<Rank4<C, O, K, K>, f32> =
-            StridedArray::new(Default::default())?;
+        let mut patches: StridedArray<_, f32> = StridedArray::new((
+            op.channels_out,
+            op.kernel_size,
+            op.kernel_size,
+            op.height_in,
+            op.width_in,
+        ))?;
+
+        let mut f1023: StridedArray<_, f32> = StridedArray::new((
+            op.channels_in,
+            op.channels_out,
+            op.kernel_size,
+            op.kernel_size,
+        ))?;
+        let mut grad_f1023: StridedArray<_, f32> = StridedArray::new((
+            op.channels_in,
+            op.channels_out,
+            op.kernel_size,
+            op.kernel_size,
+        ))?;
 
         {
-            let rhs_view = rhs.view();
-            let mut f_iter = filters_1023.iter_mut_with_index();
+            // transpose filters in f1023
+            let rhs_buf = rhs.data.as_ref();
+            let mut f_iter = f1023.iter_mut_with_index();
+
             while let Some((f, [c, o, k1, k2])) = f_iter.next() {
-                *f = *rhs_view.idx(o).idx(c).idx(k1).idx(k2);
+                *f = rhs_buf[o * rhs.strides[0]
+                    + c * rhs.strides[1]
+                    + k1 * rhs.strides[2]
+                    + k2 * rhs.strides[3]];
             }
         }
 
-        let lhs = lhs.view();
-        let mut grad_lhs = grad_lhs.view_mut();
-        let grad_out = grad_out.view();
-        for b in 0..batch.size() {
+        let [lstride, ostride] = if L::NUM_DIMS == 3 {
+            [0; 2]
+        } else {
+            debug_assert_eq!(L::NUM_DIMS, 4);
+            [lhs.strides[0], grad_out.strides[0]]
+        };
+        let lhs = lhs.data.as_ref();
+        let grad_lhs = Arc::make_mut(&mut grad_lhs.data);
+        let f = f1023.data.as_ref();
+        let grad_f = Arc::make_mut(&mut grad_f1023.data);
+        let grad_out = grad_out.data.as_ref();
+
+        for i_batch in 0..op.batch_size {
             self.conv2d_backward(
-                S, P,
-                lhs.idx(b), &mut grad_lhs.idx_mut(b),
-                filters_1023.view(), &mut grad_filters_1023.view_mut(),
-                grad_out.idx(b),
-                &mut patches
+                &op,
+                &lhs[i_batch * lstride..],
+                &mut grad_lhs[i_batch * lstride..],
+                f,
+                grad_f,
+                &grad_out[i_batch * ostride..],
+                &mut patches,
             )?;
         }
 
         {
-            let grad_filters_1023 = grad_filters_1023.view();
-            let mut iter = grad_rhs.iter_mut_with_index();
-            while let Some((f, [o, c, k1, k2])) = iter.next() {
-                *f += *grad_filters_1023.idx(c).idx(o).idx(k1).idx(k2);
+            // untranspose filters
+            let grad_rhs_buf = Arc::make_mut(&mut grad_rhs.data);
+            let mut f_iter = grad_f1023.iter_with_index();
+
+            while let Some((f, [c, o, k1, k2])) = f_iter.next() {
+                grad_rhs_buf[o * rhs.strides[0]
+                    + c * rhs.strides[1]
+                    + k1 * rhs.strides[2]
+                    + k2 * rhs.strides[3]] = *f;
             }
         }
 

--- a/src/tensor_ops/conv2d/mod.rs
+++ b/src/tensor_ops/conv2d/mod.rs
@@ -14,36 +14,44 @@ use crate::{
 pub(super) struct Conv2DOp {
     pub stride: usize,
     pub padding: usize,
-    pub kernel_size: usize,
-    pub batch_size: usize,
-    pub channels_in: usize,
-    pub channels_out: usize,
-    pub height_in: usize,
-    pub height_out: usize,
-    pub width_in: usize,
-    pub width_out: usize,
+    pub kernel: usize,
+    pub batch: usize,
+    pub chan_in: usize,
+    pub chan_out: usize,
+    pub h_in: usize,
+    pub h_out: usize,
+    pub w_in: usize,
+    pub w_out: usize,
 }
 
 impl Conv2DOp {
-    fn new(
-        stride: usize,
-        padding: usize,
-        kernel_size: usize,
-        inp_shape: [usize; 4],
-        channels_out: usize,
-    ) -> Self {
+    fn new(s: usize, p: usize, k: usize, [b, c, h_in, w_in]: [usize; 4], o: usize) -> Self {
         Self {
-            stride,
-            padding,
-            kernel_size,
-            batch_size: inp_shape[0],
-            channels_in: inp_shape[1],
-            channels_out,
-            height_in: inp_shape[2],
-            height_out: (inp_shape[2] + 2 * padding - kernel_size) / stride + 1,
-            width_in: inp_shape[3],
-            width_out: (inp_shape[3] + 2 * padding - kernel_size) / stride + 1,
+            stride: s,
+            padding: p,
+            kernel: k,
+            batch: b,
+            chan_in: c,
+            chan_out: o,
+            h_in,
+            h_out: (h_in + 2 * p - k) / s + 1,
+            w_in,
+            w_out: (w_in + 2 * p - k) / s + 1,
         }
+    }
+
+    #[rustfmt::skip]
+    pub(super) fn inp_patches_shape(&self) -> (usize, usize, usize, usize, usize) {
+        (self.chan_in, self.kernel, self.kernel, self.h_out, self.w_out)
+    }
+
+    #[rustfmt::skip]
+    pub(super) fn out_patches_shape(&self) -> (usize, usize, usize, usize, usize) {
+        (self.chan_out, self.kernel, self.kernel, self.h_in, self.w_in)
+    }
+
+    pub(super) fn filters_tr_shape(&self) -> (usize, usize, usize, usize) {
+        (self.chan_in, self.chan_out, self.kernel, self.kernel)
     }
 }
 


### PR DESCRIPTION
This will bring the cpu & cuda implementations closer together. Related to #333 and #369.

Now the kernel always expects a batch size, and accepts a structure (that can be used for cuda as well), instead of being passed params as const generics.