### PR TITLE
[WIP/RFC] Named dynamic dims: `Dyn<'B'>`.

### DIFF
--- a/examples/01-tensor.rs
+++ b/examples/01-tensor.rs
@@ -1,7 +1,7 @@
 //! Intro to dfdx::arrays and dfdx::tensor
 
 use dfdx::{
-    shapes::{Const, HasShape, Rank1, Rank2, Rank3},
+    shapes::{Const, Dyn, HasShape, Rank1, Rank2, Rank3},
     tensor::{AsArray, Cpu, OnesTensor, SampleTensor, Tensor, TensorFromArray, ZerosTensor},
 };
 
@@ -24,7 +24,8 @@ fn main() {
     let _: Tensor<Rank3<1, 2, 3>, f32, Cpu> = dev.ones();
 
     // Dynamic size
-    let dynamic: Tensor<(usize, Const<3>, Const<4>), f32, Cpu> = dev.zeros_like(&(5, Const, Const));
+    let dynamic: Tensor<(Dyn<'B'>, Const<3>, Const<4>), f32, Cpu> =
+        dev.zeros_like(&(Dyn::<'B'>(5), Const, Const));
     println!("Dynamic shape={:?}", dynamic.shape());
 
     // each of the creation methods also supports specifying the shape on the function

--- a/examples/03-nn.rs
+++ b/examples/03-nn.rs
@@ -2,7 +2,7 @@
 
 use dfdx::{
     nn::{BuildOnDevice, Linear, Module, ModuleMut, ReLU, ResetParams},
-    shapes::{Const, Rank1, Rank2},
+    shapes::{Const, Dyn, Rank1, Rank2},
     tensor::{AsArray, Cpu, SampleTensor, Tensor, ZerosTensor},
 };
 
@@ -31,7 +31,8 @@ fn main() {
 
     // Even dynamic size is supported;
     let batch_size = 3;
-    let _: Tensor<(usize, Const<2>), f32, _> = m.forward(dev.zeros_like(&(batch_size, Const)));
+    let _: Tensor<(Dyn<'B'>, Const<2>), f32, _> =
+        m.forward(dev.zeros_like(&(Dyn::<'B'>(3), Const)));
 
     // you can also combine multiple modules with tuples
     type Mlp = (Linear<4, 2>, ReLU, Linear<2, 1>);

--- a/src/data.rs
+++ b/src/data.rs
@@ -4,7 +4,7 @@ use rand::prelude::SliceRandom;
 use std::vec::Vec;
 
 use crate::{
-    shapes::{Const, Rank1},
+    shapes::{Const, Dyn, Rank1},
     tensor::{CopySlice, DeviceStorage, Tensor, ZerosTensor},
 };
 
@@ -47,7 +47,7 @@ impl<D: DeviceStorage + ZerosTensor<f32> + CopySlice<f32>> Arange for D {}
 /// let dev: Cpu = Default::default();
 /// let class_labels = [0, 1, 2, 1, 1];
 /// // NOTE: 5 is the batch size, 3 is the number of classes
-/// let probs: Tensor<(usize, Const<3>), f32, _> = dev.one_hot_encode::<3>(&class_labels);
+/// let probs: Tensor<(Dyn<'B'>, Const<3>), f32, _> = dev.one_hot_encode::<3, 'B'>(&class_labels);
 /// assert_eq!(&probs.as_vec(), &[
 ///     1.0, 0.0, 0.0,
 ///     0.0, 1.0, 0.0,
@@ -57,17 +57,17 @@ impl<D: DeviceStorage + ZerosTensor<f32> + CopySlice<f32>> Arange for D {}
 /// ]);
 /// ```
 pub trait OneHotEncode: DeviceStorage + ZerosTensor<f32> + CopySlice<f32> {
-    fn one_hot_encode<const N: usize>(
+    fn one_hot_encode<const N: usize, const B: char>(
         &self,
         labels: &[usize],
-    ) -> Tensor<(usize, Const<N>), f32, Self> {
+    ) -> Tensor<(Dyn<B>, Const<N>), f32, Self> {
         let mut data = Vec::with_capacity(labels.len() * N);
         for &l in labels {
             for i in 0..N {
                 data.push(if i == l { 1.0 } else { 0.0 });
             }
         }
-        let mut t = self.zeros_like(&(labels.len(), Const::<N>));
+        let mut t = self.zeros_like(&(Dyn::<B>(labels.len()), Const::<N>));
         t.copy_from(&data);
         t
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! let x = dev.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
 //! let y: Tensor<Rank2<2, 3>, f32, Cpu> = dev.ones();
 //! // Runtime shape
-//! let z: Tensor<(usize, Const<3>), f32, _> = dev.ones_like(&(10, Const));
+//! let z: Tensor<(Dyn<'B'>, Const<3>), f32, _> = dev.ones_like(&(Dyn::<'B'>(10), Const));
 //! ```
 //!
 //! 2. Neural networks are built with types. Tuples are sequential models. See [crate::nn].

--- a/src/shapes/broadcasts.rs
+++ b/src/shapes/broadcasts.rs
@@ -127,34 +127,34 @@ mod tests {
 
     #[test]
     fn test_no_conflict_reductions() {
-        let src = (1, Const::<2>, 3, Const::<4>);
+        let src = (Dyn::<'B'>(1), Const::<2>, Dyn::<'C'>(3), Const::<4>);
 
-        let dst: (usize, Const<2>) = src.reduced();
-        assert_eq!(dst, (1, Const::<2>));
+        let dst: (Dyn<'B'>, Const<2>) = src.reduced();
+        assert_eq!(dst, (Dyn::<'B'>(1), Const::<2>));
 
-        let dst: (Const<2>, usize) = src.reduced();
-        assert_eq!(dst, (Const::<2>, 3));
+        let dst: (Const<2>, Dyn<'C'>) = src.reduced();
+        assert_eq!(dst, (Const::<2>, Dyn::<'C'>(3)));
 
-        let dst: (usize, usize) = src.reduced();
-        assert_eq!(dst, (1, 3));
+        let dst: (Dyn<'B'>, Dyn<'C'>) = src.reduced();
+        assert_eq!(dst, (Dyn::<'B'>(1), Dyn::<'C'>(3)));
     }
 
     #[test]
     fn test_conflicting_reductions() {
-        let src = (1, 2, Const::<3>);
+        let src = (Dyn::<'B'>(1), Dyn::<'C'>(2), Const::<3>);
 
         let dst = ReduceStridesTo::<_, Axis<1>>::reduced(&src);
-        assert_eq!(dst, (1, Const::<3>));
+        assert_eq!(dst, (Dyn::<'B'>(1), Const::<3>));
 
         let dst = ReduceStridesTo::<_, Axis<0>>::reduced(&src);
-        assert_eq!(dst, (2, Const::<3>));
+        assert_eq!(dst, (Dyn::<'C'>(2), Const::<3>));
     }
 
     #[test]
     fn test_broadcast_strides() {
-        let src = (1,);
+        let src = (Dyn::<'B'>(1),);
         let dst_strides =
-            BroadcastStridesTo::<(usize, usize, usize), Axes2<0, 2>>::broadcast_strides(
+            BroadcastStridesTo::<(Dyn<'A'>, Dyn<'B'>, Dyn<'C'>), Axes2<0, 2>>::broadcast_strides(
                 &src,
                 src.strides(),
             );

--- a/src/shapes/mod.rs
+++ b/src/shapes/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use replace_dim::{RemoveDimTo, ReplaceDimTo};
 pub(crate) use same_numel::HasSameNumelAs;
 
 pub use axes::{Axes2, Axes3, Axes4, Axes5, Axes6, Axis, HasAxes};
-pub use shape::{Const, ConstDim, Dim};
+pub use shape::{Const, ConstDim, Dim, Dyn};
 pub use shape::{ConstShape, HasShape, Shape};
 pub use shape::{Dtype, HasDtype, HasUnitType, Unit};
 pub use shape::{Rank0, Rank1, Rank2, Rank3, Rank4, Rank5, Rank6};

--- a/src/shapes/permutes.rs
+++ b/src/shapes/permutes.rs
@@ -176,18 +176,18 @@ mod tests {
 
     #[test]
     fn test_permutes() {
-        let src = (1, Const::<2>, 3, Const::<4>);
+        let src = (Dyn::<'B'>(1), Const::<2>, Dyn::<'C'>(3), Const::<4>);
 
         let dst = PermuteStridesTo::<_, Axes4<1, 0, 3, 2>>::permuted(&src);
-        assert_eq!(dst, (Const::<2>, 1, Const::<4>, 3));
+        assert_eq!(dst, (Const::<2>, Dyn::<'B'>(1), Const::<4>, Dyn::<'C'>(3)));
 
         let dst = PermuteStridesTo::<_, Axes4<2, 3, 0, 1>>::permuted(&src);
-        assert_eq!(dst, (3, Const::<4>, 1, Const::<2>));
+        assert_eq!(dst, (Dyn::<'C'>(3), Const::<4>, Dyn::<'B'>(1), Const::<2>));
     }
 
     #[test]
     fn test_permute_strides() {
-        let src = (1, Const::<2>, 3);
+        let src = (Dyn::<'B'>(1), Const::<2>, Dyn::<'C'>(3));
         let dst_strides =
             PermuteStridesTo::<_, Axes3<1, 2, 0>>::permute_strides(&src, src.strides());
         assert_eq!(src.strides(), [6, 3, 1]);

--- a/src/shapes/shape.rs
+++ b/src/shapes/shape.rs
@@ -47,14 +47,30 @@ pub trait Dim: 'static + Copy + Clone + std::fmt::Debug + Send + Sync + Eq + Par
 /// instances are guarunteed to be the same size at compile time.
 pub trait ConstDim: Default + Dim {}
 
-impl Dim for usize {
+// impl Dim for usize {
+//     #[inline(always)]
+//     fn size(&self) -> usize {
+//         *self
+//     }
+//     #[inline(always)]
+//     fn from_size(size: usize) -> Option<Self> {
+//         Some(size)
+//     }
+// }
+
+/// Represents a [Dim] with size known at compile time
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Dyn<const M: char>(pub usize);
+
+impl<const M: char> Dim for Dyn<M> {
     #[inline(always)]
     fn size(&self) -> usize {
-        *self
+        self.0
     }
+
     #[inline(always)]
     fn from_size(size: usize) -> Option<Self> {
-        Some(size)
+        Some(Dyn(size))
     }
 }
 

--- a/src/tensor/storage_traits.rs
+++ b/src/tensor/storage_traits.rs
@@ -115,7 +115,7 @@ pub trait ZerosTensor<E: Unit>: DeviceStorage {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let a: Tensor<(usize, Const<3>), f32, _> = dev.zeros_like(&(5, Const));
+    /// let a: Tensor<(Dyn<'B'>, Const<3>), f32, _> = dev.zeros_like(&(Dyn::<'B'>(5), Const));
     /// ```
     ///
     /// Given another tensor:
@@ -163,7 +163,7 @@ pub trait OnesTensor<E: Unit>: DeviceStorage {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let a: Tensor<(usize, Const<3>), f32, _> = dev.ones_like(&(5, Const));
+    /// let a: Tensor<(Dyn<'B'>, Const<3>), f32, _> = dev.ones_like(&(Dyn::<'B'>(5), Const));
     /// ```
     ///
     /// Given another tensor:


### PR DESCRIPTION
This PR tries to get named dynamic dimensions into the library.

The rationale is that some dynamic code can get messy really quick with
`usize` when there are several dimensions which are dynamic.

Let's take a realistic example: an inference webserver doing dynamic
batching on a transformer model.

```rust
const DIM: usize = 768;
const H: usize = 12;
let batch : Tensor<(usize, usize, Const<DIM>)> = dev.zeros_like(&(batch,
sequence_length, Const));

/// Within the transformer's attention.
/// Equivalent of https://github.com/coreylowman/dfdx/blob/main/src/nn/transformer/mha.rs
/// with dynamic sizes

let v: Tensor<(usize, usize, DIM)>, _, _, _> = self.w_v.forward(v.retaped::<T>());
let v = v.reshape::<(usize, usize, Const<H>, Const<{ DIM / H }>)>();
let v = v.permute::<(usize, Const<H>, usize, Const<{ DIM / H }>)>();
```

And now this is where it hurts, it starts to be non obvious intent.
Did we mean to swap out axis0/axis2 ? or not ?

And this gets exacerbated when trying to work with Encoder/Decoder (two
sequence lengths) and with past_key_values (another sequence_length
within the decoder).

The goal is to replace (or simply add it) this with:

```rust
const DIM: usize = 768;
let batch : Tensor<(Dyn<'B'>, Dyn<'S'>, Const<DIM>)> = dev.zeros_like(&(batch,
sequence_length, Const));

/// Within the transformer's attention.
/// Equivalent of https://github.com/coreylowman/dfdx/blob/main/src/nn/transformer/mha.rs
/// with dynamic sizes

let v: Tensor<(Dyn<'B'>, Dyn<'S'>, Const<DIM>)>, _, _, _> = self.w_v.forward(v.retaped::<T>());
let v = v.reshape::<(Dyn<'B'>, Dyn<'S'>, Const<H>, Const<{ V / H }>)>();
let v = v.permute::<(Dyn<'B'>, Const<H>, Dyn<'S'>, Const<{ V / H }>)>();
```

### Pros

- More readable with multiple dynamic axes
- Less readable in simple cases
- Actual type safety:

```rust
let a : Tensor<Dyn<'B'>> = dev.zeros_like(&(Dyn::<'B'>(5),));
// Other part of the code
let b : Tensor<Dyn<'C'>> = dev.zeros_like(&(Dyn::<'C'>(5),));

let c = a + b; // Invalid
```

### Cons

- Might get tricky to represent to represent sums like Dyn<'B' + 1 > /
  Dyn<'B' / 2> (Is there a real need though ? ror transformers with past there is indeed a sequence addition (past + current) but if everything is dynamic it should be relatively doable)
- Might be confusing that's this size is **not** enforced at compile
  time (since it's dynamic). Only the name is enforced.
  So:

```rust
let dynamic: Tensor<(Dyn<'B'>, Const<3>, Const<4>)> =
    dev.ones_like(&(Dyn::<'B'>(5), Const, Const));
let dynamic2: Tensor<(Dyn<'B'>, Const<3>, Const<4>)> =
    dev.ones_like(&(Dyn::<'B'>(2), Const, Const));
let a = dynamic + dynamic2;
```

This is a runtime error (currently silently failing to do the right
computation). This was already the case, but this is even less obvious.

This is all I can come up with.
What do you think.