### PR TITLE
Implement Shape for arrays (#377)

### DIFF
--- a/src/shapes/axes.rs
+++ b/src/shapes/axes.rs
@@ -85,13 +85,20 @@ pub trait HasAxes<Ax> {
 }
 
 macro_rules! impl_has_axis {
-    (($($Vars:tt),*), $Axis:tt) => {
-impl<$($Vars: Dim, )*> HasAxes<Axis<$Axis>> for ($($Vars, )*) {
-    #[inline(always)]
-    fn size(&self) -> usize {
-        self.$Axis.size()
-    }
-}
+    (($($Vars:tt),*), $Num:tt, $Axis:tt) => {
+        impl<$($Vars: Dim, )*> HasAxes<Axis<$Axis>> for ($($Vars, )*) {
+            #[inline(always)]
+            fn size(&self) -> usize {
+                self.$Axis.size()
+            }
+        }
+
+        impl HasAxes<Axis<$Axis>> for [usize; $Num] {
+            #[inline(always)]
+            fn size(&self) -> usize {
+                self[$Axis]
+            }
+        }
     };
 }
 
@@ -102,27 +109,27 @@ impl HasAxes<Axis<0>> for () {
     }
 }
 
-impl_has_axis!((D1), 0);
-impl_has_axis!((D1, D2), 0);
-impl_has_axis!((D1, D2), 1);
-impl_has_axis!((D1, D2, D3), 0);
-impl_has_axis!((D1, D2, D3), 1);
-impl_has_axis!((D1, D2, D3), 2);
-impl_has_axis!((D1, D2, D3, D4), 0);
-impl_has_axis!((D1, D2, D3, D4), 1);
-impl_has_axis!((D1, D2, D3, D4), 2);
-impl_has_axis!((D1, D2, D3, D4), 3);
-impl_has_axis!((D1, D2, D3, D4, D5), 0);
-impl_has_axis!((D1, D2, D3, D4, D5), 1);
-impl_has_axis!((D1, D2, D3, D4, D5), 2);
-impl_has_axis!((D1, D2, D3, D4, D5), 3);
-impl_has_axis!((D1, D2, D3, D4, D5), 4);
-impl_has_axis!((D1, D2, D3, D4, D5, D6), 0);
-impl_has_axis!((D1, D2, D3, D4, D5, D6), 1);
-impl_has_axis!((D1, D2, D3, D4, D5, D6), 2);
-impl_has_axis!((D1, D2, D3, D4, D5, D6), 3);
-impl_has_axis!((D1, D2, D3, D4, D5, D6), 4);
-impl_has_axis!((D1, D2, D3, D4, D5, D6), 5);
+impl_has_axis!((D1), 1, 0);
+impl_has_axis!((D1, D2), 2, 0);
+impl_has_axis!((D1, D2), 2, 1);
+impl_has_axis!((D1, D2, D3), 3, 0);
+impl_has_axis!((D1, D2, D3), 3, 1);
+impl_has_axis!((D1, D2, D3), 3, 2);
+impl_has_axis!((D1, D2, D3, D4), 4, 0);
+impl_has_axis!((D1, D2, D3, D4), 4, 1);
+impl_has_axis!((D1, D2, D3, D4), 4, 2);
+impl_has_axis!((D1, D2, D3, D4), 4, 3);
+impl_has_axis!((D1, D2, D3, D4, D5), 5, 0);
+impl_has_axis!((D1, D2, D3, D4, D5), 5, 1);
+impl_has_axis!((D1, D2, D3, D4, D5), 5, 2);
+impl_has_axis!((D1, D2, D3, D4, D5), 5, 3);
+impl_has_axis!((D1, D2, D3, D4, D5), 5, 4);
+impl_has_axis!((D1, D2, D3, D4, D5, D6), 6, 0);
+impl_has_axis!((D1, D2, D3, D4, D5, D6), 6, 1);
+impl_has_axis!((D1, D2, D3, D4, D5, D6), 6, 2);
+impl_has_axis!((D1, D2, D3, D4, D5, D6), 6, 3);
+impl_has_axis!((D1, D2, D3, D4, D5, D6), 6, 4);
+impl_has_axis!((D1, D2, D3, D4, D5, D6), 6, 5);
 
 impl<const I: isize, const J: isize, S> HasAxes<Axes2<I, J>> for S
 where

--- a/src/shapes/same_numel.rs
+++ b/src/shapes/same_numel.rs
@@ -8,10 +8,10 @@ pub trait HasSameNumelAs<Dst> {}
 
 macro_rules! impl_same_num_elements {
     ([$($SrcVs:tt),*], $SrcNumEl:tt, [$($DstVs:tt),*], $DstNumEl:tt) => {
-#[cfg(feature = "nightly")]
-impl<$(const $SrcVs: usize, )* $(const $DstVs: usize, )*> HasSameNumelAs<($(Const<$SrcVs>, )*)> for ($(Const<$DstVs>, )*)
-where
-    Assert<{ $DstNumEl == $SrcNumEl }>: ConstTrue {}
+        #[cfg(feature = "nightly")]
+        impl<$(const $SrcVs: usize, )* $(const $DstVs: usize, )*> HasSameNumelAs<($(Const<$SrcVs>, )*)> for ($(Const<$DstVs>, )*)
+        where
+            Assert<{ $DstNumEl == $SrcNumEl }>: ConstTrue {}
     };
 }
 

--- a/src/shapes/shape.rs
+++ b/src/shapes/shape.rs
@@ -177,21 +177,36 @@ pub type Rank6<const M: usize, const N: usize, const O: usize, const P: usize, c
 
 macro_rules! shape {
     (($($D:tt $Idx:tt),*), rank=$Num:expr, all=$All:tt) => {
-impl<$($D: Dim, )*> Shape for ($($D, )*) {
-    const NUM_DIMS: usize = $Num;
-    type Concrete = [usize; $Num];
-    type AllAxes = $All<$($Idx,)*>;
-    type LastAxis = Axis<{$Num - 1}>;
-    #[inline(always)]
-    fn concrete(&self) -> Self::Concrete {
-        [$(self.$Idx.size(), )*]
-    }
-    #[inline(always)]
-    fn from_concrete(concrete: &Self::Concrete) -> Option<Self> {
-        Some(($(Dim::from_size(concrete[$Idx])?, )*))
-    }
-}
-impl<$($D: ConstDim, )*> ConstShape for ($($D, )*) { }
+        impl<$($D: Dim, )*> Shape for ($($D, )*) {
+            const NUM_DIMS: usize = $Num;
+            type Concrete = [usize; $Num];
+            type AllAxes = $All<$($Idx,)*>;
+            type LastAxis = Axis<{$Num - 1}>;
+            #[inline(always)]
+            fn concrete(&self) -> Self::Concrete {
+                [$(self.$Idx.size(), )*]
+            }
+            #[inline(always)]
+            fn from_concrete(concrete: &Self::Concrete) -> Option<Self> {
+                Some(($(Dim::from_size(concrete[$Idx])?, )*))
+            }
+        }
+        impl<$($D: ConstDim, )*> ConstShape for ($($D, )*) { }
+
+        impl Shape for [usize; $Num] {
+            const NUM_DIMS: usize = $Num;
+            type Concrete = Self;
+            type AllAxes = $All<$($Idx,)*>;
+            type LastAxis = Axis<{$Num - 1}>;
+
+            fn concrete(&self) -> Self::Concrete {
+                *self
+            }
+
+            fn from_concrete(concrete: &Self::Concrete) -> Option<Self> {
+                Some(*concrete)
+            }
+        }
     };
 }
 


### PR DESCRIPTION
This pr implements the Shape trait for arrays of length 1-6, resolving #377. It also reformats many of the macro definitions involved with macro definitions to make them, in my opinion, more readable. It doesn't implement the HasSameNumelAs trait for arrays, as this is to my knowledge impossible. Perhaps we could implement runtime-checked versions of reshape_to and flatten, which would also have the benefit of working on stable.