### PR TITLE
[WIP] Gradient accumulation

### DIFF
--- a/examples/12-gradient-accumulation.rs
+++ b/examples/12-gradient-accumulation.rs
@@ -1,0 +1,20 @@
+use dfdx::{optim::Sgd, prelude::*};
+
+fn main() {
+    let dev: Cpu = Default::default();
+
+    type Model = (Linear<2, 3>, ReLU, Linear<3, 4>, ReLU, Linear<4, 5>);
+    let mut model = dev.build_module::<Model, f32>();
+
+    let x: Tensor<Rank2<10, 2>, f32, _> = dev.sample_normal();
+    let mut grads = model.forward(x.trace()).square().mean().backward();
+
+    let x: Tensor<Rank2<10, 2>, f32, _> = dev.sample_normal();
+    grads += model.forward(x.trace()).square().mean().backward();
+
+    let x: Tensor<Rank2<10, 2>, f32, _> = dev.sample_normal();
+    grads += model.forward(x.trace()).square().mean().backward();
+
+    let mut opt = Sgd::new(&model, Default::default());
+    opt.update(&mut model, grads).unwrap();
+}

--- a/src/optim/adam/mod.rs
+++ b/src/optim/adam/mod.rs
@@ -120,8 +120,14 @@ impl<M, D: DeviceStorage + AdamKernel<E>, E: Dtype> ParamUpdater<D, E> for Adam<
             Some(g) => {
                 let m_t = self.moment1.get_or_alloc_mut(p)?;
                 let v_t = self.moment2.get_or_alloc_mut(p)?;
-                p.device
-                    .update(self.t, &self.cfg, &mut p.storage, m_t, v_t, g)?;
+                p.device.update(
+                    self.t,
+                    &self.cfg,
+                    &mut p.storage,
+                    &mut m_t.storage,
+                    &mut v_t.storage,
+                    g.storage,
+                )?;
             }
         }
         Ok(())

--- a/src/optim/rmsprop/mod.rs
+++ b/src/optim/rmsprop/mod.rs
@@ -134,10 +134,17 @@ impl<M, E: Dtype, D: RMSpropKernel<E> + OneFillStorage<E>> ParamUpdater<D, E> fo
                 let ga = self.grad_avg.get_or_alloc_mut(p)?;
 
                 if self.step == 0 {
-                    p.device.try_fill_with_ones(sa)?;
+                    sa.try_fill_with_ones()?;
                 }
 
-                p.device.update(&self.cfg, &mut p.storage, m, sa, ga, g)?;
+                p.device.update(
+                    &self.cfg,
+                    &mut p.storage,
+                    &mut m.storage,
+                    &mut sa.storage,
+                    &mut ga.storage,
+                    g.storage,
+                )?;
             }
         }
         Ok(())

--- a/src/optim/sgd/mod.rs
+++ b/src/optim/sgd/mod.rs
@@ -152,7 +152,8 @@ impl<M, D: SgdKernel<E>, E: Dtype> ParamUpdater<D, E> for Sgd<M, E> {
             None => unused.add(p),
             Some(g) => {
                 let v = self.velocity.get_or_alloc_mut(p)?;
-                p.device.update(&self.cfg, &mut p.storage, v, g)?;
+                p.device
+                    .update(&self.cfg, &mut p.storage, &mut v.storage, g.storage)?;
             }
         }
         Ok(())

--- a/src/tensor/cpu/device.rs
+++ b/src/tensor/cpu/device.rs
@@ -1,5 +1,5 @@
 use crate::shapes::{Dtype, HasDtype, HasShape, HasUnitType, Shape, Unit};
-use crate::tensor::storage_traits::*;
+use crate::tensor::{storage_traits::*, Tensor};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::{
     sync::{Arc, Mutex},
@@ -93,5 +93,18 @@ impl DeviceStorage for Cpu {
 
     fn random_u64(&self) -> u64 {
         self.rng.lock().unwrap().gen()
+    }
+
+    fn accumulate<S: Shape, E: Dtype>(
+        &self,
+        accum: &mut Tensor<S, E, Self>,
+        item: Tensor<S, E, Self>,
+    ) -> Result<(), Self::Err> {
+        assert_eq!(accum.storage.shape, item.storage.shape);
+        assert_eq!(accum.storage.strides, item.storage.strides);
+        for (a, i) in accum.storage.buf_iter_mut().zip(item.storage.buf_iter()) {
+            a.add_assign(*i);
+        }
+        Ok(())
     }
 }

--- a/src/tensor_ops/broadcast_to/mod.rs
+++ b/src/tensor_ops/broadcast_to/mod.rs
@@ -81,7 +81,8 @@ impl<S: Shape, E: Dtype, D: BroadcastKernel<E>, T: Tape<D>> BroadcastTo for Tens
         tape.try_alloc_grad(&out)?;
         tape.add_backward_op(move |grads| {
             let (grad_inp, grad_out) = grads.mut_and_ref(&inp, &phantom_out);
-            inp.device.backward(grad_inp, grad_out)
+            inp.device
+                .backward(&mut grad_inp.storage, &grad_out.storage)
         });
         Ok(out.put_tape(tape))
     }

