### PR TITLE
Removes `ModuleBuilder`, Adds `BuildModule` & `BuildOnDevice`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ type Mlp = (
 
 fn main() {
     let dev: Cpu = Default::default();
-    let mlp: Mlp = dev.build_module();
+    let mlp = Mlp::build_on_device(&dev);
     let x: Tensor<Rank1<10>> = dev.zeros();
     let y /*: Tensor<Rank1<2>>*/ = mlp.forward(x);
     println!("{:?}", y);
@@ -122,11 +122,11 @@ for sequentially executing modules.
 
 ```rust
 // no idea why you would do this, but you could!
-let model: (ReLU, Sigmoid, Tanh) = dev.build_module();
+let model: (ReLU, Sigmoid, Tanh) = BuildModule::build(&dev);
 ```
 
 ```rust
-let model: (Linear<10, 5>, Tanh) = dev.build_module();
+let model: (Linear<10, 5>, Tanh) = BuildModule::build(&dev);
 ```
 
 How implementing Module for a 2-tuple looks:

--- a/README.md
+++ b/README.md
@@ -122,11 +122,13 @@ for sequentially executing modules.
 
 ```rust
 // no idea why you would do this, but you could!
-let model: (ReLU, Sigmoid, Tanh) = BuildModule::build(&dev);
+type Model = (ReLU, Sigmoid, Tanh);
+let model = Model::build_on_device(&dev);
 ```
 
 ```rust
-let model: (Linear<10, 5>, Tanh) = BuildModule::build(&dev);
+type Model = (Linear<10, 5>, Tanh)
+let model = Model::build_on_device(&dev);
 ```
 
 How implementing Module for a 2-tuple looks:

--- a/examples/03-nn.rs
+++ b/examples/03-nn.rs
@@ -1,7 +1,7 @@
 //! Intro to dfdx::nn
 
 use dfdx::{
-    nn::{Linear, Module, ModuleBuilder, ModuleMut, ReLU, ResetParams},
+    nn::{BuildModule, Linear, Module, ModuleMut, ReLU, ResetParams},
     shapes::{Const, Rank1, Rank2},
     tensor::{AsArray, Cpu, SampleTensor, Tensor, ZerosTensor},
 };
@@ -11,7 +11,7 @@ fn main() {
 
     // nn exposes many different neural network types, like the Linear layer!
     // you can use Build::build to construct an initialized model
-    let mut m: Linear<4, 2> = dev.build_module();
+    let mut m: Linear<4, 2> = BuildModule::build(&dev);
 
     // Build::reset_params also allows you to re-randomize the weights
     m.reset_params();
@@ -34,7 +34,7 @@ fn main() {
     let _: Tensor<(usize, Const<2>)> = m.forward(dev.zeros_like(&(batch_size, Const)));
 
     // you can also combine multiple modules with tuples
-    let mlp: (Linear<4, 2>, ReLU, Linear<2, 1>) = dev.build_module();
+    let mlp: (Linear<4, 2>, ReLU, Linear<2, 1>) = BuildModule::build(&dev);
 
     // and of course forward passes the input through each module sequentially:
     let x = dev.sample_normal::<Rank1<4>>();

--- a/examples/03-nn.rs
+++ b/examples/03-nn.rs
@@ -1,7 +1,7 @@
 //! Intro to dfdx::nn
 
 use dfdx::{
-    nn::{BuildModule, Linear, Module, ModuleMut, ReLU, ResetParams},
+    nn::{BuildOnDevice, Linear, Module, ModuleMut, ReLU, ResetParams},
     shapes::{Const, Rank1, Rank2},
     tensor::{AsArray, Cpu, SampleTensor, Tensor, ZerosTensor},
 };
@@ -11,7 +11,7 @@ fn main() {
 
     // nn exposes many different neural network types, like the Linear layer!
     // you can use Build::build to construct an initialized model
-    let mut m: Linear<4, 2> = BuildModule::build(&dev);
+    let mut m = Linear::<4, 2>::build_on_device(&dev);
 
     // Build::reset_params also allows you to re-randomize the weights
     m.reset_params();
@@ -34,7 +34,8 @@ fn main() {
     let _: Tensor<(usize, Const<2>)> = m.forward(dev.zeros_like(&(batch_size, Const)));
 
     // you can also combine multiple modules with tuples
-    let mlp: (Linear<4, 2>, ReLU, Linear<2, 1>) = BuildModule::build(&dev);
+    type Mlp = (Linear<4, 2>, ReLU, Linear<2, 1>);
+    let mlp = Mlp::build_on_device(&dev);
 
     // and of course forward passes the input through each module sequentially:
     let x = dev.sample_normal::<Rank1<4>>();

--- a/examples/05-optim.rs
+++ b/examples/05-optim.rs
@@ -2,7 +2,7 @@
 
 use dfdx::{
     losses::mse_loss,
-    nn::{Linear, ModuleBuilder, ModuleMut, ReLU, Tanh},
+    nn::{BuildOnDevice, Linear, ModuleMut, ReLU, Tanh},
     optim::{Momentum, Optimizer, Sgd, SgdConfig},
     shapes::Rank2,
     tensor::{AsArray, Cpu, SampleTensor},
@@ -29,7 +29,7 @@ fn main() {
     });
 
     // let's initialize our model and some dummy data
-    let mut mlp: Mlp = dev.build_module();
+    let mut mlp = Mlp::build_on_device(&dev);
     let x = dev.sample_normal::<Rank2<3, 5>>();
     let y = dev.sample_normal::<Rank2<3, 2>>();
 

--- a/examples/06-mnist.rs
+++ b/examples/06-mnist.rs
@@ -99,7 +99,7 @@ fn main() {
 
     // initialize model and optimizer
     let mut model = Mlp::build_on_device(&dev);
-    let mut opt: Adam<Mlp> = Default::default();
+    let mut opt = Adam::default();
 
     // initialize dataset
     let dataset = MnistDataset::train(&mnist_path);

--- a/examples/06-mnist.rs
+++ b/examples/06-mnist.rs
@@ -74,10 +74,10 @@ impl MnistDataset {
 
 // our network structure
 type Mlp = (
-    (Linear<784, 512, Dev>, ReLU),
-    (Linear<512, 128, Dev>, ReLU),
-    (Linear<128, 32, Dev>, ReLU),
-    Linear<32, 10, Dev>,
+    (Linear<784, 512>, ReLU),
+    (Linear<512, 128>, ReLU),
+    (Linear<128, 32>, ReLU),
+    Linear<32, 10>,
 );
 
 // training batch size
@@ -98,7 +98,7 @@ fn main() {
     let mut rng = StdRng::seed_from_u64(0);
 
     // initialize model and optimizer
-    let mut model: Mlp = dev.build_module();
+    let mut model = Mlp::build_on_device(&dev);
     let mut opt: Adam<Mlp> = Default::default();
 
     // initialize dataset

--- a/examples/11-multi-headed.rs
+++ b/examples/11-multi-headed.rs
@@ -2,7 +2,7 @@
 //! outputs using `SplitInto`.
 
 use dfdx::{
-    nn::{BuildModule, Linear, Module, SplitInto},
+    nn::{BuildOnDevice, Linear, Module, SplitInto},
     shapes::Rank1,
     tensor::{Cpu, Tensor, TensorFromArray},
 };
@@ -13,7 +13,8 @@ fn main() {
     // SplitInto accepts a tuple of modules. Each one of the items in the
     // tuple must accept the same type of input.
     // Note that here, both of the linears have the same size input (1)
-    let m: SplitInto<(Linear<1, 3>, Linear<1, 5>)> = BuildModule::build(&dev);
+    type Model = SplitInto<(Linear<1, 3>, Linear<1, 5>)>;
+    let m = Model::build_on_device(&dev);
 
     // when we forward data through, we get a tuple back!
     let _: (Tensor<Rank1<3>>, Tensor<Rank1<5>>) = m.forward(dev.tensor([1.0]));

--- a/examples/11-multi-headed.rs
+++ b/examples/11-multi-headed.rs
@@ -2,7 +2,7 @@
 //! outputs using `SplitInto`.
 
 use dfdx::{
-    nn::{Linear, Module, ModuleBuilder, SplitInto},
+    nn::{BuildModule, Linear, Module, SplitInto},
     shapes::Rank1,
     tensor::{Cpu, Tensor, TensorFromArray},
 };
@@ -13,7 +13,7 @@ fn main() {
     // SplitInto accepts a tuple of modules. Each one of the items in the
     // tuple must accept the same type of input.
     // Note that here, both of the linears have the same size input (1)
-    let m: SplitInto<(Linear<1, 3>, Linear<1, 5>)> = dev.build_module();
+    let m: SplitInto<(Linear<1, 3>, Linear<1, 5>)> = BuildModule::build(&dev);
 
     // when we forward data through, we get a tuple back!
     let _: (Tensor<Rank1<3>>, Tensor<Rank1<5>>) = m.forward(dev.tensor([1.0]));

--- a/examples/nightly-conv-net.rs
+++ b/examples/nightly-conv-net.rs
@@ -15,7 +15,7 @@ fn main() {
     );
 
     let dev: Cpu = Default::default();
-    let m: Model = dev.build_module();
+    let m = Model::build_on_device(&dev);
 
     // single image forward
     let x: Tensor<Rank3<3, 28, 28>> = dev.sample_normal();

--- a/examples/nightly-resnet18.rs
+++ b/examples/nightly-resnet18.rs
@@ -42,7 +42,7 @@ fn main() {
 
     let dev: Cpu = Default::default();
     let x = dev.sample_normal::<Rank3<3, 224, 224>>();
-    let m: Resnet18<1000> = dev.build_module();
+    let m = Resnet18::<1000>::build_on_device(&dev);
     for _ in 0.. {
         let start = Instant::now();
         let _ = m.forward(x.clone());

--- a/examples/nightly-transformer.rs
+++ b/examples/nightly-transformer.rs
@@ -6,7 +6,7 @@ fn main() {
     use dfdx::prelude::*;
 
     let dev: Cpu = Default::default();
-    let t: Transformer<16, 4, 3, 3, 8> = dev.build_module();
+    let t: Transformer<16, 4, 3, 3, 8> = BuildModule::build(&dev);
 
     let src: Tensor<Rank3<4, 12, 16>> = dev.sample_normal();
     let tgt: Tensor<Rank3<4, 6, 16>> = dev.sample_normal();

--- a/examples/nightly-transformer.rs
+++ b/examples/nightly-transformer.rs
@@ -6,7 +6,8 @@ fn main() {
     use dfdx::prelude::*;
 
     let dev: Cpu = Default::default();
-    let t: Transformer<16, 4, 3, 3, 8> = BuildModule::build(&dev);
+    type Model = Transformer<16, 4, 3, 3, 8>;
+    let t = Model::build_on_device(&dev);
 
     let src: Tensor<Rank3<4, 12, 16>> = dev.sample_normal();
     let tgt: Tensor<Rank3<4, 6, 16>> = dev.sample_normal();

--- a/examples/rl-dqn.rs
+++ b/examples/rl-dqn.rs
@@ -32,8 +32,8 @@ fn main() {
     let next_state = dev.sample_normal::<Rank2<BATCH, STATE>>();
 
     // initiliaze model
-    let mut q_net: QNetwork = dev.build_module();
-    let target_q_net: QNetwork = q_net.clone();
+    let mut q_net = QNetwork::build_on_device(&dev);
+    let target_q_net = q_net.clone();
 
     let mut sgd = Sgd::new(SgdConfig {
         lr: 1e-1,

--- a/examples/rl-ppo.rs
+++ b/examples/rl-ppo.rs
@@ -28,8 +28,8 @@ fn main() {
     let advantage = dev.sample_normal::<Rank1<BATCH>>();
 
     // initiliaze model - all weights are 0s
-    let mut pi_net: PolicyNetwork = dev.build_module();
-    let target_pi_net: PolicyNetwork = pi_net.clone();
+    let mut pi_net = PolicyNetwork::build_on_device(&dev);
+    let target_pi_net = pi_net.clone();
 
     let mut sgd = Sgd::new(SgdConfig {
         lr: 1e-1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,18 +30,19 @@
 //! );
 //! ```
 //!
-//! 3. Instantiate models with [crate::nn::ResetParams] and [crate::nn::ModuleBuilder]
+//! 3. Instantiate models with [crate::nn::BuildModule] and [crate::nn::BuildOnDevice]
 //! ```rust
 //! # use dfdx::prelude::*;
 //! let dev: Cpu = Default::default();
-//! let mlp: (Linear<5, 2>, ReLU) = dev.build_module();
+//! type Model = (Linear<5, 2>, ReLU);
+//! let mlp = Model::build_on_device(&dev);
 //! ```
 //!
 //! 4. Pass data through networks with [crate::nn::Module]
 //! ```rust
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
-//! let mlp: Linear<5, 2> = dev.build_module();
+//! let mlp: Linear<5, 2> = BuildModule::build(&dev);
 //! let x: Tensor<Rank1<5>> = dev.zeros();
 //! let y = mlp.forward(x); // compiler infers that `y` must be `Tensor<Rank1<2>>`
 //! ```
@@ -50,7 +51,7 @@
 //! ```rust
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
-//! # let model: Linear<10, 5> = dev.build_module();
+//! # let model: Linear<10, 5> = BuildModule::build(&dev);
 //! # let y_true: Tensor<Rank1<5>> = dev.sample_normal().softmax();
 //! // tensors default to not having a tape
 //! let x: Tensor<Rank1<10>, f32, Cpu, NoneTape> = dev.zeros();
@@ -67,7 +68,7 @@
 //! ```rust
 //! # use dfdx::{prelude::*, gradients::Gradients};
 //! # let dev: Cpu = Default::default();
-//! # let model: Linear<10, 5> = dev.build_module();
+//! # let model: Linear<10, 5> = BuildModule::build(&dev);
 //! # let y_true = dev.sample_normal::<Rank1<5>>().softmax();
 //! # let y = model.forward(dev.zeros::<Rank1<10>>().trace());
 //! // compute cross entropy loss
@@ -80,7 +81,7 @@
 //! ```rust
 //! # use dfdx::{prelude::*, gradients::Gradients, optim::*};
 //! # let dev: Cpu = Default::default();
-//! # let mut model: Linear<10, 5> = dev.build_module();
+//! # let mut model: Linear<10, 5> = BuildModule::build(&dev);
 //! # let y_true = dev.sample_normal::<Rank1<5>>().softmax();
 //! # let y = model.forward(dev.zeros::<Rank1<10>>().trace());
 //! # let loss = cross_entropy_with_logits_loss(y, y_true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! );
 //! ```
 //!
-//! 3. Instantiate models with [crate::nn::BuildModule] and [crate::nn::BuildOnDevice]
+//! 3. Instantiate models with [crate::nn::BuildOnDevice]
 //! ```rust
 //! # use dfdx::prelude::*;
 //! let dev: Cpu = Default::default();
@@ -42,7 +42,7 @@
 //! ```rust
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
-//! let mlp: Linear<5, 2> = BuildModule::build(&dev);
+//! # let mlp: Linear<5, 2> = BuildModule::build(&dev);
 //! let x: Tensor<Rank1<5>> = dev.zeros();
 //! let y = mlp.forward(x); // compiler infers that `y` must be `Tensor<Rank1<2>>`
 //! ```

--- a/src/nn/activations.rs
+++ b/src/nn/activations.rs
@@ -1,6 +1,6 @@
 use crate::{gradients::Tape, shapes::*, tensor::*, tensor_ops::*};
 
-use super::module::{Module, NonMutableModule, ZeroSizedModule};
+use super::module::{BuildModule, Module, NonMutableModule, ZeroSizedModule};
 
 macro_rules! activation_impls {
     ($struct_name:ident, $func_name:ident, #[$docstring:meta]) => {
@@ -10,6 +10,12 @@ macro_rules! activation_impls {
 
         impl ZeroSizedModule for $struct_name {}
         impl NonMutableModule for $struct_name {}
+
+        impl<D: Device<E>, E: Dtype> BuildModule<D, E> for $struct_name {
+            fn try_build(_: &D) -> Result<Self, <D>::Err> {
+                Ok(Default::default())
+            }
+        }
 
         impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<D>> Module<Tensor<S, E, D, T>>
             for $struct_name
@@ -40,6 +46,12 @@ pub struct Softmax;
 
 impl ZeroSizedModule for Softmax {}
 impl NonMutableModule for Softmax {}
+
+impl<D: Device<E>, E: Dtype> BuildModule<D, E> for Softmax {
+    fn try_build(_: &D) -> Result<Self, <D>::Err> {
+        Ok(Default::default())
+    }
+}
 
 impl<Ax: Axes, S: Shape<LastAxis = Ax> + ReduceShape<Ax>, E: Dtype, D: Device<E>, T: Tape<D>>
     Module<Tensor<S, E, D, T>> for Softmax

--- a/src/nn/add_into.rs
+++ b/src/nn/add_into.rs
@@ -14,7 +14,8 @@ use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let model: AddInto<(Linear<2, 5>, Linear<3, 5>)> = BuildModule::build(&dev);
+/// type Model = AddInto<(Linear<2, 5>, Linear<3, 5>)>;
+/// let model = Model::build_on_device(&dev);
 /// let a = dev.zeros::<Rank1<2>>();
 /// let b = dev.zeros::<Rank1<3>>();
 /// let _: Tensor<Rank1<5>> = model.forward((a, b));

--- a/src/nn/batchnorm2d.rs
+++ b/src/nn/batchnorm2d.rs
@@ -23,7 +23,8 @@ use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let bn: BatchNorm2D<3> = BuildModule::build(&dev);
+/// type Model = BatchNorm2D<3>;
+/// let bn = Model::build_on_device(&dev);
 /// let _ = bn.forward(dev.zeros::<Rank3<3, 2, 2>>());
 /// let _ = bn.forward(dev.zeros::<Rank4<4, 3, 2, 2>>());
 /// ```

--- a/src/nn/batchnorm2d.rs
+++ b/src/nn/batchnorm2d.rs
@@ -1,6 +1,6 @@
 use crate::{gradients::*, optim::*, shapes::*, tensor::*, tensor_ops::*};
 
-use super::{Module, ModuleMut, ResetParams, BuildModule, BuildOnDevice};
+use super::{BuildModule, BuildOnDevice, Module, ModuleMut, ResetParams};
 
 /// Batch normalization for images as described in
 /// [Batch Normalization: Accelerating Deep Network Training
@@ -23,7 +23,7 @@ use super::{Module, ModuleMut, ResetParams, BuildModule, BuildOnDevice};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let bn: BatchNorm2D<3> = dev.build_module();
+/// let bn: BatchNorm2D<3> = BuildModule::build(&dev);
 /// let _ = bn.forward(dev.zeros::<Rank3<3, 2, 2>>());
 /// let _ = bn.forward(dev.zeros::<Rank4<4, 3, 2, 2>>());
 /// ```
@@ -170,7 +170,9 @@ impl<const C: usize, D: Device<f32>> BuildModule<D, f32> for BatchNorm2D<C, D> {
     }
 }
 
-impl<const C: usize, Src: Device<f32>, Dst: Device<f32>> BuildOnDevice<Dst, f32> for BatchNorm2D<C, Src> {
+impl<const C: usize, Src: Device<f32>, Dst: Device<f32>> BuildOnDevice<Dst, f32>
+    for BatchNorm2D<C, Src>
+{
     type Built = BatchNorm2D<C, Dst>;
 }
 
@@ -198,9 +200,7 @@ impl<const C: usize, D: Device<f32>> GradientUpdate<D, f32> for BatchNorm2D<C, D
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        tests::*,
-    };
+    use crate::tests::*;
 
     #[test]
     fn test_batchnorm2d_3d_forward_mut() {

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -1,6 +1,6 @@
 use crate::{gradients::Tape, optim::*, shapes::*, tensor::*, tensor_ops::*};
 
-use super::{Module, ModuleMut, ResetParams, ToDevice};
+use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 
 /// **Requires Nightly** Performs 2d convolutions on 3d and 4d images.
 ///
@@ -56,15 +56,6 @@ where
     }
 }
 
-impl<const I: usize, const O: usize, const K: usize, const S: usize, const P: usize, Src, D>
-    BuildOnDevice<D, f32> for Conv2D<I, O, K, S, P, Src>
-where
-    Src: Device<f32>,
-    D: Device<f32>,
-{
-    type Built = Conv2D<I, O, K, S, P, D>;
-}
-
 impl<const I: usize, const O: usize, const K: usize, const S: usize, const P: usize, D>
     ResetParams<D, f32> for Conv2D<I, O, K, S, P, D>
 where
@@ -96,6 +87,7 @@ where
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<const C: usize, const O: usize, const K: usize, const S: usize, const P: usize, D, Img>
     Module<Img> for Conv2D<C, O, K, S, P, D>
 where

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -133,10 +133,8 @@ impl<'a, B: Dim, const C: usize, H: Dim, W: Dim, D: Device<f32>, T: Tape<D>>
 #[cfg(test)]
 mod tests {
     use crate::{
-        nn::ModuleBuilder,
         tensor::{AsArray, SampleTensor, ZerosTensor},
-        tensor_ops::*,
-        tests::TestDevice,
+        tests::*,
     };
 
     use super::*;
@@ -197,7 +195,7 @@ mod tests {
     fn test_conv_with_optimizer() {
         let dev: TestDevice = Default::default();
 
-        let mut m: Conv2D<2, 4, 3, 1, 0, _> = dev.build_module();
+        let mut m = Conv2D::<2, 4, 3>::build_on_device(&dev);
 
         let weight_init = m.weight.clone();
         let bias_init = m.bias.clone();

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -140,6 +140,7 @@ impl<'a, B: Dim, const C: usize, H: Dim, W: Dim, D: Device<f32>, T: Tape<D>>
 #[cfg(test)]
 mod tests {
     use crate::{
+        nn::BuildOnDevice,
         tensor::{AsArray, SampleTensor, ZerosTensor},
         tests::*,
     };
@@ -151,15 +152,15 @@ mod tests {
     fn test_forward_3d_sizes() {
         let dev: TestDevice = Default::default();
         let x = dev.zeros::<Rank3<3, 10, 10>>();
-        let _: Tensor<Rank3<2, 8, 8>, _, _, _> = Conv2D::<3, 2, 3, 1, 0, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank3<4, 8, 8>, _, _, _> = Conv2D::<3, 4, 3, 1, 0, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank3<4, 9, 9>, _, _, _> = Conv2D::<3, 4, 2, 1, 0, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank3<4, 7, 7>, _, _, _> = Conv2D::<3, 4, 4, 1, 0, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank3<2, 4, 4>, _, _, _> = Conv2D::<3, 2, 3, 2, 0, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank3<2, 3, 3>, _, _, _> = Conv2D::<3, 2, 3, 3, 0, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank3<2, 10, 10>, _, _, _> = Conv2D::<3, 2, 3, 1, 1, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank3<2, 12, 12>, _, _, _> = Conv2D::<3, 2, 3, 1, 2, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank3<2, 6, 6>, _, _, _> = Conv2D::<3, 2, 3, 2, 2, _>::build(&dev).forward(x.clone());
+        let _: Tensor<Rank3<2, 8, 8>, _, _, _> = Conv2D::<3, 2, 3>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank3<4, 8, 8>, _, _, _> = Conv2D::<3, 4, 3>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank3<4, 9, 9>, _, _, _> = Conv2D::<3, 4, 2>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank3<4, 7, 7>, _, _, _> = Conv2D::<3, 4, 4>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank3<2, 4, 4>, _, _, _> = Conv2D::<3, 2, 3, 2>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank3<2, 3, 3>, _, _, _> = Conv2D::<3, 2, 3, 3>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank3<2, 10, 10>, _, _, _> = Conv2D::<3, 2, 3, 1, 1>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank3<2, 12, 12>, _, _, _> = Conv2D::<3, 2, 3, 1, 2>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank3<2, 6, 6>, _, _, _> = Conv2D::<3, 2, 3, 2, 2>::build_on_device(&dev).forward(x.clone());
     }
 
     #[rustfmt::skip]
@@ -167,15 +168,15 @@ mod tests {
     fn test_forward_4d_sizes() {
         let dev: TestDevice = Default::default();
         let x = dev.zeros::<Rank4<5, 3, 10, 10>>();
-        let _: Tensor<Rank4<5, 2, 8, 8>, _, _, _> = Conv2D::<3, 2, 3, 1, 0, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank4<5, 4, 8, 8>, _, _, _> = Conv2D::<3, 4, 3, 1, 0, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank4<5, 4, 9, 9>, _, _, _> = Conv2D::<3, 4, 2, 1, 0, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank4<5, 4, 7, 7>, _, _, _> = Conv2D::<3, 4, 4, 1, 0, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank4<5, 2, 4, 4>, _, _, _> = Conv2D::<3, 2, 3, 2, 0, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank4<5, 2, 3, 3>, _, _, _> = Conv2D::<3, 2, 3, 3, 0, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank4<5, 2, 10, 10>, _, _, _> = Conv2D::<3, 2, 3, 1, 1, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank4<5, 2, 12, 12>, _, _, _> = Conv2D::<3, 2, 3, 1, 2, _>::build(&dev).forward(x.clone());
-        let _: Tensor<Rank4<5, 2, 6, 6>, _, _, _> = Conv2D::<3, 2, 3, 2, 2, _>::build(&dev).forward(x.clone());
+        let _: Tensor<Rank4<5, 2, 8, 8>, _, _, _> = Conv2D::<3, 2, 3>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank4<5, 4, 8, 8>, _, _, _> = Conv2D::<3, 4, 3>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank4<5, 4, 9, 9>, _, _, _> = Conv2D::<3, 4, 2>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank4<5, 4, 7, 7>, _, _, _> = Conv2D::<3, 4, 4>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank4<5, 2, 4, 4>, _, _, _> = Conv2D::<3, 2, 3, 2>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank4<5, 2, 3, 3>, _, _, _> = Conv2D::<3, 2, 3, 3>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank4<5, 2, 10, 10>, _, _, _> = Conv2D::<3, 2, 3, 1, 1>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank4<5, 2, 12, 12>, _, _, _> = Conv2D::<3, 2, 3, 1, 2>::build_on_device(&dev).forward(x.clone());
+        let _: Tensor<Rank4<5, 2, 6, 6>, _, _, _> = Conv2D::<3, 2, 3, 2, 2>::build_on_device(&dev).forward(x.clone());
     }
 
     #[test]
@@ -184,7 +185,7 @@ mod tests {
         type A = Conv2D<1, 2, 3>;
         type B = Conv2D<2, 4, 3>;
         let _: Tensor<Rank3<4, 6, 6>, _, _> =
-            <(A, B)>::build(&dev).forward(dev.zeros::<Rank3<1, 10, 10>>());
+            <(A, B)>::build_on_device(&dev).forward(dev.zeros::<Rank3<1, 10, 10>>());
     }
 
     #[test]
@@ -195,7 +196,7 @@ mod tests {
 
         let dev = Cpu::default();
         let _: Tensor<Rank3<1, 8, 8>, _, _> =
-            <(A, B, C)>::build(&dev).forward_mut(dev.zeros::<Rank3<1, 10, 10>>());
+            <(A, B, C)>::build_on_device(&dev).forward_mut(dev.zeros::<Rank3<1, 10, 10>>());
     }
 
     #[test]

--- a/src/nn/dropout.rs
+++ b/src/nn/dropout.rs
@@ -16,7 +16,7 @@ use super::{Module, ModuleMut, ZeroSizedModule};
 /// ```compile_fail
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let dropout: DropoutOneIn<2> = dev.build_module();
+/// let dropout: DropoutOneIn<2> = BuildModule::build(&dev);
 /// dropout.forward(dev.zeros::<Rank1<5>>().trace());
 /// ```
 ///

--- a/src/nn/dropout.rs
+++ b/src/nn/dropout.rs
@@ -1,6 +1,6 @@
 use crate::{gradients::*, shapes::*, tensor::Tensor, tensor_ops::*};
 
-use super::{Module, ModuleMut, ZeroSizedModule};
+use super::{BuildModule, Module, ModuleMut, ZeroSizedModule};
 
 /// Does nothing as a [Module], and calls [dropout()] as [ModuleMut] with probability `1.0 / N`.
 ///
@@ -43,6 +43,12 @@ use super::{Module, ModuleMut, ZeroSizedModule};
 pub struct DropoutOneIn<const N: usize>;
 
 impl<const N: usize> ZeroSizedModule for DropoutOneIn<N> {}
+
+impl<const N: usize, D: Device<E>, E: Dtype> BuildModule<D, E> for DropoutOneIn<N> {
+    fn try_build(_: &D) -> Result<Self, <D>::Err> {
+        Ok(Default::default())
+    }
+}
 
 impl<const N: usize, S: Shape, E: Dtype, D: Device<E>> Module<Tensor<S, E, D, NoneTape>>
     for DropoutOneIn<N>
@@ -114,6 +120,12 @@ impl Default for Dropout {
 }
 
 impl ZeroSizedModule for Dropout {}
+
+impl<D: Device<E>, E: Dtype> BuildModule<D, E> for Dropout {
+    fn try_build(_: &D) -> Result<Self, <D>::Err> {
+        Ok(Default::default())
+    }
+}
 
 impl<S: Shape, E: Dtype, D: Device<E>> Module<Tensor<S, E, D, NoneTape>> for Dropout {
     type Output = Tensor<S, E, D, NoneTape>;

--- a/src/nn/flatten.rs
+++ b/src/nn/flatten.rs
@@ -2,7 +2,7 @@
 use crate::{gradients::Tape, shapes::*, tensor::Tensor, tensor_ops::*};
 
 #[allow(unused)]
-use super::{Module, NonMutableModule, ZeroSizedModule};
+use super::{BuildModule, Module, NonMutableModule, ZeroSizedModule};
 
 /// **Requires Nightly** Flattens 3d tensors to 1d, and 4d tensors to 2d.
 #[derive(Default, Clone, Copy)]
@@ -10,6 +10,12 @@ pub struct Flatten2D;
 
 impl ZeroSizedModule for Flatten2D {}
 impl NonMutableModule for Flatten2D {}
+
+impl<D: Device<E>, E: Dtype> BuildModule<D, E> for Flatten2D {
+    fn try_build(_: &D) -> Result<Self, <D>::Err> {
+        Ok(Default::default())
+    }
+}
 
 #[cfg(feature = "nightly")]
 impl<const C: usize, const H: usize, const W: usize, D: Device<E>, E: Dtype, T: Tape<D>>

--- a/src/nn/flatten.rs
+++ b/src/nn/flatten.rs
@@ -1,6 +1,8 @@
-use super::{Module, NonMutableModule, ZeroSizedModule};
-
+#[allow(unused)]
 use crate::{gradients::Tape, shapes::*, tensor::Tensor, tensor_ops::*};
+
+#[allow(unused)]
+use super::{Module, NonMutableModule, ZeroSizedModule};
 
 /// **Requires Nightly** Flattens 3d tensors to 1d, and 4d tensors to 2d.
 #[derive(Default, Clone, Copy)]
@@ -9,6 +11,7 @@ pub struct Flatten2D;
 impl ZeroSizedModule for Flatten2D {}
 impl NonMutableModule for Flatten2D {}
 
+#[cfg(feature = "nightly")]
 impl<const C: usize, const H: usize, const W: usize, D: Device<E>, E: Dtype, T: Tape<D>>
     Module<Tensor<Rank3<C, H, W>, E, D, T>> for Flatten2D
 where
@@ -20,6 +23,7 @@ where
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<const B: usize, const C: usize, const H: usize, const W: usize, D, E: Dtype, T: Tape<D>>
     Module<Tensor<Rank4<B, C, H, W>, E, D, T>> for Flatten2D
 where

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -13,7 +13,7 @@ use super::{BuildModule, BuildOnDevice, Module, ModuleMut, ResetParams};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let module: GeneralizedResidual<ReLU, Square> = dev.build_module();
+/// let module: GeneralizedResidual<ReLU, Square> = Default::default();
 /// let x = dev.tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
 /// let y = module.forward(x);
 /// assert_eq!(y.array(), [4.0, 1.0, 0.0, 2.0, 6.0]);

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -1,6 +1,6 @@
 use crate::{optim::*, shapes::*, tensor::*, tensor_ops::*};
 
-use super::{Module, ModuleMut, ResetParams};
+use super::{BuildModule, BuildOnDevice, Module, ModuleMut, ResetParams};
 
 /// A residual connection `R` around `F`: `F(x) + R(x)`,
 /// as introduced in [Deep Residual Learning for Image Recognition](https://arxiv.org/abs/1512.03385).
@@ -37,15 +37,26 @@ impl<D: Device<E>, E: Dtype, F: GradientUpdate<D, E>, R: GradientUpdate<D, E>> G
     }
 }
 
-impl<D: Device<E>, E: Dtype, F: ResetParams<D, E>, R: ResetParams<D, E>> ResetParams<D, E>
+impl<D: Device<E>, E: Dtype, F: BuildModule<D, E>, R: BuildModule<D, E>> BuildModule<D, E>
     for GeneralizedResidual<F, R>
 {
     fn try_build(device: &D) -> Result<Self, <D>::Err> {
         Ok(Self {
-            f: ResetParams::try_build(device)?,
-            r: ResetParams::try_build(device)?,
+            f: BuildModule::try_build(device)?,
+            r: BuildModule::try_build(device)?,
         })
     }
+}
+
+impl<D: Device<E>, E: Dtype, F: BuildOnDevice<D, E>, R: BuildOnDevice<D, E>> BuildOnDevice<D, E>
+    for GeneralizedResidual<F, R>
+{
+    type Built = GeneralizedResidual<F::Built, R::Built>;
+}
+
+impl<D: Device<E>, E: Dtype, F: ResetParams<D, E>, R: ResetParams<D, E>> ResetParams<D, E>
+    for GeneralizedResidual<F, R>
+{
     fn try_reset_params(&mut self) -> Result<(), <D>::Err> {
         self.f.try_reset_params()?;
         self.r.try_reset_params()?;
@@ -78,14 +89,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::nn::{Linear, ModuleBuilder};
+    use crate::nn::Linear;
     use crate::tests::{assert_close, TestDevice};
 
     #[test]
     fn test_reset_generalized_residual() {
         let dev: TestDevice = Default::default();
 
-        let model: GeneralizedResidual<Linear<2, 5, _>, Linear<2, 5, _>> = dev.build_module();
+        let model: GeneralizedResidual<Linear<2, 5, _>, Linear<2, 5, _>> = BuildModule::build(&dev);
         assert_ne!(model.f.weight.array(), [[0.0; 2]; 5]);
         assert_ne!(model.f.bias.array(), [0.0; 5]);
         assert_ne!(model.r.weight.array(), [[0.0; 2]; 5]);
@@ -96,7 +107,7 @@ mod tests {
     fn test_generalized_residual_gradients() {
         let dev: TestDevice = Default::default();
 
-        let model: GeneralizedResidual<Linear<2, 2, _>, Linear<2, 2, _>> = dev.build_module();
+        let model: GeneralizedResidual<Linear<2, 2, _>, Linear<2, 2, _>> = BuildModule::build(&dev);
 
         let x = dev.sample_normal::<Rank2<4, 2>>();
         let y = model.forward(x.trace());

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -1,6 +1,6 @@
 use crate::{optim::*, shapes::*, tensor::*, tensor_ops::*};
 
-use super::{Module, ModuleMut, OnDevice, ResetParams, ToDevice};
+use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 
 /// A residual connection `R` around `F`: `F(x) + R(x)`,
 /// as introduced in [Deep Residual Learning for Image Recognition](https://arxiv.org/abs/1512.03385).
@@ -48,12 +48,6 @@ impl<D: Device<E>, E: Dtype, F: BuildModule<D, E>, R: BuildModule<D, E>> BuildMo
     }
 }
 
-impl<D: Device<E>, E: Dtype, F: BuildOnDevice<D, E>, R: BuildOnDevice<D, E>> BuildOnDevice<D, E>
-    for GeneralizedResidual<F, R>
-{
-    type Built = GeneralizedResidual<F::Built, R::Built>;
-}
-
 impl<D: Device<E>, E: Dtype, F: ResetParams<D, E>, R: ResetParams<D, E>> ResetParams<D, E>
     for GeneralizedResidual<F, R>
 {
@@ -65,8 +59,7 @@ impl<D: Device<E>, E: Dtype, F: ResetParams<D, E>, R: ResetParams<D, E>> ResetPa
 }
 
 impl<D, F: ToDevice<D>, R: ToDevice<D>> ToDevice<D> for GeneralizedResidual<F, R> {
-    type Output = GeneralizedResidual<OnDevice<F, D>, OnDevice<R, D>>;
-
+    type Output = GeneralizedResidual<F::Output, R::Output>;
     fn to_device(&self, device: &D) -> Self::Output {
         GeneralizedResidual {
             f: self.f.to_device(device),

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -13,9 +13,10 @@ use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let module: GeneralizedResidual<ReLU, Square> = Default::default();
+/// type Model = GeneralizedResidual<ReLU, Square>;
+/// let model = Model::build_on_device(&dev);
 /// let x = dev.tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
-/// let y = module.forward(x);
+/// let y = model.forward(x);
 /// assert_eq!(y.array(), [4.0, 1.0, 0.0, 2.0, 6.0]);
 /// ```
 #[derive(Debug, Clone, Default)]

--- a/src/nn/impl_module_for_tuples.rs
+++ b/src/nn/impl_module_for_tuples.rs
@@ -248,8 +248,8 @@ mod tests {
     #[test]
     fn test_tuple_missing_gradients() {
         let dev: TestDevice = Default::default();
-        let mut model: (Linear<5, 3, _>, Linear<5, 3, _>, Linear<5, 3, _>) =
-            BuildModule::build(&dev);
+        type Model = (Linear<5, 3>, Linear<5, 3>, Linear<5, 3>);
+        let mut model = Model::build_on_device(&dev);
         let mut g: SimpleUpdater = Default::default();
 
         // no gradients present

--- a/src/nn/impl_module_for_tuples.rs
+++ b/src/nn/impl_module_for_tuples.rs
@@ -1,6 +1,6 @@
 use crate::{optim::*, shapes::*, tensor_ops::*};
 
-use super::module::{Module, ModuleMut, OnDevice, ResetParams, ToDevice};
+use super::module::{BuildModule, Module, ModuleMut, OnDevice, ResetParams, ToDevice};
 
 macro_rules! tuple_impls {
     ([$($name:ident),+] [$($idx:tt),+], $last:ident, [$($rev_tail:ident),+]) => {
@@ -22,10 +22,6 @@ macro_rules! tuple_impls {
             }
         }
 
-        impl<D: Device<E>, E: Dtype, $($name: BuildOnDevice<D, E>),+> BuildOnDevice<D, E> for ($($name,)+) {
-            type Built = ($($name::Built, )+);
-        }
-
         impl<D: Device<E>, E: Dtype, $($name: ResetParams<D, E>),+> ResetParams<D, E> for ($($name,)+) {
             #[allow(non_snake_case)]
             fn try_reset_params(&mut self) -> Result<(), D::Err> {
@@ -36,7 +32,6 @@ macro_rules! tuple_impls {
 
         impl<$($name: ToDevice<D>,)+ D> ToDevice<D> for ($($name,)+) {
             type Output = ($(OnDevice<$name, D>,)+);
-
             fn to_device(&self, device: &D) -> Self::Output {
                 ($(self.$idx.to_device(device)),+)
             }

--- a/src/nn/impl_module_for_tuples.rs
+++ b/src/nn/impl_module_for_tuples.rs
@@ -1,6 +1,6 @@
 use crate::{optim::*, shapes::*, tensor_ops::*};
 
-use super::module::{Module, ModuleMut, ResetParams};
+use super::module::{BuildModule, BuildOnDevice, Module, ModuleMut, ResetParams};
 
 macro_rules! tuple_impls {
     ([$($name:ident),+] [$($idx:tt),+], $last:ident, [$($rev_tail:ident),+]) => {
@@ -14,13 +14,20 @@ macro_rules! tuple_impls {
             }
         }
 
-        #[allow(non_snake_case)]
-        impl<D: Device<E>, E: Dtype, $($name: ResetParams<D, E>),+> ResetParams<D, E> for ($($name,)+) {
+        impl<D: Device<E>, E: Dtype, $($name: BuildModule<D, E>),+> BuildModule<D, E> for ($($name,)+) {
+            #[allow(non_snake_case)]
             fn try_build(device: &D) -> Result<Self, D::Err> {
-                $(let $name = ResetParams::try_build(device)?;)*
+                $(let $name = BuildModule::try_build(device)?;)*
                 Ok(($($name, )*))
             }
+        }
 
+        impl<D: Device<E>, E: Dtype, $($name: BuildOnDevice<D, E>),+> BuildOnDevice<D, E> for ($($name,)+) {
+            type Built = ($($name::Built, )+);
+        }
+
+        impl<D: Device<E>, E: Dtype, $($name: ResetParams<D, E>),+> ResetParams<D, E> for ($($name,)+) {
+            #[allow(non_snake_case)]
             fn try_reset_params(&mut self) -> Result<(), D::Err> {
                 $(self.$idx.try_reset_params()?;)+
                 Ok(())
@@ -111,7 +118,7 @@ mod tests {
     #[test]
     fn test_2_tuple_update() {
         let dev: TestDevice = Default::default();
-        let mut model: (Linear<2, 3, _>, Linear<3, 4, _>) = dev.build_module();
+        let mut model: (Linear<2, 3, _>, Linear<3, 4, _>) = BuildModule::build(&dev);
         assert_ne!(model.0.weight.array(), [[0.0; 2]; 3]);
         assert_ne!(model.0.bias.array(), [0.0; 3]);
         assert_ne!(model.1.weight.array(), [[0.0; 3]; 4]);
@@ -238,7 +245,8 @@ mod tests {
     #[test]
     fn test_tuple_missing_gradients() {
         let dev: TestDevice = Default::default();
-        let mut model: (Linear<5, 3, _>, Linear<5, 3, _>, Linear<5, 3, _>) = dev.build_module();
+        let mut model: (Linear<5, 3, _>, Linear<5, 3, _>, Linear<5, 3, _>) =
+            BuildModule::build(&dev);
         let mut g: SimpleUpdater = Default::default();
 
         // no gradients present

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -16,7 +16,8 @@ use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let model: LayerNorm1D<5> = BuildModule::build(&dev);
+/// type Model = LayerNorm1D<5>;
+/// let model = Model::build_on_device(&dev);
 /// let _: Tensor<Rank1<5>> = model.forward(dev.zeros::<Rank1<5>>());
 /// ```
 #[derive(Debug, Clone)]

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -16,7 +16,7 @@ use super::{BuildModule, BuildOnDevice, Module, ModuleMut, ResetParams};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let model: LayerNorm1D<5> = dev.build_module();
+/// let model: LayerNorm1D<5> = BuildModule::build(&dev);
 /// let _: Tensor<Rank1<5>> = model.forward(dev.zeros::<Rank1<5>>());
 /// ```
 #[derive(Debug, Clone)]

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -150,11 +150,14 @@ mod tests {
     fn test_linear_ondevice() {
         use super::super::module::OnDevice;
 
-        let cpu: Cpu = Default::default();
         let cuda: Cuda = Default::default();
-        let _: Linear<1, 1, _> = cpu.build_module();
-        let _: OnDevice<Linear<1, 1>, Cuda> = cuda.build_module();
-        let _: OnDevice<(Linear<1, 2>, Linear<2, 1>), Cuda> = cuda.build_module();
+        let _: Linear<1, 1, _> = BuildModule::build(&cuda);
+        let _: OnDevice<Linear<1, 1>, Cuda> = BuildModule::build(&cuda);
+        let _: OnDevice<(Linear<1, 2>, Linear<2, 1>), Cuda> = BuildModule::build(&cuda);
+
+        let _: Linear<1, 1, Cuda> = Linear::<1, 1>::build_on_device(&cuda);
+        let _: Linear<1, 1, _> = Linear::<1, 1>::build_on_device(&cuda);
+        let _ = Linear::<1, 1>::build_on_device(&cuda);
     }
 
     #[test]

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -17,7 +17,7 @@ use super::module::{BuildModule, BuildOnDevice, Module, ModuleMut, ResetParams};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let model: Linear<5, 2> = dev.build_module();
+/// let model: Linear<5, 2> = BuildModule::build(&dev);
 /// // single item forward
 /// let _: Tensor<Rank1<2>> = model.forward(dev.zeros::<Rank1<5>>());
 /// // batched forward
@@ -140,7 +140,7 @@ mod tests {
     #[test]
     fn test_linear_initialize() {
         let dev: TestDevice = Default::default();
-        let m: Linear<2000, 1, _> = BuildModule::build(&dev);
+        let m = Linear::<2000, 1>::build_on_device(&dev);
         let bound = 1.0 / 2000.0f32.sqrt();
         for v in m.weight.as_vec() {
             assert!(-bound <= v && v <= bound && v != 0.0);

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -17,7 +17,8 @@ use super::module::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let model: Linear<5, 2> = BuildModule::build(&dev);
+/// type Model = Linear<5, 2>;
+/// let model = Model::build_on_device(&dev);
 /// // single item forward
 /// let _: Tensor<Rank1<2>> = model.forward(dev.zeros::<Rank1<5>>());
 /// // batched forward

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -89,6 +89,9 @@ mod repeated;
 mod residual;
 mod split_into;
 mod transformer;
+mod conv;
+mod flatten;
+mod pool2d;
 
 pub use activations::*;
 pub use add_into::*;
@@ -105,15 +108,9 @@ pub use residual::*;
 pub use split_into::*;
 
 #[cfg(feature = "nightly")]
-mod conv;
-#[cfg(feature = "nightly")]
 pub use conv::*;
 #[cfg(feature = "nightly")]
-mod flatten;
-#[cfg(feature = "nightly")]
 pub use flatten::*;
-#[cfg(feature = "nightly")]
-mod pool2d;
 #[cfg(feature = "nightly")]
 pub use pool2d::*;
 #[cfg(feature = "nightly")]

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -25,13 +25,36 @@
 //!
 //! # Initializing
 //!
-//! All modules implement [ResetParams], which can be combined with [ModuleBuilder]
-//! implementation on devices like so:
+//! All modules implement [BuildModule]:
 //!
 //! ```rust
 //! # use dfdx::prelude::*;
 //! let dev: Cpu = Default::default();
-//! let model: Linear<5, 2> = dev.build_module(); // will allocate & randomize params
+//! let model: Linear<5, 2> = BuildModule::build(&dev); // will allocate & randomize params
+//! ```
+//!
+//! However, this becomes hard to use when you are using multiple devices. In case you are
+//! using another device, you should use [BuildOnDevice]:
+//!
+//! ```rust
+//! # use dfdx::prelude::*;
+//! # let dev: Cpu = Default::default();
+//! type Model = Linear<5, 2>;
+//! let model = Model::build_on_device(&dev);
+//! ```
+//!
+//! Here, the return type of [BuildOnDevice] depends on the device you pass in.
+//!
+//! # Resetting parameters
+//!
+//! All modules implement [ResetParams], which allows you to reset a module back to a randomized
+//! state:
+//!
+//! ```rust
+//! # use dfdx::prelude::*;
+//! # let dev: Cpu = Default::default();
+//! let mut model: Linear<5, 2> = BuildModule::build(&dev);
+//! model.reset_params();
 //! ```
 //!
 //! # Sequential models
@@ -78,20 +101,20 @@
 mod activations;
 mod add_into;
 mod batchnorm2d;
+mod conv;
 mod dropout;
+mod flatten;
 mod generalized_residual;
 mod impl_module_for_tuples;
 mod layer_norm;
 mod linear;
 mod module;
+mod pool2d;
 mod pool_global;
 mod repeated;
 mod residual;
 mod split_into;
 mod transformer;
-mod conv;
-mod flatten;
-mod pool2d;
 
 pub use activations::*;
 pub use add_into::*;

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -25,16 +25,7 @@
 //!
 //! # Initializing
 //!
-//! All modules implement [BuildModule]:
-//!
-//! ```rust
-//! # use dfdx::prelude::*;
-//! let dev: Cpu = Default::default();
-//! let model: Linear<5, 2> = BuildModule::build(&dev); // will allocate & randomize params
-//! ```
-//!
-//! However, this becomes hard to use when you are using multiple devices. In case you are
-//! using another device, you should use [BuildOnDevice]:
+//! Use [BuildOnDevice] for device agnostic module creation/randomization:
 //!
 //! ```rust
 //! # use dfdx::prelude::*;
@@ -44,6 +35,18 @@
 //! ```
 //!
 //! Here, the return type of [BuildOnDevice] depends on the device you pass in.
+//!
+//! For example, when using device [Cpu], the type is `Linear<5, 2, Cpu>`, or when using
+//! a `Cuda` device, the type is `Linear<5, 2, Cuda>`.
+//!
+//! Alternatively, you can use [BuildModule], which requires device specific model definitions:
+//!
+//! ```rust
+//! # use dfdx::prelude::*;
+//! type Dev = Cpu;
+//! let dev: Dev = Default::default();
+//! let model: Linear<5, 2, Dev> = BuildModule::build(&dev);
+//! ```
 //!
 //! # Resetting parameters
 //!

--- a/src/nn/module.rs
+++ b/src/nn/module.rs
@@ -34,7 +34,7 @@ pub trait BuildModule<D: Device<E>, E: Dtype>: Sized {
     fn build(device: &D) -> Self {
         Self::try_build(device).unwrap()
     }
-    /// Fallible version of [ResetParams::build]
+    /// Fallible version of [BuildModule::build]
     fn try_build(device: &D) -> Result<Self, D::Err>;
 }
 

--- a/src/nn/module.rs
+++ b/src/nn/module.rs
@@ -75,11 +75,11 @@ pub trait ResetParams<D: Device<E>, E: Dtype>: Sized {
 /// blanket impls for [ResetParams], [GradientUpdate], and [ModuleMut]
 pub trait ZeroSizedModule: Default {}
 
-impl<T: ZeroSizedModule, D: Device<E>, E: Dtype> BuildModule<D, E> for T {
-    fn try_build(_: &D) -> Result<Self, <D>::Err> {
-        Ok(Default::default())
-    }
-}
+// impl<T: ZeroSizedModule, D: Device<E>, E: Dtype> BuildModule<D, E> for T {
+//     fn try_build(_: &D) -> Result<Self, <D>::Err> {
+//         Ok(Default::default())
+//     }
+// }
 
 impl<T: ZeroSizedModule, D: Device<E>, E: Dtype> ResetParams<D, E> for T {
     fn try_reset_params(&mut self) -> Result<(), <D>::Err> {
@@ -89,7 +89,6 @@ impl<T: ZeroSizedModule, D: Device<E>, E: Dtype> ResetParams<D, E> for T {
 
 impl<T: ZeroSizedModule + Clone, D> ToDevice<D> for T {
     type Output = T;
-
     fn to_device(&self, _device: &D) -> Self {
         self.clone()
     }

--- a/src/nn/module.rs
+++ b/src/nn/module.rs
@@ -39,7 +39,7 @@ pub trait BuildModule<D: Device<E>, E: Dtype>: Sized {
 }
 
 /// Something that can be built on a different device
-/// than it is on. Builds [BuildOnDevice::Built].
+/// than it is on. Builds [ToDevice::Output].
 ///
 /// Related to [BuildModule]
 pub trait BuildOnDevice<D: Device<E>, E: Dtype>: ToDevice<D>

--- a/src/nn/module.rs
+++ b/src/nn/module.rs
@@ -75,12 +75,6 @@ pub trait ResetParams<D: Device<E>, E: Dtype>: Sized {
 /// blanket impls for [ResetParams], [GradientUpdate], and [ModuleMut]
 pub trait ZeroSizedModule: Default {}
 
-// impl<T: ZeroSizedModule, D: Device<E>, E: Dtype> BuildModule<D, E> for T {
-//     fn try_build(_: &D) -> Result<Self, <D>::Err> {
-//         Ok(Default::default())
-//     }
-// }
-
 impl<T: ZeroSizedModule, D: Device<E>, E: Dtype> ResetParams<D, E> for T {
     fn try_reset_params(&mut self) -> Result<(), <D>::Err> {
         Ok(())

--- a/src/nn/npz_impls.rs
+++ b/src/nn/npz_impls.rs
@@ -347,7 +347,7 @@ mod tests {
         S: ConstShape,
         E: Dtype,
         D: Device<E>,
-        M: ResetParams<D, E> + Module<Tensor<S, E, D>> + SaveToNpz + LoadFromNpz,
+        M: BuildModule<D, E> + Module<Tensor<S, E, D>> + SaveToNpz + LoadFromNpz,
     >(
         dev: &D,
     ) where
@@ -358,8 +358,8 @@ mod tests {
         let x = dev.sample_normal();
         let file = NamedTempFile::new().expect("failed to create tempfile");
 
-        let saved: M = dev.build_module();
-        let mut loaded: M = dev.build_module();
+        let saved: M = BuildModule::build(dev);
+        let mut loaded: M = BuildModule::build(dev);
 
         let y = saved.forward(x.clone());
 
@@ -378,8 +378,8 @@ mod tests {
         let x = dev.sample_normal::<Rank3<3, 4, 5>>();
         let file = NamedTempFile::new().expect("failed to create tempfile");
 
-        let mut saved: BatchNorm2D<3, _> = dev.build_module();
-        let mut loaded: BatchNorm2D<3, _> = dev.build_module();
+        let mut saved: BatchNorm2D<3, _> = BuildModule::build(&dev);
+        let mut loaded: BatchNorm2D<3, _> = BuildModule::build(&dev);
 
         saved.running_mean.fill_with_distr(Standard);
         saved.running_var.fill_with_distr(Standard);
@@ -439,8 +439,8 @@ mod tests {
 
         let file = NamedTempFile::new().expect("failed to create tempfile");
 
-        let mut saved: M = dev.build_module();
-        let mut loaded: M = dev.build_module();
+        let mut saved: M = BuildModule::build(&dev);
+        let mut loaded: M = BuildModule::build(&dev);
 
         saved.gamma.fill_with_distr(Standard);
         saved.beta.fill_with_distr(Standard);
@@ -475,12 +475,12 @@ mod tests {
     fn test_save_load_mha() {
         let dev: TestDevice = Default::default();
 
-        let saved: MultiHeadAttention<12, 4, 12, 12, TestDevice> = dev.build_module();
+        let saved: MultiHeadAttention<12, 4, 12, 12, TestDevice> = BuildModule::build(&dev);
 
         let file = NamedTempFile::new().expect("failed to create tempfile");
         saved.save(file.path()).expect("");
 
-        let mut loaded: MultiHeadAttention<12, 4, 12, 12, TestDevice> = dev.build_module();
+        let mut loaded: MultiHeadAttention<12, 4, 12, 12, TestDevice> = BuildModule::build(&dev);
 
         let q = dev.sample_normal::<Rank3<2, 3, 12>>();
         let k = dev.sample_normal::<Rank3<2, 4, 12>>();
@@ -501,12 +501,12 @@ mod tests {
     fn test_save_load_transformer() {
         let dev: TestDevice = Default::default();
 
-        let mut saved: Transformer<16, 4, 3, 4, 8, TestDevice> = dev.build_module();
+        let mut saved: Transformer<16, 4, 3, 4, 8, TestDevice> = BuildModule::build(&dev);
 
         let file = NamedTempFile::new().expect("failed to create tempfile");
         saved.save(file.path()).expect("");
 
-        let mut loaded: Transformer<16, 4, 3, 4, 8, TestDevice> = dev.build_module();
+        let mut loaded: Transformer<16, 4, 3, 4, 8, TestDevice> = BuildModule::build(&dev);
 
         let src = dev.sample_normal::<Rank3<4, 12, 16>>();
         let tgt = dev.sample_normal::<Rank3<4, 6, 16>>();

--- a/src/nn/npz_impls.rs
+++ b/src/nn/npz_impls.rs
@@ -343,23 +343,17 @@ mod tests {
     use rand_distr::{Distribution, Standard, StandardNormal};
     use tempfile::NamedTempFile;
 
-    fn test_save_load<
-        S: ConstShape,
-        E: Dtype,
-        D: Device<E>,
-        M: BuildModule<D, E> + Module<Tensor<S, E, D>> + SaveToNpz + LoadFromNpz,
-    >(
-        dev: &D,
-    ) where
-        M::Output: AsArray,
-        <M::Output as AsArray>::Array: PartialEq,
+    fn test_save_load<S: ConstShape, E: Dtype, D: Device<E>, M: BuildOnDevice<D, E>>(dev: &D)
+    where
+        OnDevice<M, D>: BuildModule<D, E> + Module<Tensor<S, E, D>> + SaveToNpz + LoadFromNpz,
+        <OnDevice<M, D> as Module<Tensor<S, E, D>>>::Output: AsArray,
         StandardNormal: Distribution<E>,
     {
         let x = dev.sample_normal();
         let file = NamedTempFile::new().expect("failed to create tempfile");
 
-        let saved: M = BuildModule::build(dev);
-        let mut loaded: M = BuildModule::build(dev);
+        let saved: OnDevice<M, D> = M::build_on_device(dev);
+        let mut loaded: OnDevice<M, D> = M::build_on_device(dev);
 
         let y = saved.forward(x.clone());
 
@@ -374,12 +368,13 @@ mod tests {
     #[test]
     fn test_batchnorm2d_save_load() {
         let dev: TestDevice = Default::default();
+        type Model = BatchNorm2D<3>;
 
         let x = dev.sample_normal::<Rank3<3, 4, 5>>();
         let file = NamedTempFile::new().expect("failed to create tempfile");
 
-        let mut saved: BatchNorm2D<3, _> = BuildModule::build(&dev);
-        let mut loaded: BatchNorm2D<3, _> = BuildModule::build(&dev);
+        let mut saved = Model::build_on_device(&dev);
+        let mut loaded = Model::build_on_device(&dev);
 
         saved.running_mean.fill_with_distr(Standard);
         saved.running_var.fill_with_distr(Standard);
@@ -398,7 +393,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[test]
     fn test_save_load_conv() {
-        type T = Conv2D<2, 4, 3, 1, 0, TestDevice>;
+        type T = Conv2D<2, 4, 3>;
         let dev: TestDevice = Default::default();
         test_save_load::<Rank3<2, 8, 8>, f32, TestDevice, T>(&dev);
     }
@@ -406,7 +401,7 @@ mod tests {
     #[test]
     fn test_save_load_generalized_residual() {
         let dev: TestDevice = Default::default();
-        type T = GeneralizedResidual<Linear<5, 5, TestDevice>, Linear<5, 5, TestDevice>>;
+        type T = GeneralizedResidual<Linear<5, 5>, Linear<5, 5>>;
         test_save_load::<Rank1<5>, f32, TestDevice, T>(&dev);
         test_save_load::<Rank1<5>, f32, TestDevice, (T, T)>(&dev);
     }
@@ -414,7 +409,7 @@ mod tests {
     #[test]
     fn test_save_load_linear() {
         let dev: TestDevice = Default::default();
-        type T = Linear<5, 5, TestDevice>;
+        type T = Linear<5, 5>;
         test_save_load::<Rank1<5>, f32, TestDevice, T>(&dev);
         test_save_load::<Rank1<5>, f32, TestDevice, (T, T)>(&dev);
     }
@@ -423,24 +418,22 @@ mod tests {
     fn test_save_load_tuple() {
         let dev: TestDevice = Default::default();
         type T = (
-            Linear<1, 2, TestDevice>,
-            ReLU,
-            Linear<2, 3, TestDevice>,
-            (Dropout, Linear<3, 3, TestDevice>, Linear<3, 4, TestDevice>),
+            (Linear<1, 2>, ReLU, Linear<2, 3>),
+            (Dropout, Linear<3, 3>, Linear<3, 4>),
         );
         test_save_load::<Rank1<1>, f32, TestDevice, T>(&dev);
     }
 
     #[test]
     fn test_save_load_layer_norm() {
-        type M = LayerNorm1D<3, TestDevice>;
+        type M = LayerNorm1D<3>;
         let dev: TestDevice = Default::default();
         let x = dev.sample_normal::<Rank1<3>>();
 
         let file = NamedTempFile::new().expect("failed to create tempfile");
 
-        let mut saved: M = BuildModule::build(&dev);
-        let mut loaded: M = BuildModule::build(&dev);
+        let mut saved = M::build_on_device(&dev);
+        let mut loaded = M::build_on_device(&dev);
 
         saved.gamma.fill_with_distr(Standard);
         saved.beta.fill_with_distr(Standard);
@@ -456,7 +449,7 @@ mod tests {
 
     #[test]
     fn test_save_load_repeated() {
-        type T = Repeated<Linear<3, 3, TestDevice>, 4>;
+        type T = Repeated<Linear<3, 3>, 4>;
         let dev: TestDevice = Default::default();
         test_save_load::<Rank1<3>, f32, TestDevice, T>(&dev);
         test_save_load::<Rank1<3>, f32, TestDevice, (T, T)>(&dev);
@@ -464,7 +457,7 @@ mod tests {
 
     #[test]
     fn test_save_load_residual() {
-        type T = Residual<Linear<5, 5, TestDevice>>;
+        type T = Residual<Linear<5, 5>>;
         let dev: TestDevice = Default::default();
         test_save_load::<Rank1<5>, f32, TestDevice, T>(&dev);
         test_save_load::<Rank1<5>, f32, TestDevice, (T, T)>(&dev);
@@ -474,13 +467,14 @@ mod tests {
     #[test]
     fn test_save_load_mha() {
         let dev: TestDevice = Default::default();
+        type Model = MultiHeadAttention<12, 4>;
 
-        let saved: MultiHeadAttention<12, 4, 12, 12, TestDevice> = BuildModule::build(&dev);
+        let saved = Model::build_on_device(&dev);
 
         let file = NamedTempFile::new().expect("failed to create tempfile");
         saved.save(file.path()).expect("");
 
-        let mut loaded: MultiHeadAttention<12, 4, 12, 12, TestDevice> = BuildModule::build(&dev);
+        let mut loaded = Model::build_on_device(&dev);
 
         let q = dev.sample_normal::<Rank3<2, 3, 12>>();
         let k = dev.sample_normal::<Rank3<2, 4, 12>>();
@@ -500,13 +494,14 @@ mod tests {
     #[test]
     fn test_save_load_transformer() {
         let dev: TestDevice = Default::default();
+        type Model = Transformer<16, 4, 3, 4, 8>;
 
-        let mut saved: Transformer<16, 4, 3, 4, 8, TestDevice> = BuildModule::build(&dev);
+        let mut saved = Model::build_on_device(&dev);
 
         let file = NamedTempFile::new().expect("failed to create tempfile");
         saved.save(file.path()).expect("");
 
-        let mut loaded: Transformer<16, 4, 3, 4, 8, TestDevice> = BuildModule::build(&dev);
+        let mut loaded = Model::build_on_device(&dev);
 
         let src = dev.sample_normal::<Rank3<4, 12, 16>>();
         let tgt = dev.sample_normal::<Rank3<4, 6, 16>>();

--- a/src/nn/pool2d.rs
+++ b/src/nn/pool2d.rs
@@ -1,8 +1,10 @@
 #[cfg(feature = "nightly")]
 use crate::tensor_ops::{ConstAvgPool2D, ConstMaxPool2D, ConstMinPool2D};
 
+use crate::{shapes::Dtype, tensor_ops::Device};
+
 #[allow(unused)]
-use super::{Module, NonMutableModule, ZeroSizedModule};
+use super::{BuildModule, Module, NonMutableModule, ZeroSizedModule};
 
 /// Average pool with 2d kernel that operates on images (3d) and batches of images (4d).
 /// Each patch reduces to the average of the values in the patch.
@@ -38,6 +40,12 @@ macro_rules! impl_pools {
     ($PoolTy:tt, $Trait:ident) => {
         impl<const K: usize, const S: usize, const P: usize> ZeroSizedModule for $PoolTy<K, S, P> {}
         impl<const K: usize, const S: usize, const P: usize> NonMutableModule for $PoolTy<K, S, P> {}
+
+        impl<const K: usize, const S: usize, const P: usize, D: Device<E>, E: Dtype> BuildModule<D, E> for $PoolTy<K, S, P> {
+            fn try_build(_: &D) -> Result<Self, <D>::Err> {
+                Ok(Default::default())
+            }
+        }
 
         #[cfg(feature = "nightly")]
         impl<const K: usize, const S: usize, const P: usize, Img: $Trait<K, S, P>> Module<Img>

--- a/src/nn/pool2d.rs
+++ b/src/nn/pool2d.rs
@@ -1,6 +1,8 @@
-use super::{Module, NonMutableModule, ZeroSizedModule};
-
+#[cfg(feature = "nightly")]
 use crate::tensor_ops::{ConstAvgPool2D, ConstMaxPool2D, ConstMinPool2D};
+
+#[allow(unused)]
+use super::{Module, NonMutableModule, ZeroSizedModule};
 
 /// Average pool with 2d kernel that operates on images (3d) and batches of images (4d).
 /// Each patch reduces to the average of the values in the patch.
@@ -37,6 +39,7 @@ macro_rules! impl_pools {
         impl<const K: usize, const S: usize, const P: usize> ZeroSizedModule for $PoolTy<K, S, P> {}
         impl<const K: usize, const S: usize, const P: usize> NonMutableModule for $PoolTy<K, S, P> {}
 
+        #[cfg(feature = "nightly")]
         impl<const K: usize, const S: usize, const P: usize, Img: $Trait<K, S, P>> Module<Img>
             for $PoolTy<K, S, P>
         {

--- a/src/nn/pool_global.rs
+++ b/src/nn/pool_global.rs
@@ -1,6 +1,6 @@
 use crate::{gradients::*, shapes::*, tensor::*, tensor_ops::*};
 
-use super::{Module, NonMutableModule, ZeroSizedModule, BuildModule};
+use super::{BuildModule, Module, NonMutableModule, ZeroSizedModule};
 
 /// Applies average pooling over an entire image, fully reducing the height and width
 /// dimensions:

--- a/src/nn/pool_global.rs
+++ b/src/nn/pool_global.rs
@@ -1,6 +1,6 @@
 use crate::{gradients::*, shapes::*, tensor::*, tensor_ops::*};
 
-use super::{Module, NonMutableModule, ZeroSizedModule};
+use super::{Module, NonMutableModule, ZeroSizedModule, BuildModule};
 
 /// Applies average pooling over an entire image, fully reducing the height and width
 /// dimensions:
@@ -60,6 +60,12 @@ macro_rules! impl_pools {
     ($PoolTy:ty, $Method:ident) => {
         impl ZeroSizedModule for $PoolTy {}
         impl NonMutableModule for $PoolTy {}
+
+        impl<D: Device<E>, E: Dtype> BuildModule<D, E> for $PoolTy {
+            fn try_build(_: &D) -> Result<Self, <D>::Err> {
+                Ok(Default::default())
+            }
+        }
 
         impl<C: Dim, H: Dim, W: Dim, D: Device<f32>, T: Tape<D>>
             Module<Tensor<(C, H, W), f32, D, T>> for $PoolTy

--- a/src/nn/repeated.rs
+++ b/src/nn/repeated.rs
@@ -12,7 +12,8 @@ use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let model: Repeated<(Linear<10, 10>, ReLU), 5> = BuildModule::build(&dev);
+/// type Model = Repeated<(Linear<10, 10>, ReLU), 5>;
+/// let model = Model::build_on_device(&dev);
 /// let out: Tensor<Rank1<10>> = model.forward(dev.zeros());
 /// ```
 #[derive(Debug, Clone)]

--- a/src/nn/repeated.rs
+++ b/src/nn/repeated.rs
@@ -12,7 +12,7 @@ use super::{BuildModule, BuildOnDevice, Module, ModuleMut, ResetParams};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let model: Repeated<(Linear<10, 10>, ReLU), 5> = dev.build_module();
+/// let model: Repeated<(Linear<10, 10>, ReLU), 5> = BuildModule::build(&dev);
 /// let out: Tensor<Rank1<10>> = model.forward(dev.zeros());
 /// ```
 #[derive(Debug, Clone)]

--- a/src/nn/repeated.rs
+++ b/src/nn/repeated.rs
@@ -1,6 +1,6 @@
 use crate::{optim::*, shapes::Dtype, tensor_ops::Device};
 
-use super::{Module, ModuleMut, ResetParams};
+use super::{BuildModule, BuildOnDevice, Module, ModuleMut, ResetParams};
 
 /// Repeats `T` `N` times. This requires that `T`'s input is the same as it's output.
 ///
@@ -20,17 +20,27 @@ pub struct Repeated<T, const N: usize> {
     pub modules: std::vec::Vec<T>,
 }
 
-impl<D: Device<E>, E: Dtype, T: ResetParams<D, E>, const N: usize> ResetParams<D, E>
+impl<D: Device<E>, E: Dtype, T: BuildModule<D, E>, const N: usize> BuildModule<D, E>
     for Repeated<T, N>
 {
     fn try_build(device: &D) -> Result<Self, <D>::Err> {
         let mut modules = std::vec::Vec::with_capacity(N);
         for _ in 0..N {
-            modules.push(ResetParams::try_build(device)?);
+            modules.push(BuildModule::try_build(device)?);
         }
         Ok(Self { modules })
     }
+}
 
+impl<D: Device<E>, E: Dtype, T: BuildOnDevice<D, E>, const N: usize> BuildOnDevice<D, E>
+    for Repeated<T, N>
+{
+    type Built = Repeated<T::Built, N>;
+}
+
+impl<D: Device<E>, E: Dtype, T: ResetParams<D, E>, const N: usize> ResetParams<D, E>
+    for Repeated<T, N>
+{
     fn try_reset_params(&mut self) -> Result<(), <D>::Err> {
         for m in self.modules.iter_mut() {
             m.try_reset_params()?;
@@ -92,7 +102,7 @@ mod tests {
     fn test_default_and_reset() {
         let dev: TestDevice = Default::default();
 
-        let m: Repeated<(Linear<3, 3, _>, ReLU), 5> = dev.build_module();
+        let m: Repeated<(Linear<3, 3, _>, ReLU), 5> = BuildModule::build(&dev);
 
         for i in 0..5 {
             assert_ne!(m.modules[i].0.weight.array(), [[0.0; 3]; 3]);
@@ -104,7 +114,7 @@ mod tests {
     fn test_forward() {
         let dev: TestDevice = Default::default();
 
-        let mut m: Repeated<(Linear<3, 3, _>, ReLU), 5> = dev.build_module();
+        let mut m: Repeated<(Linear<3, 3, _>, ReLU), 5> = BuildModule::build(&dev);
 
         let x = dev.zeros::<Rank1<3>>();
         let x = m.modules[0].forward(x);
@@ -120,7 +130,7 @@ mod tests {
     fn test_repeated_missing_gradients() {
         let dev: TestDevice = Default::default();
 
-        let mut model: Repeated<Linear<5, 5, _>, 3> = dev.build_module();
+        let mut model: Repeated<Linear<5, 5, _>, 3> = BuildModule::build(&dev);
         let mut g: SimpleUpdater = Default::default();
 
         // no gradients present

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -12,7 +12,7 @@ use super::{BuildModule, BuildOnDevice, Module, ModuleMut, ResetParams};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let module: Residual<ReLU> = dev.build_module();
+/// let module: Residual<ReLU> = Default::default();
 /// let x = dev.tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
 /// let y = module.forward(x);
 /// assert_eq!(y.array(), [-2.0, -1.0, 0.0, 2.0, 4.0]);

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -14,9 +14,10 @@ use std::ops::Add;
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let module: Residual<ReLU> = Default::default();
+/// type Model = Residual<ReLU>;
+/// let model = Model::build_on_device(&dev);
 /// let x = dev.tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
-/// let y = module.forward(x);
+/// let y = model.forward(x);
 /// assert_eq!(y.array(), [-2.0, -1.0, 0.0, 2.0, 4.0]);
 /// ```
 #[derive(Debug, Clone, Default)]

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -1,6 +1,6 @@
 use crate::{optim::*, shapes::Dtype, tensor::*, tensor_ops::Device};
 
-use super::{Module, ModuleMut, OnDevice, ResetParams, ToDevice};
+use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 
 /// Splits input into multiple heads. `T` should be a tuple,
 /// where every element of the tuple accepts the same input type.
@@ -36,10 +36,6 @@ impl<T: BuildModule<D, E>, D: Device<E>, E: Dtype> BuildModule<D, E> for SplitIn
     }
 }
 
-impl<T: BuildOnDevice<D, E>, D: Device<E>, E: Dtype> BuildOnDevice<D, E> for SplitInto<T> {
-    type Built = SplitInto<T::Built>;
-}
-
 impl<T: ResetParams<D, E>, D: Device<E>, E: Dtype> ResetParams<D, E> for SplitInto<T> {
     fn try_reset_params(&mut self) -> Result<(), <D>::Err> {
         self.0.try_reset_params()
@@ -47,7 +43,7 @@ impl<T: ResetParams<D, E>, D: Device<E>, E: Dtype> ResetParams<D, E> for SplitIn
 }
 
 impl<T: ToDevice<D>, D> ToDevice<D> for SplitInto<T> {
-    type Output = SplitInto<OnDevice<T, D>>;
+    type Output = SplitInto<T::Output>;
 
     fn to_device(&self, device: &D) -> Self::Output {
         SplitInto(self.0.to_device(device))

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -15,7 +15,8 @@ use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let model: SplitInto<(Linear<5, 3>, Linear<5, 7>)> = BuildModule::build(&dev);
+/// type Model = SplitInto<(Linear<5, 3>, Linear<5, 7>)>;
+/// let model = Model::build_on_device(&dev);
 /// let _: (Tensor<Rank1<3>>, Tensor<Rank1<7>>) = model.forward(dev.zeros::<Rank1<5>>());
 /// ```
 #[derive(Debug, Default, Clone)]

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -15,7 +15,7 @@ use super::{BuildModule, BuildOnDevice, Module, ModuleMut, ResetParams};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let model: SplitInto<(Linear<5, 3>, Linear<5, 7>)> = dev.build_module();
+/// let model: SplitInto<(Linear<5, 3>, Linear<5, 7>)> = BuildModule::build(&dev);
 /// let _: (Tensor<Rank1<3>>, Tensor<Rank1<7>>) = model.forward(dev.zeros::<Rank1<5>>());
 /// ```
 #[derive(Debug, Default, Clone)]

--- a/src/nn/transformer/decoder.rs
+++ b/src/nn/transformer/decoder.rs
@@ -115,7 +115,7 @@ pub struct TransformerDecoderBlock<
     const MODEL_DIM: usize,
     const NUM_HEADS: usize,
     const FF_DIM: usize,
-    D: Device<f32>,
+    D: Device<f32> = Cpu,
 > {
     pub self_attn: MultiHeadAttention<MODEL_DIM, NUM_HEADS, MODEL_DIM, MODEL_DIM, D>,
     pub norm1: LayerNorm1D<MODEL_DIM, D>,
@@ -239,8 +239,8 @@ mod tests {
         const NUM_HEADS: usize = 6;
         const FF_DIM: usize = 2;
 
-        let decoder: TransformerDecoderBlock<EMBED_DIM, NUM_HEADS, FF_DIM, _> =
-            BuildModule::build(&dev);
+        let decoder =
+            TransformerDecoderBlock::<EMBED_DIM, NUM_HEADS, FF_DIM>::build_on_device(&dev);
 
         let tgt = dev.sample_normal::<Rank3<BATCH, S1, EMBED_DIM>>();
         let mem = dev.sample_normal::<Rank3<BATCH, S2, EMBED_DIM>>();

--- a/src/nn/transformer/decoder.rs
+++ b/src/nn/transformer/decoder.rs
@@ -1,5 +1,5 @@
 use crate::{
-    nn::{LayerNorm1D, Linear, Module, ModuleMut, ReLU, Repeated, ResetParams, Residual, ToDevice},
+    nn::*,
     optim::{GradientUpdate, ParamUpdater, UnusedTensors},
     tensor::{Cpu, PutTape, SplitTape},
     tensor_ops::Device,
@@ -31,15 +31,6 @@ impl<const M: usize, const H: usize, const F: usize, const L: usize, D: Device<f
     fn try_build(device: &D) -> Result<Self, D::Err> {
         Ok(Self(BuildModule::try_build(device)?))
     }
-}
-
-impl<const M: usize, const H: usize, const F: usize, const L: usize, S, D> BuildOnDevice<D, f32>
-    for TransformerDecoder<M, H, F, L, S>
-where
-    S: Device<f32>,
-    D: Device<f32>,
-{
-    type Built = TransformerDecoder<M, H, F, L, D>;
 }
 
 impl<const M: usize, const H: usize, const F: usize, const L: usize, D: Device<f32>>
@@ -149,12 +140,6 @@ impl<const M: usize, const N: usize, const F: usize, D: Device<f32>> BuildModule
             norm3: BuildModule::try_build(device)?,
         })
     }
-}
-
-impl<const M: usize, const N: usize, const F: usize, S: Device<f32>, D: Device<f32>>
-    BuildOnDevice<D, f32> for TransformerDecoderBlock<M, N, F, S>
-{
-    type Built = TransformerDecoderBlock<M, N, F, D>;
 }
 
 impl<const M: usize, const N: usize, const F: usize, D: Device<f32>> ResetParams<D, f32>

--- a/src/nn/transformer/decoder.rs
+++ b/src/nn/transformer/decoder.rs
@@ -205,10 +205,9 @@ where
 mod tests {
     use super::*;
     use crate::{
-        nn::ModuleBuilder,
         shapes::Rank3,
         tensor::{AsArray, SampleTensor},
-        tests::{assert_close, TestDevice},
+        tests::*,
     };
 
     #[test]
@@ -222,7 +221,8 @@ mod tests {
         const NUM_HEADS: usize = 6;
         const FF_DIM: usize = 2;
 
-        let decoder: TransformerDecoderBlock<EMBED_DIM, NUM_HEADS, FF_DIM, _> = dev.build_module();
+        let decoder: TransformerDecoderBlock<EMBED_DIM, NUM_HEADS, FF_DIM, _> =
+            BuildModule::build(&dev);
 
         let tgt = dev.sample_normal::<Rank3<BATCH, S1, EMBED_DIM>>();
         let mem = dev.sample_normal::<Rank3<BATCH, S2, EMBED_DIM>>();

--- a/src/nn/transformer/encoder.rs
+++ b/src/nn/transformer/encoder.rs
@@ -68,9 +68,12 @@ impl<const M: usize, const H: usize, const F: usize, D: Device<f32>> BuildModule
 
 impl<const M: usize, const H: usize, const F: usize, S, D> BuildOnDevice<D, f32>
     for TransformerEncoderBlock<M, H, F, S>
-    where S: Device<f32>, D: Device<f32> {
-        type Built = TransformerEncoderBlock<M, H, F, D>;
-    }
+where
+    S: Device<f32>,
+    D: Device<f32>,
+{
+    type Built = TransformerEncoderBlock<M, H, F, D>;
+}
 
 impl<const M: usize, const H: usize, const F: usize, D: Device<f32>> ResetParams<D, f32>
     for TransformerEncoderBlock<M, H, F, D>
@@ -136,10 +139,9 @@ where
 mod tests {
     use super::*;
     use crate::{
-        nn::ModuleBuilder,
         shapes::Rank3,
         tensor::{AsArray, SampleTensor},
-        tests::{assert_close, TestDevice},
+        tests::*,
     };
 
     #[test]
@@ -152,7 +154,8 @@ mod tests {
         const NUM_HEADS: usize = 3;
         const FF_DIM: usize = 16;
 
-        let encoder: TransformerEncoderBlock<EMBED_DIM, NUM_HEADS, FF_DIM, _> = dev.build_module();
+        let encoder: TransformerEncoderBlock<EMBED_DIM, NUM_HEADS, FF_DIM, _> =
+            BuildModule::build(&dev);
 
         let x = dev.sample_normal::<Rank3<BATCH, SEQ_LEN, EMBED_DIM>>();
         let y = encoder.forward(x);

--- a/src/nn/transformer/encoder.rs
+++ b/src/nn/transformer/encoder.rs
@@ -159,8 +159,8 @@ mod tests {
         const NUM_HEADS: usize = 3;
         const FF_DIM: usize = 16;
 
-        let encoder: TransformerEncoderBlock<EMBED_DIM, NUM_HEADS, FF_DIM, _> =
-            BuildModule::build(&dev);
+        let encoder =
+            TransformerEncoderBlock::<EMBED_DIM, NUM_HEADS, FF_DIM>::build_on_device(&dev);
 
         let x = dev.sample_normal::<Rank3<BATCH, SEQ_LEN, EMBED_DIM>>();
         let y = encoder.forward(x);

--- a/src/nn/transformer/encoder.rs
+++ b/src/nn/transformer/encoder.rs
@@ -1,5 +1,5 @@
 use crate::{
-    nn::{LayerNorm1D, Linear, Module, ModuleMut, ReLU, Repeated, ResetParams, Residual, ToDevice},
+    nn::*,
     optim::{GradientUpdate, ParamUpdater, UnusedTensors},
     tensor::{Cpu, PutTape, SplitTape},
     tensor_ops::Device,
@@ -66,15 +66,6 @@ impl<const M: usize, const H: usize, const F: usize, D: Device<f32>> BuildModule
     }
 }
 
-impl<const M: usize, const H: usize, const F: usize, S, D> BuildOnDevice<D, f32>
-    for TransformerEncoderBlock<M, H, F, S>
-where
-    S: Device<f32>,
-    D: Device<f32>,
-{
-    type Built = TransformerEncoderBlock<M, H, F, D>;
-}
-
 impl<const M: usize, const H: usize, const F: usize, D: Device<f32>> ResetParams<D, f32>
     for TransformerEncoderBlock<M, H, F, D>
 {
@@ -106,7 +97,6 @@ impl<const M: usize, const H: usize, const F: usize, D1: Device<f32>, D2: Device
     for TransformerEncoderBlock<M, H, F, D1>
 {
     type Output = TransformerEncoderBlock<M, H, F, D2>;
-
     fn to_device(&self, device: &D2) -> Self::Output {
         TransformerEncoderBlock {
             self_attn: self.self_attn.to_device(device),

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -244,7 +244,7 @@ mod tests {
         const S1: usize = 3;
         const S2: usize = 4;
 
-        let mha: MultiHeadAttention<M, NUM_HEADS, M, M, _> = dev.build_module();
+        let mha = MultiHeadAttention::<M, NUM_HEADS>::build_on_device(&dev);
 
         let q = dev.sample_normal::<Rank2<S1, M>>();
         let k = dev.sample_normal::<Rank2<S2, M>>();
@@ -278,7 +278,7 @@ mod tests {
         const S1: usize = 3;
         const S2: usize = 4;
 
-        let mha: MultiHeadAttention<M, NUM_HEADS, M, M, _> = dev.build_module();
+        let mha = MultiHeadAttention::<M, NUM_HEADS>::build_on_device(&dev);
 
         let q = dev.sample_normal::<Rank3<BATCH, S1, M>>();
         let k = dev.sample_normal::<Rank3<BATCH, S2, M>>();
@@ -328,7 +328,7 @@ mod tests {
     fn test_backward_updates_all() {
         let dev: TestDevice = Default::default();
 
-        let mut mha: MultiHeadAttention<12, 4, 12, 12, _> = dev.build_module();
+        let mut mha = MultiHeadAttention::<12, 4>::build_on_device(&dev);
 
         let q = dev.sample_normal::<Rank3<2, 3, 12>>();
         let k = dev.sample_normal::<Rank3<2, 4, 12>>();

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -45,15 +45,6 @@ impl<const M: usize, const H: usize, const K: usize, const V: usize, D: Device<f
     }
 }
 
-impl<const M: usize, const H: usize, const K: usize, const V: usize, S, D> BuildOnDevice<D, f32>
-    for MultiHeadAttention<M, H, K, V, S>
-where
-    S: Device<f32>,
-    D: Device<f32>,
-{
-    type Built = MultiHeadAttention<M, H, K, V, D>;
-}
-
 impl<const M: usize, const H: usize, const K: usize, const V: usize, D: Device<f32>>
     ResetParams<D, f32> for MultiHeadAttention<M, H, K, V, D>
 {
@@ -81,14 +72,11 @@ impl<const M: usize, const H: usize, const K: usize, const V: usize, D: Device<f
     }
 }
 
-impl<
-        const M: usize,
-        const H: usize,
-        const K: usize,
-        const V: usize,
-        D1: Device<f32>,
-        D2: Device<f32>,
-    > ToDevice<D2> for MultiHeadAttention<M, H, K, V, D1>
+impl<const M: usize, const H: usize, const K: usize, const V: usize, D1, D2> ToDevice<D2>
+    for MultiHeadAttention<M, H, K, V, D1>
+where
+    D1: Device<f32>,
+    D2: Device<f32>,
 {
     type Output = MultiHeadAttention<M, H, K, V, D2>;
 

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -33,16 +33,30 @@ pub struct MultiHeadAttention<
 }
 
 impl<const M: usize, const H: usize, const K: usize, const V: usize, D: Device<f32>>
-    ResetParams<D, f32> for MultiHeadAttention<M, H, K, V, D>
+    BuildModule<D, f32> for MultiHeadAttention<M, H, K, V, D>
 {
     fn try_build(device: &D) -> Result<Self, <D>::Err> {
         Ok(Self {
-            w_q: ResetParams::try_build(device)?,
-            w_k: ResetParams::try_build(device)?,
-            w_v: ResetParams::try_build(device)?,
-            w_o: ResetParams::try_build(device)?,
+            w_q: BuildModule::try_build(device)?,
+            w_k: BuildModule::try_build(device)?,
+            w_v: BuildModule::try_build(device)?,
+            w_o: BuildModule::try_build(device)?,
         })
     }
+}
+
+impl<const M: usize, const H: usize, const K: usize, const V: usize, S, D> BuildOnDevice<D, f32>
+    for MultiHeadAttention<M, H, K, V, S>
+where
+    S: Device<f32>,
+    D: Device<f32>,
+{
+    type Built = MultiHeadAttention<M, H, K, V, D>;
+}
+
+impl<const M: usize, const H: usize, const K: usize, const V: usize, D: Device<f32>>
+    ResetParams<D, f32> for MultiHeadAttention<M, H, K, V, D>
+{
     fn try_reset_params(&mut self) -> Result<(), <D>::Err> {
         self.w_q.try_reset_params()?;
         self.w_k.try_reset_params()?;

--- a/src/nn/transformer/mod.rs
+++ b/src/nn/transformer/mod.rs
@@ -140,18 +140,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        nn::{tests::SimpleUpdater, ModuleBuilder},
-        shapes::*,
-        tensor::*,
-        tensor_ops::*,
-        tests::TestDevice,
-    };
+    use crate::{nn::tests::SimpleUpdater, shapes::*, tensor::*, tensor_ops::*, tests::TestDevice};
 
     #[test]
     fn test_forward() {
         let dev = TestDevice::seed_from_u64(0);
-        let mut t: Transformer<16, 4, 3, 3, 8, _> = dev.build_module();
+        let mut t: Transformer<16, 4, 3, 3, 8, _> = BuildModule::build(&dev);
 
         // unbatched
         let src = dev.sample_normal::<Rank2<7, 16>>();
@@ -167,7 +161,7 @@ mod tests {
     #[test]
     fn test_backward() {
         let dev = TestDevice::seed_from_u64(0);
-        let mut t: Transformer<16, 4, 3, 3, 8, _> = dev.build_module();
+        let mut t: Transformer<16, 4, 3, 3, 8, _> = BuildModule::build(&dev);
 
         let src = dev.sample_normal::<Rank3<4, 12, 16>>();
         let tgt = dev.sample_normal::<Rank3<4, 6, 16>>();

--- a/src/nn/transformer/mod.rs
+++ b/src/nn/transformer/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     tensor_ops::Device,
 };
 
-use super::{Module, ModuleMut, ResetParams, ToDevice};
+use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 
 /// **Requires Nightly** Transformer architecture as described in
 /// [Attention is all you need](https://arxiv.org/abs/1706.03762).
@@ -63,15 +63,6 @@ where
     }
 }
 
-impl<const M: usize, const H: usize, const A: usize, const B: usize, const F: usize, S, D>
-    BuildOnDevice<D, f32> for Transformer<M, H, A, B, F, S>
-where
-    S: Device<f32>,
-    D: Device<f32>,
-{
-    type Built = Transformer<M, H, A, B, F, D>;
-}
-
 impl<const M: usize, const H: usize, const A: usize, const B: usize, const F: usize, D>
     ResetParams<D, f32> for Transformer<M, H, A, B, F, D>
 where
@@ -99,17 +90,13 @@ where
     }
 }
 
-impl<
-        const M: usize,
-        const H: usize,
-        const EL: usize,
-        const DL: usize,
-        const F: usize,
-        D1: Device<f32>,
-        D2: Device<f32>,
-    > ToDevice<D2> for Transformer<M, H, EL, DL, F, D1>
+impl<const M: usize, const H: usize, const A: usize, const B: usize, const F: usize, D1, D2>
+    ToDevice<D2> for Transformer<M, H, A, B, F, D1>
+where
+    D1: Device<f32>,
+    D2: Device<f32>,
 {
-    type Output = Transformer<M, H, EL, DL, F, D2>;
+    type Output = Transformer<M, H, A, B, F, D2>;
 
     fn to_device(&self, device: &D2) -> Self::Output {
         Transformer {

--- a/src/optim/mod.rs
+++ b/src/optim/mod.rs
@@ -17,7 +17,7 @@
 //! # use dfdx::{prelude::*, optim::*, losses, gradients::Gradients};
 //! # type MyModel = Linear<5, 2>;
 //! # let dev: Cpu = Default::default();
-//! let mut model: MyModel = dev.build_module();
+//! let mut model = MyModel::build_on_device(&dev);
 //! let mut opt: Sgd<MyModel> = Default::default();
 //! # let y = model.forward(dev.zeros::<Rank1<5>>().traced());
 //! # let loss = losses::mse_loss(y, dev.zeros());

--- a/src/tensor/storage_traits.rs
+++ b/src/tensor/storage_traits.rs
@@ -251,7 +251,7 @@ pub trait TensorFromArray<Src, S: Shape, E: Unit>: DeviceStorage {
 
 /// Convert tensors to rust arrays
 pub trait AsArray {
-    type Array: std::fmt::Debug;
+    type Array: std::fmt::Debug + PartialEq;
     fn array(&self) -> Self::Array;
 }
 impl<S: Shape, E: Unit, D: DeviceStorage, T> AsArray for Tensor<S, E, D, T>


### PR DESCRIPTION
Resolves #388 

See discussions in issue and in #394.

This removes `ModuleBuilder`, notably you can't call `dev.build_module()` anymore. Instead users should use either `BuildModule` if they are using only the Cpu device, or if they want to specify device in the typing. Or the more general `BuildOnDevice`, which should be called like `Model::build_on_device(&dev)`.

A con of this is that this does complicate creating modules a bit since there are two distinct ways to create them. The main suggested pathway should be:

1. Specifying your model as a type alias (e.g. `type Model = ...`)
2. Using `BuildOnDevice` to build it (e.g. `let mut model = Model::build_on_device(&dev)`)

This makes it trivial to switch devices in the future.

# Error message for BuildOnDevice with the wrong device

```rust
error[E0308]: mismatched types
  --> examples/tmp.rs:6:43
   |
6  |     let m: Model = Model::build_on_device(&dev);
   |                    ---------------------- ^^^^ expected struct `dfdx::tensor::Cpu`, found struct `dfdx::tensor::Cuda`
   |                    |
   |                    arguments to this function are incorrect
   |
   = note: expected reference `&dfdx::tensor::Cpu`
              found reference `&dfdx::tensor::Cuda`
note: associated function defined here
  --> /home/ubuntu/dfdx/src/nn/module.rs:49:8
   |
49 |     fn build_on_device(device: &D) -> Self::Output {
   |        ^^^^^^^^^^^^^^^
```

# Error message for BuildModule with the wrong device

```rust
error[E0277]: the trait bound `dfdx::nn::Linear<5, 2>: dfdx::nn::BuildModule<dfdx::tensor::Cuda, f32>` is not satisfied
 --> examples/tmp.rs:5:39
  |
5 |     let m: Model = BuildModule::build(&dev);
  |                    ------------------ ^^^^ the trait `dfdx::nn::BuildModule<dfdx::tensor::Cuda, f32>` is not implemented for `dfdx::nn::Linear<5, 2>`
  |                    |
  |                    required by a bound introduced by this call
  |
  = help: the trait `dfdx::nn::BuildModule<D, f32>` is implemented for `dfdx::nn::Linear<I, O, D>`

For more information about this error, try `rustc --explain E0277`.
```