### PR TITLE
Removing defaults for Tensor Dtype & Device generic parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ fn main() {
     let dev: Cpu = Default::default();
     // OR `let dev: Cuda = Default::default();`
     let mlp = Mlp::build_on_device(&dev);
-    let x: Tensor<Rank1<10>> = dev.zeros();
-    let y /*: Tensor<Rank1<2>>*/ = mlp.forward(x);
+    let x: Tensor<Rank1<10>, f32, Cpu> = dev.zeros();
+    let y /*: Tensor<Rank1<2>, f32, Cpu>*/ = mlp.forward(x);
     println!("{:?}", y);
     mlp.save("checkpoint.npz")?;
 }
@@ -93,13 +93,13 @@ sgd.update(&mut model, gradients);
 
 3. 💡 Tensors can be converted to and from normal rust arrays
 ```rust
-let t0: Tensor<Rank0> = dev.tensor(0.0);
+let t0: Tensor<Rank0, f32, _> = dev.tensor(0.0);
 assert_eq!(t0.array(), &0.0);
 
-let t1 /*: Tensor<Rank1<3>>*/ = dev.tensor([1.0, 2.0, 3.0]);
+let t1 /*: Tensor<Rank1<3>, f32, _>*/ = dev.tensor([1.0, 2.0, 3.0]);
 assert_eq!(t1.array(), [1.0, 2.0, 3.0]);
 
-let t2: Tensor<Rank2<2, 3>> = dev.sample_normal();
+let t2: Tensor<Rank2<2, 3>, f32, _> = dev.sample_normal();
 assert_ne!(t2.array(), [[0.0; 3]; 2]);
 ```
 