--- a/src/tensor_ops/choose/mod.rs
+++ b/src/tensor_ops/choose/mod.rs
@@ -73,8 +73,12 @@ impl<
         tape.try_alloc_grad(&out)?;
         tape.add_backward_op(move |grads| {
             let (grad_lhs, grad_rhs, grad_out) = grads.muts_and_ref(&lhs, &rhs, &phantom_out);
-            lhs.device
-                .backward(&self.storage, grad_lhs, grad_rhs, grad_out)
+            lhs.device.backward(
+                &self.storage,
+                &mut grad_lhs.storage,
+                &mut grad_rhs.storage,
+                &grad_out.storage,
+            )
         });
 
         Ok(out.put_tape(tape))

--- a/src/tensor_ops/dropout/mod.rs
+++ b/src/tensor_ops/dropout/mod.rs
@@ -74,7 +74,8 @@ impl<S: Shape, E: Dtype, D: DropoutKernel<E>, T: Tape<D>> Tensor<S, E, D, T> {
         tape.try_alloc_grad(&out)?;
         tape.add_backward_op(move |grads| {
             let (grad_inp, grad_out) = grads.mut_and_ref(&inp, &phantom_out);
-            inp.device.backward(op, &inp.storage, grad_inp, grad_out)?;
+            inp.device
+                .backward(op, &inp.storage, &mut grad_inp.storage, &grad_out.storage)?;
             Ok(())
         });
         Ok(out.put_tape(tape))

--- a/src/tensor_ops/matmul/mod.rs
+++ b/src/tensor_ops/matmul/mod.rs
@@ -101,7 +101,7 @@ fn try_binary_op<
     tape.try_alloc_grad(&out)?;
     tape.add_backward_op(move |grads| {
         let (grad_lhs, grad_rhs, grad_out) = grads.muts_and_ref(&lhs, &rhs, &phantom_out);
-        bwd(&lhs.device, &lhs.storage, grad_lhs, &rhs.storage, grad_rhs, grad_out)
+        bwd(&lhs.device, &lhs.storage, &mut grad_lhs.storage, &rhs.storage, &mut grad_rhs.storage, &grad_out.storage)
     });
     Ok(out.put_tape(tape))
 }

--- a/src/tensor_ops/max_to/mod.rs
+++ b/src/tensor_ops/max_to/mod.rs
@@ -73,8 +73,12 @@ impl<S: Shape, E: Dtype, D: MaxReduceKernel<E>, T: Tape<D>> MaxTo for Tensor<S, 
         tape.try_alloc_grad(&out)?;
         tape.add_backward_op(move |grads| {
             let (grad_inp, grad_out) = grads.mut_and_ref(&inp, &phantom_out);
-            inp.device
-                .backward(&inp.storage, grad_inp, &phantom_out.storage, grad_out)
+            inp.device.backward(
+                &inp.storage,
+                &mut grad_inp.storage,
+                &phantom_out.storage,
+                &grad_out.storage,
+            )
         });
         Ok(out.put_tape(tape))
     }

--- a/src/tensor_ops/min_to/mod.rs
+++ b/src/tensor_ops/min_to/mod.rs
@@ -73,8 +73,12 @@ impl<S: Shape, E: Dtype, D: MinReduceKernel<E>, T: Tape<D>> MinTo for Tensor<S, 
         tape.try_alloc_grad(&out)?;
         tape.add_backward_op(move |grads| {
             let (grad_inp, grad_out) = grads.mut_and_ref(&inp, &phantom_out);
-            inp.device
-                .backward(&inp.storage, grad_inp, &phantom_out.storage, grad_out)
+            inp.device.backward(
+                &inp.storage,
+                &mut grad_inp.storage,
+                &phantom_out.storage,
+                &grad_out.storage,
+            )
         });
         Ok(out.put_tape(tape))
     }

