### PR TITLE
Add try_forward and try_forward_mut to Module and ModuleMut.

### DIFF
--- a/examples/07-custom-module.rs
+++ b/examples/07-custom-module.rs
@@ -66,7 +66,10 @@ impl<
     type Output = Tensor<Rank2<BATCH, OUT>, f32, Device, T>;
     type Error = Err;
 
-    fn try_forward(&self, x: Tensor<Rank2<BATCH, IN>, f32, Device, T>) -> Result<Self::Output, Err> {
+    fn try_forward(
+        &self,
+        x: Tensor<Rank2<BATCH, IN>, f32, Device, T>,
+    ) -> Result<Self::Output, Err> {
         let x = self.l1.try_forward(x)?;
         let x = self.relu.try_forward(x)?;
         self.l2.try_forward(x)

--- a/examples/07-custom-module.rs
+++ b/examples/07-custom-module.rs
@@ -16,6 +16,8 @@ type Device = dfdx::tensor::Cpu;
 #[cfg(feature = "cuda")]
 type Device = dfdx::tensor::Cuda;
 
+type Err = <Device as HasErr>::Err;
+
 /// Custom model struct
 /// This case is trivial and should be done with a tuple of linears and relus,
 /// but it demonstrates how to build models with custom behavior
@@ -29,7 +31,7 @@ struct Mlp<const IN: usize, const INNER: usize, const OUT: usize> {
 impl<const IN: usize, const INNER: usize, const OUT: usize> BuildModule<Device, f32>
     for Mlp<IN, INNER, OUT>
 {
-    fn try_build(device: &Device) -> Result<Self, <Device as HasErr>::Err> {
+    fn try_build(device: &Device) -> Result<Self, Err> {
         Ok(Self {
             l1: BuildModule::try_build(device)?,
             l2: BuildModule::try_build(device)?,
@@ -43,11 +45,12 @@ impl<const IN: usize, const INNER: usize, const OUT: usize> Module<Tensor<Rank1<
     for Mlp<IN, INNER, OUT>
 {
     type Output = Tensor<Rank1<OUT>, f32, Device>;
+    type Error = Err;
 
-    fn forward(&self, x: Tensor<Rank1<IN>, f32, Device>) -> Self::Output {
-        let x = self.l1.forward(x);
-        let x = self.relu.forward(x);
-        self.l2.forward(x)
+    fn try_forward(&self, x: Tensor<Rank1<IN>, f32, Device>) -> Result<Self::Output, Err> {
+        let x = self.l1.try_forward(x)?;
+        let x = self.relu.try_forward(x)?;
+        self.l2.try_forward(x)
     }
 }
 
@@ -61,11 +64,12 @@ impl<
     > Module<Tensor<Rank2<BATCH, IN>, f32, Device, T>> for Mlp<IN, INNER, OUT>
 {
     type Output = Tensor<Rank2<BATCH, OUT>, f32, Device, T>;
+    type Error = Err;
 
-    fn forward(&self, x: Tensor<Rank2<BATCH, IN>, f32, Device, T>) -> Self::Output {
-        let x = self.l1.forward(x);
-        let x = self.relu.forward(x);
-        self.l2.forward(x)
+    fn try_forward(&self, x: Tensor<Rank2<BATCH, IN>, f32, Device, T>) -> Result<Self::Output, Err> {
+        let x = self.l1.try_forward(x)?;
+        let x = self.relu.try_forward(x)?;
+        self.l2.try_forward(x)
     }
 }
 

--- a/src/nn/activations.rs
+++ b/src/nn/activations.rs
@@ -15,24 +15,26 @@ macro_rules! activation_impls {
             for $struct_name
         {
             type Output = Tensor<S, E, D, T>;
-            fn forward(&self, input: Tensor<S, E, D, T>) -> Self::Output {
-                $func_name(input)
+            type Error = D::Err;
+
+            fn try_forward(&self, input: Tensor<S, E, D, T>) -> Result<Self::Output, D::Err> {
+                input.$func_name()
             }
         }
     };
 }
 
-activation_impls!(ReLU, relu, #[doc="Unit struct that impls [Module] as calling [relu()] on `input`."]);
-activation_impls!(GeLU, gelu, #[doc="Unit struct that impls [Module] as calling [gelu()] on `input`."]);
-activation_impls!(Sin, sin, #[doc="Unit struct that impls [Module] as calling [sin()] on `input`."]);
-activation_impls!(Cos, cos, #[doc="Unit struct that impls [Module] as calling [cos()] on `input`."]);
-activation_impls!(Ln, ln, #[doc="Unit struct that impls [Module] as calling [ln()] on `input`."]);
-activation_impls!(Exp, exp, #[doc="Unit struct that impls [Module] as calling [exp()] on `input`."]);
-activation_impls!(Sigmoid, sigmoid, #[doc="Unit struct that impls [Module] as calling [sigmoid()] on `input`."]);
-activation_impls!(Tanh, tanh, #[doc="Unit struct that impls [Module] as calling [tanh()] on `input`."]);
-activation_impls!(Square, square, #[doc="Unit struct that impls [Module] as calling [square()] on `input`."]);
-activation_impls!(Sqrt, sqrt, #[doc="Unit struct that impls [Module] as calling [sqrt()] on `input`."]);
-activation_impls!(Abs, abs, #[doc="Unit struct that impls [Module] as calling [abs()] on `input`."]);
+activation_impls!(ReLU, try_relu, #[doc="Unit struct that impls [Module] as calling [relu()] on `input`."]);
+activation_impls!(GeLU, try_gelu, #[doc="Unit struct that impls [Module] as calling [gelu()] on `input`."]);
+activation_impls!(Sin, try_sin, #[doc="Unit struct that impls [Module] as calling [sin()] on `input`."]);
+activation_impls!(Cos, try_cos, #[doc="Unit struct that impls [Module] as calling [cos()] on `input`."]);
+activation_impls!(Ln, try_ln, #[doc="Unit struct that impls [Module] as calling [ln()] on `input`."]);
+activation_impls!(Exp, try_exp, #[doc="Unit struct that impls [Module] as calling [exp()] on `input`."]);
+activation_impls!(Sigmoid, try_sigmoid, #[doc="Unit struct that impls [Module] as calling [sigmoid()] on `input`."]);
+activation_impls!(Tanh, try_tanh, #[doc="Unit struct that impls [Module] as calling [tanh()] on `input`."]);
+activation_impls!(Square, try_square, #[doc="Unit struct that impls [Module] as calling [square()] on `input`."]);
+activation_impls!(Sqrt, try_sqrt, #[doc="Unit struct that impls [Module] as calling [sqrt()] on `input`."]);
+activation_impls!(Abs, try_abs, #[doc="Unit struct that impls [Module] as calling [abs()] on `input`."]);
 
 /// Unit struct that impls [Module] as calling [softmax()] on `input`."
 #[derive(Default, Debug, Clone, Copy)]
@@ -45,8 +47,10 @@ impl<Ax: Axes, S: Shape<LastAxis = Ax> + ReduceShape<Ax>, E: Dtype, D: Device<E>
     Module<Tensor<S, E, D, T>> for Softmax
 {
     type Output = Tensor<S, E, D, T>;
-    fn forward(&self, input: Tensor<S, E, D, T>) -> Self::Output {
-        input.softmax::<Ax>()
+    type Error = D::Err;
+
+    fn try_forward(&self, input: Tensor<S, E, D, T>) -> Result<Self::Output, D::Err> {
+        input.try_softmax::<Ax>()
     }
 }
 

--- a/src/nn/batchnorm2d.rs
+++ b/src/nn/batchnorm2d.rs
@@ -82,9 +82,9 @@ impl<const C: usize, E: Dtype, D: Device<E>> BatchNorm2D<C, E, D> {
         let mean = self.running_mean.clone();
 
         // normalize & affine
-        let x = x.try_sub(mean.broadcast_like(&shape))?;
-        let x = x.try_div(std.broadcast_like(&shape))?;
-        let x = x.try_mul(self.scale.clone().broadcast_like(&shape))?;
+        let x = x.try_sub(mean.try_broadcast_like(&shape))?;
+        let x = x.try_div(std.try_broadcast_like(&shape))?;
+        let x = x.try_mul(self.scale.clone().try_broadcast_like(&shape))?;
         x.try_add(self.bias.clone().try_broadcast_like(&shape)?)
     }
 

--- a/src/nn/batchnorm2d.rs
+++ b/src/nn/batchnorm2d.rs
@@ -82,9 +82,9 @@ impl<const C: usize, E: Dtype, D: Device<E>> BatchNorm2D<C, E, D> {
         let mean = self.running_mean.clone();
 
         // normalize & affine
-        let x = x.try_sub(mean.try_broadcast_like(&shape))?;
-        let x = x.try_div(std.try_broadcast_like(&shape))?;
-        let x = x.try_mul(self.scale.clone().try_broadcast_like(&shape))?;
+        let x = x.try_sub(mean.try_broadcast_like(&shape)?)?;
+        let x = x.try_div(std.try_broadcast_like(&shape)?)?;
+        let x = x.try_mul(self.scale.clone().try_broadcast_like(&shape)?)?;
         x.try_add(self.bias.clone().try_broadcast_like(&shape)?)
     }
 

--- a/src/nn/batchnorm2d.rs
+++ b/src/nn/batchnorm2d.rs
@@ -71,27 +71,27 @@ pub struct BatchNorm2D<const C: usize, E: Dtype, D: DeviceStorage> {
 
 impl<const C: usize, E: Dtype, D: Device<E>> BatchNorm2D<C, E, D> {
     /// generic forward for inference
-    fn infer_fwd<S: Shape, Ax: Axes>(&self, x: Tensor<S, E, D>) -> Tensor<S, E, D>
+    fn infer_fwd<S: Shape, Ax: Axes>(&self, x: Tensor<S, E, D>) -> Result<Tensor<S, E, D>, D::Err>
     where
         Rank1<C>: BroadcastShapeTo<S, Ax>,
     {
         let shape = *x.shape();
 
         // statistics for normalizing
-        let std = (self.running_var.clone() + self.epsilon).sqrt();
+        let std = (self.running_var.clone() + self.epsilon).try_sqrt()?;
         let mean = self.running_mean.clone();
 
         // normalize & affine
-        let x = sub(x, mean.broadcast_like(&shape));
-        let x = div(x, std.broadcast_like(&shape));
-        let x = mul(x, self.scale.clone().broadcast_like(&shape));
-        add(x, self.bias.clone().broadcast_like(&shape))
+        let x = x.try_sub(mean.broadcast_like(&shape))?;
+        let x = x.try_div(std.broadcast_like(&shape))?;
+        let x = x.try_mul(self.scale.clone().broadcast_like(&shape))?;
+        x.try_add(self.bias.clone().try_broadcast_like(&shape)?)
     }
 
     fn train_fwd<S: Shape, T: Tape<D>, Ax: Axes>(
         &mut self,
         x: Tensor<S, E, D, T>,
-    ) -> Tensor<S, E, D, T>
+    ) -> Result<Tensor<S, E, D, T>, D::Err>
     where
         S: HasAxes<Ax> + ReduceShapeTo<Rank1<C>, Ax>,
     {
@@ -99,29 +99,39 @@ impl<const C: usize, E: Dtype, D: Device<E>> BatchNorm2D<C, E, D> {
         let shape = *x.shape();
 
         // compute statistics for updating running stats later - on tape
-        let mean_chan = x.retaped::<T>().mean::<Rank1<C>, _>();
+        let mean_chan = x.retaped::<T>().try_mean::<Rank1<C>, _>()?;
 
         // update statistics since we are training - off tape
-        self.running_mean = self.running_mean.clone() * (E::ONE - self.momentum)
-            + mean_chan.retaped::<NoneTape>() * self.momentum;
+        self.running_mean = self
+            .running_mean
+            .clone()
+            .try_mul(E::ONE - self.momentum)?
+            .try_add(mean_chan.retaped::<NoneTape>().try_mul(self.momentum)?)?;
 
-        let centered = x - mean_chan.broadcast_like(&shape);
+        let centered = x - mean_chan.try_broadcast_like(&shape)?;
 
         let var_chan = centered.retaped::<T>().square().mean::<Rank1<C>, _>();
 
         // NOTE: uses unbiased variance in running estimate
-        self.running_var = self.running_var.clone() * (E::ONE - self.momentum)
-            + var_chan.retaped::<NoneTape>() * (self.momentum * n / (n - E::ONE));
+        self.running_var = self
+            .running_var
+            .clone()
+            .try_mul(E::ONE - self.momentum)?
+            .try_add(
+                var_chan
+                    .retaped::<NoneTape>()
+                    .try_mul(self.momentum * n / (n - E::ONE))?,
+            )?;
 
         // statistics for normalizing - on tape
-        let std = (var_chan + self.epsilon).sqrt();
+        let std = (var_chan + self.epsilon).try_sqrt()?;
 
         // record broadcast of scale & bias - on tape
-        let scale = (self.scale.retaped::<T>() / std).broadcast_like(&shape);
-        let bias = self.bias.retaped::<T>().broadcast_like(&shape);
+        let scale = (self.scale.retaped::<T>() / std).try_broadcast_like(&shape)?;
+        let bias = self.bias.retaped::<T>().try_broadcast_like(&shape)?;
 
         // normalize & affine - on tape
-        centered * scale + bias
+        centered.try_mul(scale)?.try_add(bias)
     }
 }
 
@@ -129,9 +139,13 @@ impl<const C: usize, H: Dim, W: Dim, E: Dtype, D: Device<E>>
     Module<Tensor<(Const<C>, H, W), E, D, NoneTape>> for BatchNorm2D<C, E, D>
 {
     type Output = Tensor<(Const<C>, H, W), E, D, NoneTape>;
+    type Error = D::Err;
 
     /// Inference 3d forward - does **not** update [Self::running_mean] and [Self::running_var]
-    fn forward(&self, x: Tensor<(Const<C>, H, W), E, D, NoneTape>) -> Self::Output {
+    fn try_forward(
+        &self,
+        x: Tensor<(Const<C>, H, W), E, D, NoneTape>,
+    ) -> Result<Self::Output, D::Err> {
         self.infer_fwd(x)
     }
 }
@@ -140,9 +154,13 @@ impl<B: Dim, const C: usize, H: Dim, W: Dim, E: Dtype, D: Device<E>>
     Module<Tensor<(B, Const<C>, H, W), E, D, NoneTape>> for BatchNorm2D<C, E, D>
 {
     type Output = Tensor<(B, Const<C>, H, W), E, D, NoneTape>;
+    type Error = D::Err;
 
     /// Inference 4d forward - does **not** update [Self::running_mean] and [Self::running_var]
-    fn forward(&self, x: Tensor<(B, Const<C>, H, W), E, D, NoneTape>) -> Self::Output {
+    fn try_forward(
+        &self,
+        x: Tensor<(B, Const<C>, H, W), E, D, NoneTape>,
+    ) -> Result<Self::Output, D::Err> {
         self.infer_fwd(x)
     }
 }
@@ -151,9 +169,13 @@ impl<const C: usize, H: Dim, W: Dim, E: Dtype, D: Device<E>>
     ModuleMut<Tensor<(Const<C>, H, W), E, D, OwnedTape<D>>> for BatchNorm2D<C, E, D>
 {
     type Output = Tensor<(Const<C>, H, W), E, D, OwnedTape<D>>;
+    type Error = D::Err;
 
     /// Training 3d forward - updates [Self::running_mean] and [Self::running_var]
-    fn forward_mut(&mut self, x: Tensor<(Const<C>, H, W), E, D, OwnedTape<D>>) -> Self::Output {
+    fn try_forward_mut(
+        &mut self,
+        x: Tensor<(Const<C>, H, W), E, D, OwnedTape<D>>,
+    ) -> Result<Self::Output, D::Err> {
         self.train_fwd(x)
     }
 }
@@ -162,9 +184,13 @@ impl<B: Dim, const C: usize, H: Dim, W: Dim, E: Dtype, D: Device<E>>
     ModuleMut<Tensor<(B, Const<C>, H, W), E, D, OwnedTape<D>>> for BatchNorm2D<C, E, D>
 {
     type Output = Tensor<(B, Const<C>, H, W), E, D, OwnedTape<D>>;
+    type Error = D::Err;
 
     /// Training 4d forward - updates [Self::running_mean] and [Self::running_var]
-    fn forward_mut(&mut self, x: Tensor<(B, Const<C>, H, W), E, D, OwnedTape<D>>) -> Self::Output {
+    fn try_forward_mut(
+        &mut self,
+        x: Tensor<(B, Const<C>, H, W), E, D, OwnedTape<D>>,
+    ) -> Result<Self::Output, D::Err> {
         self.train_fwd(x)
     }
 }
@@ -300,7 +326,7 @@ mod tests {
     }
 
     #[test]
-    fn test_batchform2d_3d_repeated_forward_mut() {
+    fn test_batchnorm2d_3d_repeated_forward_mut() {
         let dev = TestDevice::seed_from_u64(12);
 
         let x1: Tensor<Rank3<3, 4, 5>, TestDtype, _> = dev.sample_normal();

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -3,7 +3,7 @@ use rand_distr::uniform::SampleUniform;
 
 use crate::{gradients::Tape, shapes::*, tensor::*, tensor_ops::*};
 
-use super::{tensor_collection::*, BuildModule, BuildOnDevice, Module, ToDevice, ModuleMut};
+use super::{tensor_collection::*, BuildModule, BuildOnDevice, Module, ModuleMut, ToDevice};
 
 pub mod builder {
     #[derive(Debug)]
@@ -157,8 +157,14 @@ impl<'a, const C: usize, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<D>>
     type Output = Tensor<(Const<C>, H, W), E, D, T>;
     type Error = D::Err;
 
-    fn try_forward(&self, input: Tensor<(Const<C>, H, W), E, D, T>) -> Result<Self::Output, D::Err> {
-        self.beta.retaped::<T>().try_broadcast_like(input.shape())?.try_add(input)
+    fn try_forward(
+        &self,
+        input: Tensor<(Const<C>, H, W), E, D, T>,
+    ) -> Result<Self::Output, D::Err> {
+        self.beta
+            .retaped::<T>()
+            .try_broadcast_like(input.shape())?
+            .try_add(input)
     }
 }
 
@@ -168,8 +174,14 @@ impl<'a, B: Dim, const C: usize, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape
     type Output = Tensor<(B, Const<C>, H, W), E, D, T>;
     type Error = D::Err;
 
-    fn try_forward(&self, input: Tensor<(B, Const<C>, H, W), E, D, T>) -> Result<Self::Output, D::Err> {
-        self.beta.retaped::<T>().try_broadcast_like(input.shape())?.try_add(input)
+    fn try_forward(
+        &self,
+        input: Tensor<(B, Const<C>, H, W), E, D, T>,
+    ) -> Result<Self::Output, D::Err> {
+        self.beta
+            .retaped::<T>()
+            .try_broadcast_like(input.shape())?
+            .try_add(input)
     }
 }
 

--- a/src/nn/dropout.rs
+++ b/src/nn/dropout.rs
@@ -64,7 +64,10 @@ impl<const N: usize, S: Shape, E: Dtype, D: Device<E>> ModuleMut<Tensor<S, E, D,
     type Error = D::Err;
 
     /// Calls [dropout()] with `p=1/N` using `self.rng`.
-    fn try_forward_mut(&mut self, input: Tensor<S, E, D, OwnedTape<D>>) -> Result<Self::Output, D::Err> {
+    fn try_forward_mut(
+        &mut self,
+        input: Tensor<S, E, D, OwnedTape<D>>,
+    ) -> Result<Self::Output, D::Err> {
         input.try_dropout(E::ONE / E::from_usize(N).unwrap())
     }
 }
@@ -136,7 +139,10 @@ impl<S: Shape, E: Dtype, D: Device<E>> ModuleMut<Tensor<S, E, D, OwnedTape<D>>> 
     type Error = D::Err;
 
     /// Calls [dropout()]
-    fn try_forward_mut(&mut self, input: Tensor<S, E, D, OwnedTape<D>>) -> Result<Self::Output, D::Err> {
+    fn try_forward_mut(
+        &mut self,
+        input: Tensor<S, E, D, OwnedTape<D>>,
+    ) -> Result<Self::Output, D::Err> {
         input.try_dropout(E::from_f32(self.p).unwrap())
     }
 }

--- a/src/nn/embedding.rs
+++ b/src/nn/embedding.rs
@@ -87,9 +87,11 @@ impl<const V: usize, const M: usize, const S: usize, E: Dtype, D: Device<E>, T: 
     Module<Tensor<Rank1<S>, usize, D, T>> for Embedding<V, M, E, D>
 {
     type Output = Tensor<Rank2<S, M>, E, D, T>;
-    fn forward(&self, input: Tensor<Rank1<S>, usize, D, T>) -> Self::Output {
+    type Error = D::Err;
+
+    fn try_forward(&self, input: Tensor<Rank1<S>, usize, D, T>) -> Result<Self::Output, D::Err> {
         let (input, tape) = input.split_tape();
-        self.weight.clone().put_tape(tape).gather(input)
+        self.weight.clone().put_tape(tape).try_gather(input)
     }
 }
 
@@ -104,9 +106,11 @@ impl<
     > Module<Tensor<Rank2<BATCH, SEQ>, usize, D, T>> for Embedding<VOCAB, DIM, E, D>
 {
     type Output = Tensor<Rank3<BATCH, SEQ, DIM>, E, D, T>;
-    fn forward(&self, input: Tensor<Rank2<BATCH, SEQ>, usize, D, T>) -> Self::Output {
+    type Error = D::Err;
+
+    fn try_forward(&self, input: Tensor<Rank2<BATCH, SEQ>, usize, D, T>) -> Result<Self::Output, D::Err> {
         let (input, tape) = input.split_tape();
-        self.weight.clone().put_tape(tape).gather(input)
+        self.weight.clone().put_tape(tape).try_gather(input)
     }
 }
 

--- a/src/nn/embedding.rs
+++ b/src/nn/embedding.rs
@@ -108,7 +108,10 @@ impl<
     type Output = Tensor<Rank3<BATCH, SEQ, DIM>, E, D, T>;
     type Error = D::Err;
 
-    fn try_forward(&self, input: Tensor<Rank2<BATCH, SEQ>, usize, D, T>) -> Result<Self::Output, D::Err> {
+    fn try_forward(
+        &self,
+        input: Tensor<Rank2<BATCH, SEQ>, usize, D, T>,
+    ) -> Result<Self::Output, D::Err> {
         let (input, tape) = input.split_tape();
         self.weight.clone().put_tape(tape).try_gather(input)
     }

--- a/src/nn/flatten.rs
+++ b/src/nn/flatten.rs
@@ -17,8 +17,10 @@ where
     Rank3<C, H, W>: HasSameNumelAs<Rank1<{ C * H * W }>>,
 {
     type Output = Tensor<Rank1<{ C * H * W }>, E, D, T>;
-    fn forward(&self, input: Tensor<Rank3<C, H, W>, E, D, T>) -> Self::Output {
-        input.reshape()
+    type Error = D::Err;
+
+    fn try_forward(&self, input: Tensor<Rank3<C, H, W>, E, D, T>) -> Result<Self::Output, D::Err> {
+        input.try_reshape()
     }
 }
 
@@ -30,8 +32,10 @@ where
     Rank4<B, C, H, W>: HasSameNumelAs<Rank2<B, { C * H * W }>>,
 {
     type Output = Tensor<Rank2<B, { C * H * W }>, E, D, T>;
-    fn forward(&self, input: Tensor<Rank4<B, C, H, W>, E, D, T>) -> Self::Output {
-        input.reshape()
+    type Error = D::Err;
+
+    fn try_forward(&self, input: Tensor<Rank4<B, C, H, W>, E, D, T>) -> Result<Self::Output, D::Err> {
+        input.try_reshape()
     }
 }
 

--- a/src/nn/flatten.rs
+++ b/src/nn/flatten.rs
@@ -34,7 +34,10 @@ where
     type Output = Tensor<Rank2<B, { C * H * W }>, E, D, T>;
     type Error = D::Err;
 
-    fn try_forward(&self, input: Tensor<Rank4<B, C, H, W>, E, D, T>) -> Result<Self::Output, D::Err> {
+    fn try_forward(
+        &self,
+        input: Tensor<Rank4<B, C, H, W>, E, D, T>,
+    ) -> Result<Self::Output, D::Err> {
         input.try_reshape()
     }
 }

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -70,12 +70,14 @@ where
     type Error = F::Error;
 
     fn try_forward(&self, x: T) -> Result<Self::Output, F::Error> {
-        self.f.try_forward(x.with_empty_tape())?.try_add(self.r.try_forward(x)?)
+        self.f
+            .try_forward(x.with_empty_tape())?
+            .try_add(self.r.try_forward(x)?)
     }
 }
 
-impl<T: SplitTape, F: ModuleMut<T>, R: ModuleMut<T, Output = F::Output, Error = F::Error>> ModuleMut<T>
-    for GeneralizedResidual<F, R>
+impl<T: SplitTape, F: ModuleMut<T>, R: ModuleMut<T, Output = F::Output, Error = F::Error>>
+    ModuleMut<T> for GeneralizedResidual<F, R>
 where
     F::Output: TryAdd<F::Output> + HasErr<Err = F::Error>,
 {
@@ -83,7 +85,9 @@ where
     type Error = F::Error;
 
     fn try_forward_mut(&mut self, x: T) -> Result<Self::Output, F::Error> {
-        self.f.try_forward_mut(x.with_empty_tape())?.try_add(self.r.try_forward_mut(x)?)
+        self.f
+            .try_forward_mut(x.with_empty_tape())?
+            .try_add(self.r.try_forward_mut(x)?)
     }
 }
 

--- a/src/nn/generalized_residual.rs
+++ b/src/nn/generalized_residual.rs
@@ -1,4 +1,4 @@
-use crate::{shapes::*, tensor::*};
+use crate::{shapes::*, tensor::*, tensor_ops::TryAdd};
 
 use super::{tensor_collection::*, BuildModule, BuildOnDevice, Module, ModuleMut, ToDevice};
 
@@ -61,25 +61,29 @@ impl<D, F: ToDevice<D>, R: ToDevice<D>> ToDevice<D> for GeneralizedResidual<F, R
     }
 }
 
-impl<T: SplitTape, F: Module<T>, R: Module<T, Output = F::Output>> Module<T>
+impl<T: SplitTape, F: Module<T>, R: Module<T, Output = F::Output, Error = F::Error>> Module<T>
     for GeneralizedResidual<F, R>
 where
-    F::Output: std::ops::Add<F::Output>,
+    F::Output: TryAdd<F::Output> + HasErr<Err = F::Error>,
 {
-    type Output = <F::Output as std::ops::Add<F::Output>>::Output;
-    fn forward(&self, x: T) -> Self::Output {
-        self.f.forward(x.with_empty_tape()) + self.r.forward(x)
+    type Output = F::Output;
+    type Error = F::Error;
+
+    fn try_forward(&self, x: T) -> Result<Self::Output, F::Error> {
+        self.f.try_forward(x.with_empty_tape())?.try_add(self.r.try_forward(x)?)
     }
 }
 
-impl<T: SplitTape, F: ModuleMut<T>, R: ModuleMut<T, Output = F::Output>> ModuleMut<T>
+impl<T: SplitTape, F: ModuleMut<T>, R: ModuleMut<T, Output = F::Output, Error = F::Error>> ModuleMut<T>
     for GeneralizedResidual<F, R>
 where
-    F::Output: std::ops::Add<F::Output>,
+    F::Output: TryAdd<F::Output> + HasErr<Err = F::Error>,
 {
-    type Output = <F::Output as std::ops::Add<F::Output>>::Output;
-    fn forward_mut(&mut self, x: T) -> Self::Output {
-        self.f.forward_mut(x.with_empty_tape()) + self.r.forward_mut(x)
+    type Output = F::Output;
+    type Error = F::Error;
+
+    fn try_forward_mut(&mut self, x: T) -> Result<Self::Output, F::Error> {
+        self.f.try_forward_mut(x.with_empty_tape())?.try_add(self.r.try_forward_mut(x)?)
     }
 }
 

--- a/src/nn/impl_module_for_tuples.rs
+++ b/src/nn/impl_module_for_tuples.rs
@@ -58,30 +58,32 @@ macro_rules! tuple_impls {
         impl<
             Input,
             $last:
-            $(Module::<$rev_tail ::Output>, $rev_tail: )+
+            $(Module::<$rev_tail ::Output, Error=$rev_tail::Error>, $rev_tail: )+
             Module<Input>
         > Module<Input> for ($($name,)+) {
             type Output = $last ::Output;
+            type Error = $last ::Error;
 
             /// Calls forward sequentially on each module in the tuple.
-            fn forward(&self, x: Input) -> Self::Output {
-                $(let x = self.$idx.forward(x);)+
-                x
+            fn try_forward(&self, x: Input) -> Result<Self::Output, Self::Error> {
+                $(let x = self.$idx.try_forward(x)?;)+
+                Ok(x)
             }
         }
 
         impl<
             Input,
             $last:
-            $(ModuleMut::<$rev_tail ::Output>, $rev_tail: )+
+            $(ModuleMut::<$rev_tail ::Output, Error=$rev_tail::Error>, $rev_tail: )+
             ModuleMut<Input>
         > ModuleMut<Input> for ($($name,)+) {
             type Output = $last ::Output;
+            type Error = $last ::Error;
 
             /// Calls forward sequentially on each module in the tuple.
-            fn forward_mut(&mut self, x: Input) -> Self::Output {
-                $(let x = self.$idx.forward_mut(x);)+
-                x
+            fn try_forward_mut(&mut self, x: Input) -> Result<Self::Output, Self::Error> {
+                $(let x = self.$idx.try_forward_mut(x)?;)+
+                Ok(x)
             }
         }
     };
@@ -154,11 +156,14 @@ mod tests {
     #[derive(Debug, Default, Clone)]
     struct SetTo1<const I: usize, const N: usize>;
     impl<const I: usize, const N: usize> ZeroSizedModule for SetTo1<I, N> {}
+
     impl<const I: usize, const N: usize> Module<Tensor<Rank1<N>, f32, Cpu>> for SetTo1<I, N> {
         type Output = Tensor<Rank1<N>, f32, Cpu>;
-        fn forward(&self, mut input: Tensor<Rank1<N>, f32, Cpu>) -> Self::Output {
+        type Error = <Cpu as HasErr>::Err;
+
+        fn try_forward(&self, mut input: Tensor<Rank1<N>, f32, Cpu>) -> Result<Self::Output, Self::Error> {
             std::sync::Arc::make_mut(&mut input.storage.data)[I] = 1.0;
-            input
+            Ok(input)
         }
     }
 

--- a/src/nn/impl_module_for_tuples.rs
+++ b/src/nn/impl_module_for_tuples.rs
@@ -161,7 +161,10 @@ mod tests {
         type Output = Tensor<Rank1<N>, f32, Cpu>;
         type Error = <Cpu as HasErr>::Err;
 
-        fn try_forward(&self, mut input: Tensor<Rank1<N>, f32, Cpu>) -> Result<Self::Output, Self::Error> {
+        fn try_forward(
+            &self,
+            mut input: Tensor<Rank1<N>, f32, Cpu>,
+        ) -> Result<Self::Output, Self::Error> {
             std::sync::Arc::make_mut(&mut input.storage.data)[I] = 1.0;
             Ok(input)
         }

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -93,7 +93,9 @@ impl<const M: usize, E: Dtype, D: Device<E>, T: Tape<D>> Module<Tensor<Rank1<M>,
     type Error = D::Err;
 
     fn try_forward(&self, x: Tensor<Rank1<M>, E, D, T>) -> Result<Self::Output, D::Err> {
-        x.try_normalize(self.epsilon)?.try_mul(self.gamma.clone())?.try_add(self.beta.clone())
+        x.try_normalize(self.epsilon)?
+            .try_mul(self.gamma.clone())?
+            .try_add(self.beta.clone())
     }
 }
 
@@ -105,7 +107,8 @@ impl<B: Dim, const M: usize, E: Dtype, D: Device<E>, T: Tape<D>>
 
     fn try_forward(&self, x: Tensor<(B, Const<M>), E, D, T>) -> Result<Self::Output, D::Err> {
         let shape = *x.shape();
-        x.try_normalize::<Axis<1>>(self.epsilon)?.try_mul(self.gamma.retaped::<T>().try_broadcast_like(&shape)?)?
+        x.try_normalize::<Axis<1>>(self.epsilon)?
+            .try_mul(self.gamma.retaped::<T>().try_broadcast_like(&shape)?)?
             .try_add(self.beta.retaped::<T>().try_broadcast_like(&shape)?)
     }
 }
@@ -118,7 +121,8 @@ impl<B: Dim, S: Dim, const M: usize, E: Dtype, D: Device<E>, T: Tape<D>>
 
     fn try_forward(&self, x: Tensor<(B, S, Const<M>), E, D, T>) -> Result<Self::Output, D::Err> {
         let shape = *x.shape();
-        x.try_normalize::<Axis<2>>(self.epsilon)?.try_mul(self.gamma.retaped::<T>().try_broadcast_like(&shape)?)?
+        x.try_normalize::<Axis<2>>(self.epsilon)?
+            .try_mul(self.gamma.retaped::<T>().try_broadcast_like(&shape)?)?
             .try_add(self.beta.retaped::<T>().try_broadcast_like(&shape)?)
     }
 }

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -90,8 +90,10 @@ impl<const M: usize, E: Dtype, D: Device<E>, T: Tape<D>> Module<Tensor<Rank1<M>,
     for LayerNorm1D<M, E, D>
 {
     type Output = Tensor<Rank1<M>, E, D, T>;
-    fn forward(&self, x: Tensor<Rank1<M>, E, D, T>) -> Self::Output {
-        x.normalize(self.epsilon) * self.gamma.clone() + self.beta.clone()
+    type Error = D::Err;
+
+    fn try_forward(&self, x: Tensor<Rank1<M>, E, D, T>) -> Result<Self::Output, D::Err> {
+        x.try_normalize(self.epsilon)?.try_mul(self.gamma.clone())?.try_add(self.beta.clone())
     }
 }
 
@@ -99,10 +101,12 @@ impl<B: Dim, const M: usize, E: Dtype, D: Device<E>, T: Tape<D>>
     Module<Tensor<(B, Const<M>), E, D, T>> for LayerNorm1D<M, E, D>
 {
     type Output = Tensor<(B, Const<M>), E, D, T>;
-    fn forward(&self, x: Tensor<(B, Const<M>), E, D, T>) -> Self::Output {
+    type Error = D::Err;
+
+    fn try_forward(&self, x: Tensor<(B, Const<M>), E, D, T>) -> Result<Self::Output, D::Err> {
         let shape = *x.shape();
-        x.normalize::<Axis<1>>(self.epsilon) * self.gamma.retaped::<T>().broadcast_like(&shape)
-            + self.beta.retaped::<T>().broadcast_like(&shape)
+        x.try_normalize::<Axis<1>>(self.epsilon)?.try_mul(self.gamma.retaped::<T>().try_broadcast_like(&shape)?)?
+            .try_add(self.beta.retaped::<T>().try_broadcast_like(&shape)?)
     }
 }
 
@@ -110,10 +114,12 @@ impl<B: Dim, S: Dim, const M: usize, E: Dtype, D: Device<E>, T: Tape<D>>
     Module<Tensor<(B, S, Const<M>), E, D, T>> for LayerNorm1D<M, E, D>
 {
     type Output = Tensor<(B, S, Const<M>), E, D, T>;
-    fn forward(&self, x: Tensor<(B, S, Const<M>), E, D, T>) -> Self::Output {
+    type Error = D::Err;
+
+    fn try_forward(&self, x: Tensor<(B, S, Const<M>), E, D, T>) -> Result<Self::Output, D::Err> {
         let shape = *x.shape();
-        x.normalize::<Axis<2>>(self.epsilon) * self.gamma.retaped::<T>().broadcast_like(&shape)
-            + self.beta.retaped::<T>().broadcast_like(&shape)
+        x.try_normalize::<Axis<2>>(self.epsilon)?.try_mul(self.gamma.retaped::<T>().try_broadcast_like(&shape)?)?
+            .try_add(self.beta.retaped::<T>().try_broadcast_like(&shape)?)
     }
 }
 

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -144,7 +144,10 @@ impl<'a, B: Dim, const M: usize, E: Dtype, D: Device<E>, T: Tape<D>>
     type Error = D::Err;
 
     fn try_forward(&self, input: Tensor<(B, Const<M>), E, D, T>) -> Result<Self::Output, D::Err> {
-        self.beta.retaped::<T>().try_broadcast_like(input.shape())?.try_add(input)
+        self.beta
+            .retaped::<T>()
+            .try_broadcast_like(input.shape())?
+            .try_add(input)
     }
 }
 
@@ -154,8 +157,14 @@ impl<'a, B: Dim, S: Dim, const M: usize, E: Dtype, D: Device<E>, T: Tape<D>>
     type Output = Tensor<(B, S, Const<M>), E, D, T>;
     type Error = D::Err;
 
-    fn try_forward(&self, input: Tensor<(B, S, Const<M>), E, D, T>) -> Result<Self::Output, D::Err> {
-        self.beta.retaped::<T>().try_broadcast_like(input.shape())?.try_add(input)
+    fn try_forward(
+        &self,
+        input: Tensor<(B, S, Const<M>), E, D, T>,
+    ) -> Result<Self::Output, D::Err> {
+        self.beta
+            .retaped::<T>()
+            .try_broadcast_like(input.shape())?
+            .try_add(input)
     }
 }
 

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -107,16 +107,17 @@ impl<const I: usize, const O: usize, E: Dtype, D1: Device<E>, D2: Device<E>> ToD
 
 impl<const I: usize, const O: usize, E: Dtype, D: Device<E>, T> Module<T> for Linear<I, O, E, D>
 where
-    T: SplitTape + TryMatMul<Tensor<Rank2<I, O>, E, D, T::Tape>>,
+    T: SplitTape + TryMatMul<Tensor<Rank2<I, O>, E, D, T::Tape>> + HasErr<Err = D::Err>,
     T::Tape: Tape<D>,
-    for<'a> Bias1D<'a, O, E, D>: Module<T::Output, Output = T::Output>,
+    for<'a> Bias1D<'a, O, E, D>: Module<T::Output, Output = T::Output, Error = D::Err>,
 {
     type Output = T::Output;
+    type Error = D::Err;
 
     /// 1d forward using [matmul()] and [add()].
-    fn forward(&self, x: T) -> Self::Output {
-        let o = x.matmul(self.weight.retaped::<T::Tape>().permute());
-        Bias1D { beta: &self.bias }.forward(o)
+    fn try_forward(&self, x: T) -> Result<Self::Output, D::Err> {
+        let o = x.try_matmul(self.weight.retaped::<T::Tape>().try_permute()?)?;
+        Bias1D { beta: &self.bias }.try_forward(o)
     }
 }
 
@@ -129,8 +130,10 @@ impl<'a, const M: usize, E: Dtype, D: Device<E>, T: Tape<D>> Module<Tensor<Rank1
     for Bias1D<'a, M, E, D>
 {
     type Output = Tensor<Rank1<M>, E, D, T>;
-    fn forward(&self, input: Tensor<Rank1<M>, E, D, T>) -> Self::Output {
-        input + self.beta.clone()
+    type Error = D::Err;
+
+    fn try_forward(&self, input: Tensor<Rank1<M>, E, D, T>) -> Result<Self::Output, D::Err> {
+        input.try_add(self.beta.clone())
     }
 }
 
@@ -138,8 +141,10 @@ impl<'a, B: Dim, const M: usize, E: Dtype, D: Device<E>, T: Tape<D>>
     Module<Tensor<(B, Const<M>), E, D, T>> for Bias1D<'a, M, E, D>
 {
     type Output = Tensor<(B, Const<M>), E, D, T>;
-    fn forward(&self, input: Tensor<(B, Const<M>), E, D, T>) -> Self::Output {
-        self.beta.retaped::<T>().broadcast_like(input.shape()) + input
+    type Error = D::Err;
+
+    fn try_forward(&self, input: Tensor<(B, Const<M>), E, D, T>) -> Result<Self::Output, D::Err> {
+        self.beta.retaped::<T>().try_broadcast_like(input.shape())?.try_add(input)
     }
 }
 
@@ -147,8 +152,10 @@ impl<'a, B: Dim, S: Dim, const M: usize, E: Dtype, D: Device<E>, T: Tape<D>>
     Module<Tensor<(B, S, Const<M>), E, D, T>> for Bias1D<'a, M, E, D>
 {
     type Output = Tensor<(B, S, Const<M>), E, D, T>;
-    fn forward(&self, input: Tensor<(B, S, Const<M>), E, D, T>) -> Self::Output {
-        self.beta.retaped::<T>().broadcast_like(input.shape()) + input
+    type Error = D::Err;
+
+    fn try_forward(&self, input: Tensor<(B, S, Const<M>), E, D, T>) -> Result<Self::Output, D::Err> {
+        self.beta.retaped::<T>().try_broadcast_like(input.shape())?.try_add(input)
     }
 }
 

--- a/src/nn/pool2d.rs
+++ b/src/nn/pool2d.rs
@@ -44,8 +44,10 @@ macro_rules! impl_pools {
             for $PoolTy<K, S, P>
         {
             type Output = Img::Output;
-            fn forward(&self, x: Img) -> Self::Output {
-                x.try_pool2d().unwrap()
+            type Error = Img::Err;
+
+            fn try_forward(&self, x: Img) -> Result<Self::Output, Img::Err> {
+                x.try_pool2d()
             }
         }
     };

--- a/src/nn/pool_global.rs
+++ b/src/nn/pool_global.rs
@@ -65,8 +65,10 @@ macro_rules! impl_pools {
             Module<Tensor<(C, H, W), E, D, T>> for $PoolTy
         {
             type Output = Tensor<(C,), E, D, T>;
-            fn forward(&self, input: Tensor<(C, H, W), E, D, T>) -> Self::Output {
-                input.min()
+            type Error = D::Err;
+
+            fn try_forward(&self, input: Tensor<(C, H, W), E, D, T>) -> Result<Self::Output, D::Err> {
+                input.try_min()
             }
         }
 
@@ -74,13 +76,15 @@ macro_rules! impl_pools {
             Module<Tensor<(B, C, H, W), E, D, T>> for $PoolTy
         {
             type Output = Tensor<(B, C), E, D, T>;
-            fn forward(&self, input: Tensor<(B, C, H, W), E, D, T>) -> Self::Output {
+            type Error = D::Err;
+
+            fn try_forward(&self, input: Tensor<(B, C, H, W), E, D, T>) -> Result<Self::Output, D::Err> {
                 input.$Method()
             }
         }
     };
 }
 
-impl_pools!(AvgPoolGlobal, mean);
-impl_pools!(MaxPoolGlobal, max);
-impl_pools!(MinPoolGlobal, min);
+impl_pools!(AvgPoolGlobal, try_mean);
+impl_pools!(MaxPoolGlobal, try_max);
+impl_pools!(MinPoolGlobal, try_min);

--- a/src/nn/pool_global.rs
+++ b/src/nn/pool_global.rs
@@ -67,7 +67,10 @@ macro_rules! impl_pools {
             type Output = Tensor<(C,), E, D, T>;
             type Error = D::Err;
 
-            fn try_forward(&self, input: Tensor<(C, H, W), E, D, T>) -> Result<Self::Output, D::Err> {
+            fn try_forward(
+                &self,
+                input: Tensor<(C, H, W), E, D, T>,
+            ) -> Result<Self::Output, D::Err> {
                 input.try_min()
             }
         }
@@ -78,7 +81,10 @@ macro_rules! impl_pools {
             type Output = Tensor<(B, C), E, D, T>;
             type Error = D::Err;
 
-            fn try_forward(&self, input: Tensor<(B, C, H, W), E, D, T>) -> Result<Self::Output, D::Err> {
+            fn try_forward(
+                &self,
+                input: Tensor<(B, C, H, W), E, D, T>,
+            ) -> Result<Self::Output, D::Err> {
                 input.$Method()
             }
         }

--- a/src/nn/repeated.rs
+++ b/src/nn/repeated.rs
@@ -76,11 +76,13 @@ impl<T, const N: usize> std::ops::Index<usize> for Repeated<T, N> {
 
 impl<Input, T: Module<Input, Output = Input>, const N: usize> Module<Input> for Repeated<T, N> {
     type Output = T::Output;
-    fn forward(&self, mut x: Input) -> Self::Output {
+    type Error = T::Error;
+
+    fn try_forward(&self, mut x: Input) -> Result<Self::Output, T::Error> {
         for i in 0..N {
-            x = self.modules[i].forward(x);
+            x = self.modules[i].try_forward(x)?;
         }
-        x
+        Ok(x)
     }
 }
 
@@ -88,11 +90,13 @@ impl<Input, T: ModuleMut<Input, Output = Input>, const N: usize> ModuleMut<Input
     for Repeated<T, N>
 {
     type Output = T::Output;
-    fn forward_mut(&mut self, mut x: Input) -> Self::Output {
+    type Error = T::Error;
+
+    fn try_forward_mut(&mut self, mut x: Input) -> Result<Self::Output, T::Error> {
         for i in 0..N {
-            x = self.modules[i].forward_mut(x);
+            x = self.modules[i].try_forward_mut(x)?;
         }
-        x
+        Ok(x)
     }
 }
 

--- a/src/nn/residual.rs
+++ b/src/nn/residual.rs
@@ -53,7 +53,9 @@ impl<T: SplitTape + TryAdd<T>, F: Module<T, Output = T, Error = T::Err>> Module<
     }
 }
 
-impl<T: SplitTape + TryAdd<T>, F: ModuleMut<T, Output = T, Error = T::Err>> ModuleMut<T> for Residual<F> {
+impl<T: SplitTape + TryAdd<T>, F: ModuleMut<T, Output = T, Error = T::Err>> ModuleMut<T>
+    for Residual<F>
+{
     type Output = T;
     type Error = F::Error;
 

--- a/src/nn/transformer/decoder.rs
+++ b/src/nn/transformer/decoder.rs
@@ -5,7 +5,7 @@ use crate::{
     nn::{modules::*, tensor_collection::*, *},
     shapes::Dtype,
     tensor::{PutTape, SplitTape},
-    tensor_ops::Device,
+    tensor_ops::{Device, TryAdd}, prelude::storage_traits::HasErr,
 };
 
 use super::mha::MultiHeadAttention;
@@ -107,26 +107,30 @@ impl<const M: usize, const H: usize, const F: usize, const L: usize, E, D, Tgt, 
 where
     E: Dtype,
     D: Device<E>,
-    TransformerDecoderBlock<M, H, F, E, D>: Module<(Tgt, Mem), Output = Tgt>,
+    TransformerDecoderBlock<M, H, F, E, D>: Module<(Tgt, Mem), Output = Tgt, Error = D::Err>,
 {
     type Output = Tgt;
-    fn forward(&self, (mut tgt, mem): (Tgt, Mem)) -> Self::Output {
+    type Error = D::Err;
+
+    fn try_forward(&self, (mut tgt, mem): (Tgt, Mem)) -> Result<Self::Output, D::Err> {
         for block in self.0.modules.iter() {
-            tgt = block.forward((tgt, mem.clone()));
+            tgt = block.try_forward((tgt, mem.clone()))?;
         }
-        tgt
+        Ok(tgt)
     }
 }
 
 impl<const M: usize, const H: usize, const F: usize, const L: usize, E: Dtype, D: Device<E>, T>
     ModuleMut<T> for TransformerDecoder<M, H, F, L, E, D>
 where
-    Self: Module<T>,
+    Self: Module<T, Error = D::Err>,
 {
     type Output = <Self as Module<T>>::Output;
 
-    fn forward_mut(&mut self, t: T) -> Self::Output {
-        self.forward(t)
+    type Error = D::Err;
+
+    fn try_forward_mut(&mut self, t: T) -> Result<Self::Output, D::Err> {
+        self.try_forward(t)
     }
 }
 
@@ -216,28 +220,29 @@ impl<const M: usize, const H: usize, const F: usize, E: Dtype, D1: Device<E>, D2
 impl<const M: usize, const H: usize, const F: usize, E: Dtype, D: Device<E>, Tgt, Mem>
     Module<(Tgt, Mem)> for TransformerDecoderBlock<M, H, F, E, D>
 where
-    Tgt: SplitTape + std::ops::Add<Tgt::NoTape, Output = Tgt>,
+    Tgt: SplitTape + TryAdd<Tgt::NoTape> + HasErr<Err = D::Err>,
     Mem: Clone,
     MultiHeadAttention<M, H, M, M, E, D>:
-        Module<Tgt, Output = Tgt> + Module<(Tgt, Mem, Mem), Output = Tgt>,
-    LayerNorm1D<M, E, D>: Module<Tgt, Output = Tgt>,
-    FF<M, F, E, D>: Module<Tgt, Output = Tgt>,
+        Module<Tgt, Output = Tgt, Error = D::Err> + Module<(Tgt, Mem, Mem), Output = Tgt, Error = D::Err>,
+    LayerNorm1D<M, E, D>: Module<Tgt, Output = Tgt, Error = D::Err>,
+    FF<M, F, E, D>: Module<Tgt, Output = Tgt, Error = D::Err>,
 {
     type Output = Tgt;
+    type Error = D::Err;
 
-    fn forward(&self, (tgt, mem): (Tgt, Mem)) -> Self::Output {
+    fn try_forward(&self, (tgt, mem): (Tgt, Mem)) -> Result<Self::Output, D::Err> {
         let (tgt, tape) = tgt.split_tape();
-        let x = self.self_attn.forward(tgt.clone().put_tape(tape));
-        let x = x + tgt;
-        let x = self.norm1.forward(x);
+        let x = self.self_attn.try_forward(tgt.clone().put_tape(tape))?;
+        let x = x.try_add(tgt)?;
+        let x = self.norm1.try_forward(x)?;
 
         let (x, tape) = x.split_tape();
         let x_residual = x.clone();
-        let x = self.mh_attn.forward((x.put_tape(tape), mem.clone(), mem));
-        let x = x + x_residual;
-        let x = self.norm2.forward(x);
-        let x = self.ff.forward(x);
-        self.norm3.forward(x)
+        let x = self.mh_attn.try_forward((x.put_tape(tape), mem.clone(), mem))?;
+        let x = x.try_add(x_residual)?;
+        let x = self.norm2.try_forward(x)?;
+        let x = self.ff.try_forward(x)?;
+        self.norm3.try_forward(x)
     }
 }
 

--- a/src/nn/transformer/encoder.rs
+++ b/src/nn/transformer/encoder.rs
@@ -144,31 +144,33 @@ impl<const M: usize, const H: usize, const F: usize, E: Dtype, D: Device<E>, Src
     for TransformerEncoderBlock<M, H, F, E, D>
 where
     Src: SplitTape + std::ops::Add<Src::NoTape, Output = Src>,
-    MultiHeadAttention<M, H, M, M, E, D>: Module<Src, Output = Src>,
-    LayerNorm1D<M, E, D>: Module<Src, Output = Src>,
-    FF<M, F, E, D>: Module<Src, Output = Src>,
+    MultiHeadAttention<M, H, M, M, E, D>: Module<Src, Output = Src, Error = D::Err>,
+    LayerNorm1D<M, E, D>: Module<Src, Output = Src, Error = D::Err>,
+    FF<M, F, E, D>: Module<Src, Output = Src, Error = D::Err>,
 {
     type Output = Src;
+    type Error = D::Err;
 
-    fn forward(&self, src: Src) -> Self::Output {
+    fn try_forward(&self, src: Src) -> Result<Self::Output, D::Err> {
         let (src, tape) = src.split_tape();
-        let x = self.self_attn.forward(src.clone().put_tape(tape));
+        let x = self.self_attn.try_forward(src.clone().put_tape(tape))?;
         let x = x + src;
-        let x = self.norm1.forward(x);
-        let x = self.ff.forward(x);
-        self.norm2.forward(x)
+        let x = self.norm1.try_forward(x)?;
+        let x = self.ff.try_forward(x)?;
+        self.norm2.try_forward(x)
     }
 }
 
 impl<const M: usize, const H: usize, const F: usize, E: Dtype, D: Device<E>, T> ModuleMut<T>
     for TransformerEncoderBlock<M, H, F, E, D>
 where
-    Self: Module<T>,
+    Self: Module<T, Error = D::Err>,
 {
     type Output = <Self as Module<T>>::Output;
+    type Error = D::Err;
 
-    fn forward_mut(&mut self, t: T) -> Self::Output {
-        self.forward(t)
+    fn try_forward_mut(&mut self, t: T) -> Result<Self::Output, D::Err> {
+        self.try_forward(t)
     }
 }
 


### PR DESCRIPTION
Closes #323. I've tried my best to convert every operation in implementations of `try_forward` and `try_forward_mut` to their `try_` counterpart, but it's possible that I have missed some.