--- a/examples/01-tensor.rs
+++ b/examples/01-tensor.rs
@@ -16,32 +16,35 @@ fn main() {
     // 2. Data type (in this case the default of `f32`)
     // 3. The device they are stored on (in this case the default of `Cpu`)
     // 4. A tape - see examples/04-gradients.rs
-    let _: Tensor<Rank1<5>> = dev.tensor([1.0, 2.0, 3.0, 4.0, 5.0]);
+    let _: Tensor<Rank1<5>, f32, Cpu> = dev.tensor([1.0, 2.0, 3.0, 4.0, 5.0]);
 
     // You can also use [ZerosTensor::zeros] and [OnesTensor::ones] to create tensors
     // filled with the corresponding values.
-    let _: Tensor<Rank2<2, 3>> = dev.zeros();
-    let _: Tensor<Rank3<1, 2, 3>> = dev.ones();
+    let _: Tensor<Rank2<2, 3>, f32, Cpu> = dev.zeros();
+    let _: Tensor<Rank3<1, 2, 3>, f32, Cpu> = dev.ones();
 
     // Dynamic size
-    let dynamic: Tensor<(usize, Const<3>, Const<4>)> = dev.zeros_like(&(5, Const, Const));
+    let dynamic: Tensor<(usize, Const<3>, Const<4>), f32, Cpu> = dev.zeros_like(&(5, Const, Const));
     println!("Dynamic shape={:?}", dynamic.shape());
 
     // each of the creation methods also supports specifying the shape on the function
     // note to change the dtype we specify the dtype as the 2nd generic parameter
-    let _: Tensor<Rank2<2, 3>, f64> = dev.zeros();
-    let _ = dev.ones::<Rank2<2, 3>>();
+    let _: Tensor<Rank2<2, 3>, f64, Cpu> = dev.zeros();
+    let _: Tensor<Rank2<2, 3>, f32, Cpu> = dev.ones();
 
     // we can also create tensors filled with random values
     // from a normal distribution
-    let _: Tensor<Rank3<2, 3, 4>> = dev.sample(rand_distr::StandardNormal);
+    let _: Tensor<Rank3<2, 3, 4>, f32, Cpu> = dev.sample_normal();
 
     // or a uniform distribution
-    let a: Tensor<Rank3<2, 3, 4>> = dev.sample(rand_distr::Uniform::new(0.0f32, 1.0));
+    let _: Tensor<Rank3<2, 3, 4>, f32, Cpu> = dev.sample_uniform();
+
+    // or whatever distributino you want to use!
+    let a: Tensor<Rank3<2, 3, 4>, f32, Cpu> = dev.sample(rand_distr::Uniform::new(-1.0, 1.0));
 
     // use `AsArray::as_array` to get acces to the data as an array
     let a_data: [[[f32; 4]; 3]; 2] = a.array();
-    println!("a={:?}", a_data);
+    println!("a={a_data:?}");
 
     // you can clone() a tensor:
     let a_copy = a.clone();

--- a/examples/02-ops.rs
+++ b/examples/02-ops.rs
@@ -2,17 +2,19 @@
 
 use dfdx::{
     shapes::{Rank0, Rank1, Rank2},
-    tensor::{AsArray, Cpu, SampleTensor},
+    tensor::{AsArray, Cpu, SampleTensor, Tensor},
     tensor_ops::{MeanTo, TryMatMul},
 };
 
 fn main() {
     let dev: Cpu = Default::default();
 
-    let a = dev.sample_normal::<Rank2<2, 3>>();
+    let a: Tensor<Rank2<2, 3>, f32, _> = dev.sample_normal();
     dbg!(a.array());
 
-    let b = dev.sample_normal::<Rank2<2, 3>>();
+    // rust can infer the shape & dtype here because we add this
+    // to a below!
+    let b = dev.sample_normal();
     dbg!(b.array());
 
     // we can do binary operations like add two tensors together
@@ -41,14 +43,14 @@ fn main() {
         / 2.0;
 
     // then we have things like matrix and vector multiplication:
-    let a = dev.sample_normal::<Rank2<3, 5>>();
-    let b = dev.sample_normal::<Rank2<5, 7>>();
+    let a: Tensor<Rank2<3, 5>, f32, _> = dev.sample_normal();
+    let b: Tensor<Rank2<5, 7>, f32, _> = dev.sample_normal();
     let c = a.matmul(b);
     dbg!(c.array());
 
     // which even the outer product between two vectors!
-    let a = dev.sample_normal::<Rank1<3>>();
-    let b = dev.sample_normal::<Rank1<7>>();
+    let a: Tensor<Rank1<3>, f32, _> = dev.sample_normal();
+    let b: Tensor<Rank1<7>, f32, _> = dev.sample_normal();
     let c = a.matmul(b);
     dbg!(c.array());
 }

--- a/examples/03-nn.rs
+++ b/examples/03-nn.rs
@@ -18,28 +18,28 @@ fn main() {
 
     // Modules act on tensors using either:
     // 1. `Module::forward`, which does not mutate the module
-    let _: Tensor<Rank1<2>> = m.forward(dev.zeros::<Rank1<4>>());
+    let _: Tensor<Rank1<2>, f32, _> = m.forward(dev.zeros::<Rank1<4>>());
 
     // 2. `ModuleMut::forward_mut()`, which may mutate the module
-    let _: Tensor<Rank1<2>> = m.forward_mut(dev.zeros::<Rank1<4>>());
+    let _: Tensor<Rank1<2>, f32, _> = m.forward_mut(dev.zeros::<Rank1<4>>());
 
     // most of them can also act on many different shapes of tensors
     // here we see that Linear can also accept batches of inputs
     // Note: the Rank2 with a batch size of 10 in the input
     //       AND the output
-    let _: Tensor<Rank2<10, 2>> = m.forward(dev.zeros::<Rank2<10, 4>>());
+    let _: Tensor<Rank2<10, 2>, f32, _> = m.forward(dev.zeros::<Rank2<10, 4>>());
 
     // Even dynamic size is supported;
     let batch_size = 3;
-    let _: Tensor<(usize, Const<2>)> = m.forward(dev.zeros_like(&(batch_size, Const)));
+    let _: Tensor<(usize, Const<2>), f32, _> = m.forward(dev.zeros_like(&(batch_size, Const)));
 
     // you can also combine multiple modules with tuples
     type Mlp = (Linear<4, 2>, ReLU, Linear<2, 1>);
     let mlp = Mlp::build_on_device(&dev);
 
     // and of course forward passes the input through each module sequentially:
-    let x = dev.sample_normal::<Rank1<4>>();
-    let a: Tensor<Rank1<1>> = mlp.forward(x.clone());
+    let x: Tensor<Rank1<4>, f32, _> = dev.sample_normal();
+    let a = mlp.forward(x.clone());
     let b = mlp.2.forward(mlp.1.forward(mlp.0.forward(x)));
     assert_eq!(a.array(), b.array());
 }

--- a/examples/04-gradients.rs
+++ b/examples/04-gradients.rs
@@ -19,14 +19,14 @@ fn main() {
     // the first step to tracing is to call .trace()
     // this sticks a gradient tape into the input tensor!
     // NOTE: the tape has changed from a `NoneTape` to an `OwnedTape`.
-    let b: Tensor<Rank2<3, 4>, f32, Cpu, OwnedTape<Cpu>> = a.trace();
+    let b: Tensor<Rank2<3, 4>, _, _, OwnedTape<Cpu>> = a.trace();
 
     // the tape will **automatically** be moved around as you perform ops
     // ie. the tapes on inputs to operations are moved to the output
     // of the operation.
-    let c: Tensor<Rank2<3, 2>, f32, Cpu, OwnedTape<_>> = b.matmul(weight.clone());
-    let d: Tensor<Rank2<3, 2>, f32, Cpu, OwnedTape<_>> = c.sin();
-    let e: Tensor<Rank0, f32, Cpu, OwnedTape<_>> = d.mean();
+    let c: Tensor<Rank2<3, 2>, _, _, OwnedTape<_>> = b.matmul(weight.clone());
+    let d: Tensor<Rank2<3, 2>, _, _, OwnedTape<_>> = c.sin();
+    let e: Tensor<Rank0, _, _, OwnedTape<_>> = d.mean();
 
     // finally you can use .backward() to extract the gradients!
     // NOTE: that this method is only available on tensors that **own**

--- a/examples/05-optim.rs
+++ b/examples/05-optim.rs
@@ -5,7 +5,7 @@ use dfdx::{
     nn::{BuildOnDevice, Linear, ModuleMut, ReLU, Tanh},
     optim::{Momentum, Optimizer, Sgd, SgdConfig},
     shapes::Rank2,
-    tensor::{AsArray, Cpu, SampleTensor},
+    tensor::{AsArray, Cpu, SampleTensor, Tensor},
     tensor_ops::Backward,
 };
 
@@ -30,8 +30,8 @@ fn main() {
 
     // let's initialize our model and some dummy data
     let mut mlp = Mlp::build_on_device(&dev);
-    let x = dev.sample_normal::<Rank2<3, 5>>();
-    let y = dev.sample_normal::<Rank2<3, 2>>();
+    let x: Tensor<Rank2<3, 5>, f32, _> = dev.sample_normal();
+    let y: Tensor<Rank2<3, 2>, f32, _> = dev.sample_normal();
 
     // first we pass our gradient tracing input through the network.
     // since we are training, we use forward_mut() instead of forward

--- a/examples/07-custom-module.rs
+++ b/examples/07-custom-module.rs
@@ -49,12 +49,12 @@ impl<const IN: usize, const INNER: usize, const OUT: usize> GradientUpdate<Cpu, 
 }
 
 // impl Module for single item
-impl<const IN: usize, const INNER: usize, const OUT: usize> nn::Module<Tensor<Rank1<IN>>>
+impl<const IN: usize, const INNER: usize, const OUT: usize> nn::Module<Tensor<Rank1<IN>, f32, Cpu>>
     for Mlp<IN, INNER, OUT>
 {
-    type Output = Tensor<Rank1<OUT>>;
+    type Output = Tensor<Rank1<OUT>, f32, Cpu>;
 
-    fn forward(&self, x: Tensor<Rank1<IN>>) -> Self::Output {
+    fn forward(&self, x: Tensor<Rank1<IN>, f32, Cpu>) -> Self::Output {
         let x = self.l1.forward(x);
         let x = self.relu.forward(x);
         self.l2.forward(x)
@@ -82,10 +82,10 @@ fn main() {
     let model: Mlp<10, 512, 20> = nn::BuildModule::build(&dev);
 
     // Forward pass with a single sample
-    let item: Tensor<Rank1<10>> = dev.sample_normal();
+    let item: Tensor<Rank1<10>, f32, _> = dev.sample_normal();
     let _: Tensor<Rank1<20>, f32, Cpu> = model.forward(item);
 
     // Forward pass with a batch of samples
-    let batch: Tensor<Rank2<32, 10>> = dev.sample_normal();
+    let batch: Tensor<Rank2<32, 10>, f32, _> = dev.sample_normal();
     let _: Tensor<Rank2<32, 20>, f32, Cpu, _> = model.forward(batch.trace());
 }

--- a/examples/09-tensor-permute.rs
+++ b/examples/09-tensor-permute.rs
@@ -7,7 +7,7 @@ use dfdx::tensor_ops::PermuteTo;
 fn main() {
     let dev: Cpu = Default::default();
 
-    let a: Tensor<Rank3<3, 5, 7>,f32, _> = dev.zeros();
+    let a: Tensor<Rank3<3, 5, 7>, f32, _> = dev.zeros();
 
     // permuting is as easy as just expressing the desired shape
     // note that we are reversing the order of the axes here!

--- a/examples/09-tensor-permute.rs
+++ b/examples/09-tensor-permute.rs
@@ -7,7 +7,7 @@ use dfdx::tensor_ops::PermuteTo;
 fn main() {
     let dev: Cpu = Default::default();
 
-    let a: Tensor<Rank3<3, 5, 7>> = dev.zeros();
+    let a: Tensor<Rank3<3, 5, 7>,f32, _> = dev.zeros();
 
     // permuting is as easy as just expressing the desired shape
     // note that we are reversing the order of the axes here!
@@ -19,7 +19,7 @@ fn main() {
     // Just like broadcast/reduce there are times when
     // type inference is impossible because of ambiguities.
     // You can specify axes explicitly to get aroudn this.
-    let c: Tensor<Rank3<1, 1, 1>> = dev.zeros();
+    let c: Tensor<Rank3<1, 1, 1>, f32, _> = dev.zeros();
     let _ = c.permute::<_, Axes3<1, 0, 2>>();
     // NOTE: fails with "Multiple impls satisfying..."
     // let _ = c.permute::<Rank3<1, 1, 1>, _>();

--- a/examples/10-tensor-index.rs
+++ b/examples/10-tensor-index.rs
@@ -9,7 +9,7 @@ use dfdx::{
 fn main() {
     let dev: Cpu = Default::default();
 
-    let a: Tensor<Rank3<4, 2, 3>> = dev.tensor([
+    let a: Tensor<Rank3<4, 2, 3>, f32, _> = dev.tensor([
         [[0.00, 0.01, 0.02], [0.10, 0.11, 0.12]],
         [[1.00, 1.01, 1.02], [1.10, 1.11, 1.12]],
         [[2.00, 2.01, 2.02], [2.10, 2.11, 2.12]],

--- a/examples/11-multi-headed.rs
+++ b/examples/11-multi-headed.rs
@@ -17,5 +17,5 @@ fn main() {
     let m = Model::build_on_device(&dev);
 
     // when we forward data through, we get a tuple back!
-    let _: (Tensor<Rank1<3>>, Tensor<Rank1<5>>) = m.forward(dev.tensor([1.0]));
+    let _: (Tensor<Rank1<3>, f32, _>, Tensor<Rank1<5>, f32, _>) = m.forward(dev.tensor([1.0]));
 }

--- a/examples/nightly-conv-net.rs
+++ b/examples/nightly-conv-net.rs
@@ -18,12 +18,12 @@ fn main() {
     let m = Model::build_on_device(&dev);
 
     // single image forward
-    let x: Tensor<Rank3<3, 28, 28>> = dev.sample_normal();
-    let _: Tensor<Rank1<10>> = m.forward(x);
+    let x: Tensor<Rank3<3, 28, 28>, f32, _> = dev.sample_normal();
+    let _: Tensor<Rank1<10>, f32, _> = m.forward(x);
 
     // batched image forward
-    let x: Tensor<Rank4<32, 3, 28, 28>> = dev.sample_normal();
-    let _: Tensor<Rank2<32, 10>> = m.forward(x);
+    let x: Tensor<Rank4<32, 3, 28, 28>, f32, _> = dev.sample_normal();
+    let _: Tensor<Rank2<32, 10>, f32, _> = m.forward(x);
 }
 
 #[cfg(not(feature = "nightly"))]

--- a/examples/nightly-resnet18.rs
+++ b/examples/nightly-resnet18.rs
@@ -41,7 +41,7 @@ fn main() {
     );
 
     let dev: Cpu = Default::default();
-    let x = dev.sample_normal::<Rank3<3, 224, 224>>();
+    let x: Tensor<Rank3<3, 224, 224>, f32, _> = dev.sample_normal();
     let m = Resnet18::<1000>::build_on_device(&dev);
     for _ in 0.. {
         let start = Instant::now();

--- a/examples/nightly-transformer.rs
+++ b/examples/nightly-transformer.rs
@@ -9,8 +9,8 @@ fn main() {
     type Model = Transformer<16, 4, 3, 3, 8>;
     let t = Model::build_on_device(&dev);
 
-    let src: Tensor<Rank3<4, 12, 16>> = dev.sample_normal();
-    let tgt: Tensor<Rank3<4, 6, 16>> = dev.sample_normal();
+    let src: Tensor<Rank3<4, 12, 16>, f32, _> = dev.sample_normal();
+    let tgt: Tensor<Rank3<4, 6, 16>, f32, _> = dev.sample_normal();
     let _: Tensor<Rank3<4, 6, 16>, _, _, _> = t.forward((src.trace(), tgt));
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -47,7 +47,7 @@ impl<D: DeviceStorage + ZerosTensor<f32> + CopySlice<f32>> Arange for D {}
 /// let dev: Cpu = Default::default();
 /// let class_labels = [0, 1, 2, 1, 1];
 /// // NOTE: 5 is the batch size, 3 is the number of classes
-/// let probs: Tensor<(usize, Const<3>), f32> = dev.one_hot_encode::<3>(&class_labels);
+/// let probs: Tensor<(usize, Const<3>), f32, _> = dev.one_hot_encode::<3>(&class_labels);
 /// assert_eq!(&probs.as_vec(), &[
 ///     1.0, 0.0, 0.0,
 ///     0.0, 1.0, 0.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@
 //! # use dfdx::prelude::*;
 //! let dev: Cpu = Default::default();
 //! let x = dev.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
-//! let y: Tensor<Rank2<2, 3>> = dev.ones();
+//! let y: Tensor<Rank2<2, 3>, f32, Cpu> = dev.ones();
 //! // Runtime shape
-//! let z: Tensor<(usize, Const<3>)> = dev.ones_like(&(10, Const));
+//! let z: Tensor<(usize, Const<3>), f32, _> = dev.ones_like(&(10, Const));
 //! ```
 //!
 //! 2. Neural networks are built with types. Tuples are sequential models. See [crate::nn].
@@ -43,7 +43,7 @@
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
 //! # let mlp: Linear<5, 2> = BuildModule::build(&dev);
-//! let x: Tensor<Rank1<5>> = dev.zeros();
+//! let x: Tensor<Rank1<5>, f32, _> = dev.zeros();
 //! let y = mlp.forward(x); // compiler infers that `y` must be `Tensor<Rank1<2>>`
 //! ```
 //!
@@ -52,7 +52,7 @@
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
 //! # let model: Linear<10, 5> = BuildModule::build(&dev);
-//! # let y_true: Tensor<Rank1<5>> = dev.sample_normal().softmax();
+//! # let y_true: Tensor<Rank1<5>, f32, _> = dev.sample_normal().softmax();
 //! // tensors default to not having a tape
 //! let x: Tensor<Rank1<10>, f32, Cpu, NoneTape> = dev.zeros();
 //!

--- a/src/nn/add_into.rs
+++ b/src/nn/add_into.rs
@@ -16,9 +16,9 @@ use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 /// # let dev: Cpu = Default::default();
 /// type Model = AddInto<(Linear<2, 5>, Linear<3, 5>)>;
 /// let model = Model::build_on_device(&dev);
-/// let a = dev.zeros::<Rank1<2>>();
-/// let b = dev.zeros::<Rank1<3>>();
-/// let _: Tensor<Rank1<5>> = model.forward((a, b));
+/// let a: Tensor<Rank1<2>, f32, _> = dev.zeros();
+/// let b: Tensor<Rank1<3>, f32, _> = dev.zeros();
+/// let _: Tensor<Rank1<5>, f32, _> = model.forward((a, b));
 /// ```
 #[derive(Debug, Default, Clone)]
 pub struct AddInto<T>(pub T);

--- a/src/nn/embedding.rs
+++ b/src/nn/embedding.rs
@@ -20,11 +20,11 @@ use super::module::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 /// # let dev: Cpu = Default::default();
 /// let mut model: Embedding<7, 2> = BuildModule::build(&dev);
 /// // single sequence of ids
-/// let inputs: Tensor<_, usize> = dev.zeros::<Rank1<5>>();
-/// let _: Tensor<(Const<5>, Const<2>,), f32> = model.forward(inputs);
+/// let inputs: Tensor<Rank1<5>, usize, _> = dev.zeros();
+/// let _: Tensor<(Const<5>, Const<2>,), f32, _> = model.forward(inputs);
 /// // batched sequence of ids
-/// let inputs: Tensor<_, usize> = dev.zeros::<Rank2<10, 5>>();
-/// let _: Tensor<(Const<10>, Const<5>, Const<2>), f32> = model.forward(inputs);
+/// let inputs: Tensor<Rank2<10, 5>, usize, _> = dev.zeros();
+/// let _: Tensor<(Const<10>, Const<5>, Const<2>), f32, _> = model.forward(inputs);
 /// ```
 #[derive(Debug, Clone)]
 pub struct Embedding<const VOCAB: usize, const DIM: usize, D: Device<f32> = Cpu> {

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -18,7 +18,7 @@ use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 /// # let dev: Cpu = Default::default();
 /// type Model = LayerNorm1D<5>;
 /// let model = Model::build_on_device(&dev);
-/// let _: Tensor<Rank1<5>> = model.forward(dev.zeros::<Rank1<5>>());
+/// let _: Tensor<Rank1<5>, f32, _> = model.forward(dev.zeros::<Rank1<5>>());
 /// ```
 #[derive(Debug, Clone)]
 pub struct LayerNorm1D<const M: usize, D: Device<f32> = Cpu> {

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -20,9 +20,9 @@ use super::module::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 /// type Model = Linear<5, 2>;
 /// let model = Model::build_on_device(&dev);
 /// // single item forward
-/// let _: Tensor<Rank1<2>> = model.forward(dev.zeros::<Rank1<5>>());
+/// let _: Tensor<Rank1<2>, f32, _> = model.forward(dev.zeros::<Rank1<5>>());
 /// // batched forward
-/// let _: Tensor<Rank2<10, 2>> = model.forward(dev.zeros::<Rank2<10, 5>>());
+/// let _: Tensor<Rank2<10, 2>, f32, _> = model.forward(dev.zeros::<Rank2<10, 5>>());
 /// ```
 #[derive(Debug, Clone)]
 pub struct Linear<const I: usize, const O: usize, D: Device<f32> = Cpu> {

--- a/src/nn/pool_global.rs
+++ b/src/nn/pool_global.rs
@@ -14,8 +14,8 @@ use super::{BuildModule, Module, NonMutableModule, ZeroSizedModule};
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
 /// let m: AvgPoolGlobal = Default::default();
-/// let _: Tensor<Rank1<5>> = m.forward(dev.zeros::<Rank3<5, 16, 8>>());
-/// let _: Tensor<Rank2<10, 5>> = m.forward(dev.zeros::<Rank4<10, 5, 16, 8>>());
+/// let _: Tensor<Rank1<5>, f32, _> = m.forward(dev.zeros::<Rank3<5, 16, 8>>());
+/// let _: Tensor<Rank2<10, 5>, f32, _> = m.forward(dev.zeros::<Rank4<10, 5, 16, 8>>());
 /// ```
 #[derive(Clone, Copy, Default)]
 pub struct AvgPoolGlobal;
@@ -32,8 +32,8 @@ pub struct AvgPoolGlobal;
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
 /// let m: MaxPoolGlobal = Default::default();
-/// let _: Tensor<Rank1<5>> = m.forward(dev.zeros::<Rank3<5, 16, 8>>());
-/// let _: Tensor<Rank2<10, 5>> = m.forward(dev.zeros::<Rank4<10, 5, 16, 8>>());
+/// let _: Tensor<Rank1<5>, f32, _> = m.forward(dev.zeros::<Rank3<5, 16, 8>>());
+/// let _: Tensor<Rank2<10, 5>, f32, _> = m.forward(dev.zeros::<Rank4<10, 5, 16, 8>>());
 /// ```
 #[derive(Clone, Copy, Default)]
 pub struct MaxPoolGlobal;
@@ -50,8 +50,8 @@ pub struct MaxPoolGlobal;
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
 /// let m: MinPoolGlobal = Default::default();
-/// let _: Tensor<Rank1<5>> = m.forward(dev.zeros::<Rank3<5, 16, 8>>());
-/// let _: Tensor<Rank2<10, 5>> = m.forward(dev.zeros::<Rank4<10, 5, 16, 8>>());
+/// let _: Tensor<Rank1<5>, f32, _> = m.forward(dev.zeros::<Rank3<5, 16, 8>>());
+/// let _: Tensor<Rank2<10, 5>, f32, _> = m.forward(dev.zeros::<Rank4<10, 5, 16, 8>>());
 /// ```
 #[derive(Clone, Copy, Default)]
 pub struct MinPoolGlobal;

--- a/src/nn/repeated.rs
+++ b/src/nn/repeated.rs
@@ -14,7 +14,7 @@ use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 /// # let dev: Cpu = Default::default();
 /// type Model = Repeated<(Linear<10, 10>, ReLU), 5>;
 /// let model = Model::build_on_device(&dev);
-/// let out: Tensor<Rank1<10>> = model.forward(dev.zeros());
+/// let out: Tensor<Rank1<10>, f32, _> = model.forward(dev.zeros());
 /// ```
 #[derive(Debug, Clone)]
 pub struct Repeated<T, const N: usize> {

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -17,7 +17,7 @@ use super::{BuildModule, Module, ModuleMut, ResetParams, ToDevice};
 /// # let dev: Cpu = Default::default();
 /// type Model = SplitInto<(Linear<5, 3>, Linear<5, 7>)>;
 /// let model = Model::build_on_device(&dev);
-/// let _: (Tensor<Rank1<3>>, Tensor<Rank1<7>>) = model.forward(dev.zeros::<Rank1<5>>());
+/// let _: (Tensor<Rank1<3>, f32, _>, Tensor<Rank1<7>, f32, _>) = model.forward(dev.zeros::<Rank1<5>>());
 /// ```
 #[derive(Debug, Default, Clone)]
 pub struct SplitInto<T>(pub T);

--- a/src/optim/adam/mod.rs
+++ b/src/optim/adam/mod.rs
@@ -59,14 +59,14 @@ impl Default for AdamConfig<f32> {
 /// Constructing using default:
 /// ```rust
 /// # use dfdx::{prelude::*, optim::*};
-/// # type Model = Tensor<Rank0>;
+/// # type Model = Tensor<Rank0, f32, Cpu>;
 /// let mut opt: Adam<Model> = Default::default();
 /// ```
 ///
 /// Changing using new
 /// ```rust
 /// # use dfdx::{prelude::*, optim::*};
-/// # type Model = Tensor<Rank0>;
+/// # type Model = Tensor<Rank0, f32, Cpu>;
 /// let mut opt: Adam<Model> = Adam::new(AdamConfig {
 ///     lr: 1e-2,
 ///     betas: [0.5, 0.25],

--- a/src/optim/rmsprop/mod.rs
+++ b/src/optim/rmsprop/mod.rs
@@ -67,14 +67,14 @@ impl Default for RMSpropConfig<f32> {
 /// Constructing using default:
 /// ```rust
 /// # use dfdx::{prelude::*, optim::*};
-/// # type Model = Tensor<Rank0>;
+/// # type Model = Tensor<Rank0, f32, Cpu>;
 /// let mut opt: RMSprop<Model> = Default::default();
 /// ```
 ///
 /// Constructing using new:
 /// ```rust
 /// # use dfdx::{prelude::*, optim::*};
-/// # type Model = Tensor<Rank0>;
+/// # type Model = Tensor<Rank0, f32, Cpu>;
 /// let rmsprop: RMSprop<Model> = RMSprop::new(RMSpropConfig {
 ///     lr: 1e-3,
 ///     alpha: 0.5,

--- a/src/optim/sgd/mod.rs
+++ b/src/optim/sgd/mod.rs
@@ -98,14 +98,14 @@ impl Default for SgdConfig<f32> {
 /// Constructing using default:
 /// ```rust
 /// # use dfdx::{prelude::*, optim::*};
-/// # type Model = Tensor<Rank0>;
+/// # type Model = Tensor<Rank0, f32, Cpu>;
 /// let mut opt: Sgd<Model> = Default::default();
 /// ```
 ///
 /// Constructing using new:
 /// ```rust
 /// # use dfdx::{prelude::*, optim::*};
-/// # type Model = Tensor<Rank0>;
+/// # type Model = Tensor<Rank0, f32, Cpu>;
 /// let mut opt: Sgd<Model> = Sgd::new(SgdConfig {
 ///     lr: 1e-3,
 ///     momentum: Some(Momentum::Classic(0.5)),

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -38,8 +38,8 @@
 //! ```rust
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
-//! let _: Tensor<Rank1<5>> = dev.zeros();
-//! let _: Tensor<Rank2<3, 2>> = dev.ones();
+//! let _: Tensor<Rank1<5>,f32 , _> = dev.zeros();
+//! let _: Tensor<Rank2<3, 2>, f32, _> = dev.ones();
 //! ```
 //!
 //! ### Filled with random data
@@ -49,11 +49,11 @@
 //! ```rust
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
-//! let _: Tensor<Rank1<5>> = dev.sample_uniform();
-//! let _: Tensor<Rank2<3, 5>> = dev.sample_normal();
+//! let _: Tensor<Rank1<5>, f32, _> = dev.sample_uniform();
+//! let _: Tensor<Rank2<3, 5>, f32, _> = dev.sample_normal();
 //! // or pass in actual distributions
-//! let _: Tensor<Rank1<3>> = dev.sample(rand_distr::Standard);
-//! let _: Tensor<Rank2<4, 3>> = dev.sample(rand_distr::StandardNormal);
+//! let _: Tensor<Rank1<3>, f32, _> = dev.sample(rand_distr::Standard);
+//! let _: Tensor<Rank2<4, 3>, f32, _> = dev.sample(rand_distr::StandardNormal);
 //! ```
 //!
 //! ### Copy data from slices
@@ -63,7 +63,7 @@
 //! ```rust
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
-//! let mut a: Tensor<Rank1<1000>> = dev.zeros();
+//! let mut a: Tensor<Rank1<1000>, f32, _> = dev.zeros();
 //! let buf: Vec<f32> = vec![1.0; 1000];
 //! a.copy_from(&buf);
 //! ```
@@ -83,7 +83,7 @@
 //! ```rust
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
-//! let t: Tensor<Rank2<2, 3>> = dev.zeros();
+//! let t: Tensor<Rank2<2, 3>, f32, _> = dev.zeros();
 //! let t: [[f32; 3]; 2] = t.array();
 //! ```
 //!
@@ -98,7 +98,7 @@
 //! ```rust
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
-//! let t: Tensor<Rank1<5>> = dev.zeros();
+//! let t: Tensor<Rank1<5>,f32, _> = dev.zeros();
 //! let t_clone: Tensor<Rank1<5>, _, _, OwnedTape<_>> = t.trace(); // copies t
 //! let t = t.traced(); // takes ownership of t
 //! ```

--- a/src/tensor/storage_traits.rs
+++ b/src/tensor/storage_traits.rs
@@ -69,7 +69,7 @@ impl<S: Shape, E: Unit, D: CopySlice<E>, T> Tensor<S, E, D, T> {
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
     /// let data = [1.0, 2.0, 3.0, 4.0];
-    /// let mut t: Tensor<Rank2<2, 2>> = dev.zeros();
+    /// let mut t: Tensor<Rank2<2, 2>, f32, _> = dev.zeros();
     /// t.copy_from(&data);
     /// assert_eq!(t.array(), [[1.0, 2.0], [3.0, 4.0]]);
     /// ```
@@ -82,7 +82,7 @@ impl<S: Shape, E: Unit, D: CopySlice<E>, T> Tensor<S, E, D, T> {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let t: Tensor<Rank2<2, 2>> = dev.tensor([[1.0, 2.0], [3.0, 4.0]]);
+    /// let t: Tensor<Rank2<2, 2>, f32, _> = dev.tensor([[1.0, 2.0], [3.0, 4.0]]);
     /// let mut data = [0.0; 4];
     /// t.copy_into(&mut data);
     /// assert_eq!(data, [1.0, 2.0, 3.0, 4.0]);
@@ -98,7 +98,7 @@ pub trait ZerosTensor<E: Unit>: DeviceStorage {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let a: Tensor<Rank2<2, 3>> = dev.zeros();
+    /// let a: Tensor<Rank2<2, 3>, f32, _> = dev.zeros();
     /// ```
     fn zeros<S: ConstShape>(&self) -> Tensor<S, E, Self> {
         self.try_zeros_like::<S>(&Default::default()).unwrap()
@@ -115,15 +115,15 @@ pub trait ZerosTensor<E: Unit>: DeviceStorage {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let a: Tensor<(usize, Const<3>)> = dev.zeros_like(&(5, Const));
+    /// let a: Tensor<(usize, Const<3>), f32, _> = dev.zeros_like(&(5, Const));
     /// ```
     ///
     /// Given another tensor:
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let a: Tensor<Rank2<2, 3>> = dev.zeros();
-    /// let b: Tensor<Rank2<2, 3>> = dev.zeros_like(&a);
+    /// let a: Tensor<Rank2<2, 3>, f32, _> = dev.zeros();
+    /// let b: Tensor<Rank2<2, 3>, f32, _> = dev.zeros_like(&a);
     /// ```
     fn zeros_like<S: HasShape>(&self, src: &S) -> Tensor<S::Shape, E, Self> {
         self.try_zeros_like(src).unwrap()
@@ -146,7 +146,7 @@ pub trait OnesTensor<E: Unit>: DeviceStorage {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let a: Tensor<Rank2<2, 3>> = dev.ones();
+    /// let a: Tensor<Rank2<2, 3>, f32, _> = dev.ones();
     /// ```
     fn ones<S: ConstShape>(&self) -> Tensor<S, E, Self> {
         self.try_ones_like::<S>(&Default::default()).unwrap()
@@ -163,14 +163,14 @@ pub trait OnesTensor<E: Unit>: DeviceStorage {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let a: Tensor<(usize, Const<3>)> = dev.ones_like(&(5, Const));
+    /// let a: Tensor<(usize, Const<3>), f32, _> = dev.ones_like(&(5, Const));
     /// ```
     ///
     /// Given another tensor:
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let a: Tensor<Rank2<2, 3>> = dev.ones();
+    /// let a: Tensor<Rank2<2, 3>, f32, _> = dev.ones();
     /// let b = dev.ones_like(&a);
     /// ```
     fn ones_like<S: HasShape>(&self, src: &S) -> Tensor<S::Shape, E, Self> {
@@ -240,7 +240,7 @@ pub trait TensorFromArray<Src, S: Shape, E: Unit>: DeviceStorage {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let _: Tensor<Rank2<2, 3>> = dev.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+    /// let _: Tensor<Rank2<2, 3>, f32, _> = dev.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
     /// ```
     fn tensor(&self, src: Src) -> Tensor<S, E, Self> {
         self.try_tensor(src).unwrap()

--- a/src/tensor_ops/add/mod.rs
+++ b/src/tensor_ops/add/mod.rs
@@ -83,7 +83,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{tensor::*, tensor_ops::*, tests::*, shapes::*};
+    use crate::{shapes::*, tensor::*, tensor_ops::*, tests::*};
 
     #[test]
     fn test_add_0d() {

--- a/src/tensor_ops/add/mod.rs
+++ b/src/tensor_ops/add/mod.rs
@@ -83,7 +83,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{tensor::*, tensor_ops::*, tests::*};
+    use crate::{tensor::*, tensor_ops::*, tests::*, shapes::*};
 
     #[test]
     fn test_add_0d() {
@@ -133,8 +133,8 @@ mod tests {
         let a = dev.tensor([[0.6570, 0.1708, 0.1500], [0.5658, 0.7010, 0.8342]]);
         let b = dev.tensor([[0.5199, 0.3844, 0.3759], [0.8259, 0.3682, 0.0388]]);
 
-        let a2: Tensor3D<2, 3, 4, TestDevice> = a.broadcast();
-        let b2: Tensor3D<2, 3, 4, TestDevice> = b.broadcast();
+        let a2: Tensor<Rank3<2, 3, 4>, f32, TestDevice> = a.broadcast();
+        let b2: Tensor<Rank3<2, 3, 4>, f32, TestDevice> = b.broadcast();
 
         let r = a2.trace() + b2.clone();
         assert_eq!(
@@ -155,8 +155,8 @@ mod tests {
         let a = dev.tensor([[0.6570, 0.1708, 0.1500], [0.5658, 0.7010, 0.8342]]);
         let b = dev.tensor([[0.5199, 0.3844, 0.3759], [0.8259, 0.3682, 0.0388]]);
 
-        let a2: Tensor3D<4, 2, 3, TestDevice> = a.broadcast();
-        let b2: Tensor3D<4, 2, 3, TestDevice> = b.broadcast();
+        let a2: Tensor<Rank3<4, 2, 3>, f32, TestDevice> = a.broadcast();
+        let b2: Tensor<Rank3<4, 2, 3>, f32, TestDevice> = b.broadcast();
 
         let r = a2.trace() + b2.clone();
         assert_eq!(

--- a/src/tensor_ops/broadcast_to/mod.rs
+++ b/src/tensor_ops/broadcast_to/mod.rs
@@ -28,7 +28,7 @@ pub trait BroadcastTo: HasErr + HasShape {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let a: Tensor<Rank2<3, 7>, f32> = dev.zeros();
+    /// let a: Tensor<Rank2<3, 7>, f32, _> = dev.zeros();
     ///
     /// // broadcast axis 1
     /// let _ = a.clone().broadcast::<Rank3<3, 5, 7>, _>();

--- a/src/tensor_ops/log_softmax.rs
+++ b/src/tensor_ops/log_softmax.rs
@@ -9,7 +9,7 @@ use crate::{gradients::Tape, shapes::*, tensor::Tensor};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let t: Tensor<Rank3<2, 3, 5>, f32> = dev.zeros();
+/// let t: Tensor<Rank3<2, 3, 5>, f32, _> = dev.zeros();
 /// let _ = t.log_softmax::<Axis<2>>();
 /// ```
 ///
@@ -17,7 +17,7 @@ use crate::{gradients::Tape, shapes::*, tensor::Tensor};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// # let t: Tensor<Rank3<2, 3, 5>, f32> = dev.zeros();
+/// # let t: Tensor<Rank3<2, 3, 5>, f32, _> = dev.zeros();
 /// let _ = t.log_softmax::<Axes2<0, 2>>();
 /// ```
 pub fn log_softmax<Ax: Axes, S: Shape, E: Dtype, D: Device<E>, T: Tape<D>>(

--- a/src/tensor_ops/logsumexp_to.rs
+++ b/src/tensor_ops/logsumexp_to.rs
@@ -13,7 +13,7 @@ pub trait LogSumExpTo: HasErr + HasShape {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let t: Tensor<Rank3<2, 4, 6>, f32> = dev.zeros();
+    /// let t: Tensor<Rank3<2, 4, 6>, f32, _> = dev.zeros();
     /// let _ = t.logsumexp::<Rank2<2, 4>, _>(); // or `logsumexp::<_, Axis<2>>()`
     /// ```
     ///
@@ -21,7 +21,7 @@ pub trait LogSumExpTo: HasErr + HasShape {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// # let t: Tensor<Rank3<2, 4, 6>, f32> = dev.zeros();
+    /// # let t: Tensor<Rank3<2, 4, 6>, f32, _> = dev.zeros();
     /// let _ = t.logsumexp::<Rank1<4>, _>(); // or `logsumexp::<_, Axes2<0, 2>>()`
     /// ```
     fn logsumexp<Dst: Shape, Ax: Axes>(self) -> Self::WithShape<Dst>

--- a/src/tensor_ops/matmul/mod.rs
+++ b/src/tensor_ops/matmul/mod.rs
@@ -18,45 +18,45 @@ use crate::{
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let x: Tensor<Rank2<3, 10>> = dev.zeros();
-/// let y: Tensor<Rank2<10, 5>> = dev.zeros();
-/// let result: Tensor<Rank2<3, 5>> = x.matmul(y);
+/// let x: Tensor<Rank2<3, 10>, f32, _> = dev.zeros();
+/// let y: Tensor<Rank2<10, 5>, f32, _> = dev.zeros();
+/// let _: Tensor<Rank2<3, 5>, f32, _> = x.matmul(y);
 /// ```
 ///
 /// 2. Vector x Matrix
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let x: Tensor<Rank1<2>> = dev.zeros();
-/// let y: Tensor<Rank2<2, 4>> = dev.zeros();
-/// let result: Tensor<Rank1<4>> = x.matmul(y);
+/// let x: Tensor<Rank1<2>, f32, _> = dev.zeros();
+/// let y: Tensor<Rank2<2, 4>, f32, _> = dev.zeros();
+/// let _: Tensor<Rank1<4>, f32, _> = x.matmul(y);
 /// ```
 ///
 /// 3. Vector x Vector
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let x: Tensor<Rank1<2>> = dev.zeros();
-/// let y: Tensor<Rank1<4>> = dev.zeros();
-/// let result: Tensor<Rank2<2, 4>> = x.matmul(y);
+/// let x: Tensor<Rank1<2>, f32, _> = dev.zeros();
+/// let y: Tensor<Rank1<4>, f32, _> = dev.zeros();
+/// let _: Tensor<Rank2<2, 4>, f32, _> = x.matmul(y);
 /// ```
 ///
 /// 4. Batched matmul
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let x: Tensor<Rank3<10, 3, 2>> = dev.zeros();
-/// let y: Tensor<Rank3<10, 2, 4>> = dev.zeros();
-/// let result: Tensor<Rank3<10, 3, 4>> = x.matmul(y);
+/// let x: Tensor<Rank3<10, 3, 2>, f32, _> = dev.zeros();
+/// let y: Tensor<Rank3<10, 2, 4>, f32, _> = dev.zeros();
+/// let _: Tensor<Rank3<10, 3, 4>, f32, _> = x.matmul(y);
 /// ```
 ///
 /// 5. Broadcasted matmul
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let x: Tensor<Rank3<10, 3, 2>> = dev.zeros();
-/// let y: Tensor<Rank2<2, 4>> = dev.zeros();
-/// let result: Tensor<Rank3<10, 3, 4>> = x.matmul(y);
+/// let x: Tensor<Rank3<10, 3, 2>, f32, _> = dev.zeros();
+/// let y: Tensor<Rank2<2, 4>, f32, _> = dev.zeros();
+/// let _: Tensor<Rank3<10, 3, 4>, f32, _> = x.matmul(y);
 /// ```
 pub fn matmul<Lhs, Rhs>(lhs: Lhs, rhs: Rhs) -> Lhs::Output
 where

--- a/src/tensor_ops/max_to/mod.rs
+++ b/src/tensor_ops/max_to/mod.rs
@@ -35,7 +35,7 @@ pub trait MaxTo: HasErr + HasShape {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let t: Tensor<Rank2<2, 3>, _> = dev.tensor([[1.0, 2.0, 3.0], [-1.0, -2.0, -3.0]]);
+    /// let t: Tensor<Rank2<2, 3>, f32, _> = dev.tensor([[1.0, 2.0, 3.0], [-1.0, -2.0, -3.0]]);
     /// let r = t.max::<Rank1<2>, _>(); // or `max::<_, Axis<1>>()`
     /// assert_eq!(r.array(), [3.0, -1.0]);
     /// ```

--- a/src/tensor_ops/min_to/mod.rs
+++ b/src/tensor_ops/min_to/mod.rs
@@ -35,7 +35,7 @@ pub trait MinTo: HasErr + HasShape {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let t: Tensor<Rank2<2, 3>, _> = dev.tensor([[1.0, 2.0, 3.0], [-1.0, -2.0, -3.0]]);
+    /// let t: Tensor<Rank2<2, 3>, f32, _> = dev.tensor([[1.0, 2.0, 3.0], [-1.0, -2.0, -3.0]]);
     /// let r = t.min::<Rank1<2>, _>(); // or `min::<_, Axis<1>>()`
     /// assert_eq!(r.array(), [1.0, -3.0]);
     /// ```

--- a/src/tensor_ops/mod.rs
+++ b/src/tensor_ops/mod.rs
@@ -38,11 +38,13 @@
 //! ```rust
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
-//! let t: Tensor<Rank3<2, 4, 6>> = dev.zeros();
+//! let t: Tensor<Rank3<2, 4, 6>, f32, _> = dev.zeros();
 //! // shape version
-//! let _: Tensor<Rank1<4>> = t.clone().sum::<Rank1<4>, _>();
+//! let _ = t.clone().sum::<Rank1<4>, _>();
 //! // axes version
-//! let _: Tensor<Rank1<2>> = t.clone().sum::<_, Axes2<1, 2>>();
+//! let _ = t.clone().sum::<_, Axes2<0, 2>>();
+//! // typed version
+//! let _: Tensor<Rank1<4>, _, _> = t.clone().sum();
 //! ```
 //!
 //! Complete list of reductions:
@@ -67,17 +69,19 @@
 //! ```rust
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
-//! let t: Tensor<Rank1<4>> = dev.zeros();
+//! let t: Tensor<Rank1<4>, f32, _> = dev.zeros();
 //! // shape version
-//! let _: Tensor<Rank3<2, 4, 6>> = t.clone().broadcast::<Rank3<2, 4, 6>, _>();
+//! let _ = t.clone().broadcast::<Rank3<2, 4, 6>, _>();
+//! // typed version
+//! let _: Tensor<Rank3<2, 4, 6>, _, _> = t.clone().broadcast();
 //! ```
 //!
 //! Rust can also infer the output type if you use it in another operation:
 //! ```rust
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
-//! let big: Tensor<Rank2<2, 5>> = dev.zeros();
-//! let small: Tensor<Rank1<5>> = dev.zeros();
+//! let big: Tensor<Rank2<2, 5>, f32, _> = dev.zeros();
+//! let small: Tensor<Rank1<5>, f32, _> = dev.zeros();
 //! let _ = big + small.broadcast();
 //! ```
 //!
@@ -87,7 +91,7 @@
 //! ```rust
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
-//! let t: Tensor<Rank3<2, 3, 4>> = dev.zeros();
+//! let t: Tensor<Rank3<2, 3, 4>, f32, _> = dev.zeros();
 //! // shape version
 //! let _ = t.clone().permute::<Rank3<3, 4, 2>, _>();
 //! // axes version
@@ -105,7 +109,7 @@
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
 //! let t = dev.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
-//! let r: Tensor<Rank1<3>> = t.select(dev.tensor(1));
+//! let r: Tensor<Rank1<3>, f32, _> = t.select(dev.tensor(1));
 //! assert_eq!(r.array(), [4.0, 5.0, 6.0]);
 //! ```
 //!
@@ -114,7 +118,7 @@
 //! # use dfdx::prelude::*;
 //! # let dev: Cpu = Default::default();
 //! let t = dev.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
-//! let r: Tensor<Rank2<3, 3>> = t.gather(dev.tensor([1, 1, 0]));
+//! let r: Tensor<Rank2<3, 3>, f32, _> = t.gather(dev.tensor([1, 1, 0]));
 //! assert_eq!(r.array(), [
 //!     [4.0, 5.0, 6.0],
 //!     [4.0, 5.0, 6.0],

--- a/src/tensor_ops/normalize.rs
+++ b/src/tensor_ops/normalize.rs
@@ -13,7 +13,7 @@ use super::{BroadcastTo, Device, MeanTo, StddevTo, TryDiv, TrySub};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let t: Tensor<Rank2<2, 3>> = dev.zeros();
+/// let t: Tensor<Rank2<2, 3>, f32, _> = dev.zeros();
 /// let _ = t.normalize::<Axis<1>>(1e-5);
 /// ```
 pub fn normalize<Ax: Axes, S: Shape + ReduceShape<Ax>, D: Device<f32>, T: Tape<D>>(

--- a/src/tensor_ops/permute_to/mod.rs
+++ b/src/tensor_ops/permute_to/mod.rs
@@ -27,9 +27,9 @@ pub trait PermuteTo: HasErr + HasShape {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let a: Tensor<Rank3<1, 2, 3>, f32> = dev.zeros();
-    /// let _ = a.clone().permute::<Rank3<3, 2, 1>, _>(); // or `permute::<_, Axes<2, 1, 0>>()`
-    /// let _ = a.clone().permute::<Rank3<2, 1, 3>, _>(); // or `permute::<_, Axes<1, 0, 2>>()`
+    /// let a: Tensor<Rank3<1, 2, 3>, f32, _> = dev.zeros();
+    /// let _ = a.clone().permute::<Rank3<3, 2, 1>, _>();
+    /// let _ = a.clone().permute::<_, Axes3<2, 1, 0>>();
     /// ```
     fn permute<Dst: Shape, Ax: Axes>(self) -> Self::WithShape<Dst>
     where

--- a/src/tensor_ops/select_and_gather/mod.rs
+++ b/src/tensor_ops/select_and_gather/mod.rs
@@ -61,15 +61,15 @@ pub trait SelectTo<D: DeviceStorage>: HasErr + HasShape {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let a: Tensor<Rank2<3, 5>> = dev.zeros();
+    /// let a: Tensor<Rank2<3, 5>, f32, _> = dev.zeros();
     ///
     /// // select from the 0th axis
-    /// let idx: Tensor<Rank0, usize> = dev.tensor(0);
-    /// let _: Tensor<Rank1<5>> = a.clone().select(idx);
+    /// let idx: Tensor<Rank0, usize, _> = dev.tensor(0);
+    /// let _: Tensor<Rank1<5>, f32, _> = a.clone().select(idx);
     ///
     /// // select from the 1st axis
-    /// let idx: Tensor<Rank1<3>, usize> = dev.tensor([0, 2, 4]);
-    /// let _: Tensor<Rank1<3>> = a.select(idx);
+    /// let idx: Tensor<Rank1<3>, usize, _> = dev.tensor([0, 2, 4]);
+    /// let _: Tensor<Rank1<3>, f32, _> = a.select(idx);
     ///```
     fn select<Dst: Shape, Idx: Shape>(self, idx: Tensor<Idx, usize, D>) -> Self::WithShape<Dst>
     where
@@ -129,15 +129,15 @@ pub trait GatherTo<D: DeviceStorage>: HasErr + HasShape {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let a: Tensor<Rank2<3, 5>> = dev.zeros();
+    /// let a: Tensor<Rank2<3, 5>, f32, _> = dev.zeros();
     ///
     /// // gather from the 0th axis; dimension 0 becomes 4
-    /// let idx: Tensor<Rank1<4>, usize> = dev.tensor([0, 0, 1, 2]);
-    /// let _: Tensor<Rank2<4, 5>> = a.clone().gather(idx);
+    /// let idx: Tensor<Rank1<4>, usize, _> = dev.tensor([0, 0, 1, 2]);
+    /// let _: Tensor<Rank2<4, 5>, f32, _> = a.clone().gather(idx);
     ///
     /// // gather from the 1st axis; dimension 1 becomes 2
-    /// let idx: Tensor<Rank2<3, 2>, usize> = dev.tensor([[0, 1], [2, 3], [4, 4]]);
-    /// let _: Tensor<Rank2<3, 2>> = a.gather(idx);
+    /// let idx: Tensor<Rank2<3, 2>, usize, _> = dev.tensor([[0, 1], [2, 3], [4, 4]]);
+    /// let _: Tensor<Rank2<3, 2>, f32, _> = a.gather(idx);
     ///```
     fn gather<Dst: Shape, Idx: Shape>(self, idx: Tensor<Idx, usize, D>) -> Self::WithShape<Dst>
     where

--- a/src/tensor_ops/softmax.rs
+++ b/src/tensor_ops/softmax.rs
@@ -12,7 +12,7 @@ use crate::{gradients::Tape, shapes::*, tensor::Tensor};
 /// ```rust
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let t: Tensor<Rank3<2, 3, 5>, f32> = dev.zeros();
+/// let t: Tensor<Rank3<2, 3, 5>, f32, _> = dev.zeros();
 /// let _ = t.softmax::<Axis<2>>();
 /// ```
 pub fn softmax<Ax: Axes, S: Shape, E: Dtype, D: Device<E>, T: Tape<D>>(

--- a/src/tensor_ops/sum_to/mod.rs
+++ b/src/tensor_ops/sum_to/mod.rs
@@ -30,7 +30,7 @@ pub trait SumTo: HasErr + HasShape {
     /// ```rust
     /// # use dfdx::prelude::*;
     /// # let dev: Cpu = Default::default();
-    /// let t: Tensor<Rank2<2, 3>, _> = dev.tensor([[1.0, 2.0, 3.0], [-1.0, -2.0, -3.0]]);
+    /// let t: Tensor<Rank2<2, 3>, f32, _> = dev.tensor([[1.0, 2.0, 3.0], [-1.0, -2.0, -3.0]]);
     /// let r = t.sum::<Rank1<2>, _>(); // or `sum::<_, Axis<1>>()`
     /// assert_eq!(r.array(), [6.0, -6.0]);
     /// ```


### PR DESCRIPTION
This means you always have to specify 3 generics for tensor (shape, dtype, device).

Related to discussion in #410 related to device defaults in nn layer

Reasoning:
1. Currently defaulting dtype to f32 is okay because only f32 is supported. However in the future multiple dtypes will be supported, and this is preparation for that.
2. Similar to discussion in linked issue, it's better to be explicit at this level. Anyone looking at a tensor definition will know the dtype.
3. Users can define type aliases if they want. `type FloatTensor<S, D, T> = Tensor<S, f32, D, T>`;
