### PR TITLE
Bump cudarc 0.7.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ matrixmultiply = { version = "0.3.2", default-features = false }
 zip = { version = "0.6.2", default-features = false, optional = true }
 cblas-sys = { version = "0.1.4", default-features = false, optional = true }
 libc = { version = "0.2", default-features = false, optional = true }
-cudarc = { version = "0.7.1", default-features = false, optional = true }
+cudarc = { version = "0.7.2", default-features = false, optional = true }
 num-traits = { version = "0.2.15", default-features = false }
 
 [features]


### PR DESCRIPTION
Potentially resolves #464.

cudarc 0.7.2 changes to using default stream for everything.