--- a/src/tensor_ops/permute_to/mod.rs
+++ b/src/tensor_ops/permute_to/mod.rs
@@ -55,7 +55,8 @@ impl<S: Shape, E: Dtype, D: PermuteKernel<E>, T: Tape<D>> PermuteTo for Tensor<S
         tape.try_alloc_grad(&out)?;
         tape.add_backward_op(move |grads| {
             let (grad_inp, grad_out) = grads.mut_and_ref(&inp, &phantom_out);
-            inp.device.backward(grad_inp, grad_out)
+            inp.device
+                .backward(&mut grad_inp.storage, &grad_out.storage)
         });
         Ok(out.put_tape(tape))
     }

--- a/src/tensor_ops/reshape_to/mod.rs
+++ b/src/tensor_ops/reshape_to/mod.rs
@@ -48,7 +48,8 @@ impl<S: Shape, E: Dtype, D: ReshapeKernel<E>, T: Tape<D>> ReshapeTo for Tensor<S
         tape.try_alloc_grad(&out)?;
         tape.add_backward_op(move |grads| {
             let (grad_inp, grad_out) = grads.mut_and_ref(&inp, &phantom_out);
-            inp.device.backward(grad_inp, grad_out)
+            inp.device
+                .backward(&mut grad_inp.storage, &grad_out.storage)
         });
         Ok(out.put_tape(tape))
     }

--- a/src/tensor_ops/select_and_gather/mod.rs
+++ b/src/tensor_ops/select_and_gather/mod.rs
@@ -104,7 +104,8 @@ impl<Src: Shape, E: Dtype, D: RemoveDimKernel<E>, T: Tape<D>> SelectTo<D> for Te
         tape.try_alloc_grad(&out)?;
         tape.add_backward_op(move |grads| {
             let (grad_inp, grad_out) = grads.mut_and_ref(&inp, &phantom_out);
-            inp.device.backward(grad_inp, &idx.storage, grad_out)
+            inp.device
+                .backward(&mut grad_inp.storage, &idx.storage, &grad_out.storage)
         });
         Ok(out.put_tape(tape))
     }
@@ -174,7 +175,8 @@ impl<Src: Shape, E: Dtype, D: ReplaceDimKernel<E>, T: Tape<D>> GatherTo<D>
         tape.try_alloc_grad(&out)?;
         tape.add_backward_op(move |grads| {
             let (grad_inp, grad_out) = grads.mut_and_ref(&inp, &phantom_out);
-            inp.device.backward(grad_inp, &idx.storage, grad_out)
+            inp.device
+                .backward(&mut grad_inp.storage, &idx.storage, &grad_out.storage)
         });
         Ok(out.put_tape(tape))
     }

--- a/src/tensor_ops/sum_to/mod.rs
+++ b/src/tensor_ops/sum_to/mod.rs
@@ -68,7 +68,8 @@ impl<S: Shape, E: Dtype, D: SumKernel<E>, T: Tape<D>> SumTo for Tensor<S, E, D, 
         tape.try_alloc_grad(&out)?;
         tape.add_backward_op(move |grads| {
             let (grad_inp, grad_out) = grads.mut_and_ref(&inp, &phantom_out);
-            inp.device.backward(grad_inp, grad_out)
+            inp.device
+                .backward(&mut grad_inp.storage, &grad_out.storage)
         });
         Ok(out.put_tape(tape))
     }

--- a/src/tensor_ops/utilities/backward.rs
+++ b/src/tensor_ops/utilities/backward.rs
@@ -17,7 +17,7 @@ pub trait Backward: HasErr {
 impl<E: Dtype, D: OneFillStorage<E>> Backward for Tensor<Rank0, E, D, OwnedTape<D>> {
     fn try_backward(self) -> Result<Gradients, Self::Err> {
         let (t, mut tape) = self.split_tape();
-        tape.add_backward_op(move |grads| t.device.try_fill_with_ones(grads.get_mut(&t)));
+        tape.add_backward_op(move |grads| grads.get_mut(&t).try_fill_with_ones());
         tape.0.execute()
     }
 }


### PR DESCRIPTION
Resolves #400 

`Gradients` now stores a vec of other `Gradient` objects to lazily add together when `Gradients::remove` is called. When two `Gradients` are added together, it just appends the underlying hashmaps together

Changes:
1. Gradients stored in `Gradients` are now tensors instead of storage
3. Add `accumulate` method in `DeviceStorage` that mutates a mutable tensor with another tensor
4. impl AddAssign for `Tensor` and `Gradients`
5. impl Add for `Gradients`

TODOS
- [ ] only keep keys that are shared between the two gradients (unless self is empty)
- [ ] impl accumulate for Cuda
- [ ] unit tests