### PR TITLE
Making Conv2D unbiased by default, and adding Bias2D module

### DIFF
--- a/src/nn/bias2d.rs
+++ b/src/nn/bias2d.rs
@@ -1,0 +1,103 @@
+use crate::{gradients::Tape, shapes::*, tensor::*, tensor_ops::*};
+
+use super::{tensor_collection::*, BuildModule, BuildOnDevice, Module, NonMutableModule, ToDevice};
+
+pub mod builder {
+    #[derive(Debug)]
+    pub struct Bias2D<const CHAN: usize>;
+}
+
+impl<const C: usize, E: Dtype, D: Device<E>> BuildOnDevice<D, E> for builder::Bias2D<C>
+where
+    Bias2D<C, E, D>: BuildModule<D, E>,
+{
+    type Built = Bias2D<C, E, D>;
+    fn try_build_on_device(device: &D) -> Result<Self::Built, <D>::Err> {
+        Self::Built::try_build(device)
+    }
+}
+
+/// Adds a learnable 1d bias to 3d and 4d inputs. Can be used with [crate::nn::modules::Conv2D]
+/// to create a Biased conv.
+///
+/// Example:
+/// ```rust
+/// # use dfdx::prelude::*;
+/// # let dev: Cpu = Default::default();
+/// const NUM_CHANS: usize = 5;
+/// type Model = Bias2D<NUM_CHANS>;
+/// let model = dev.build_module::<Model, f32>();
+///
+/// // 3d input
+/// let x: Tensor<Rank3<NUM_CHANS, 2, 3>, f32, _> = dev.sample_normal();
+/// model.forward(x);
+///
+/// // 4d input
+/// let x: Tensor<Rank4<10, NUM_CHANS, 2, 3>, f32, _> = dev.sample_normal();
+/// model.forward(x);
+/// ```
+#[derive(Clone, Debug)]
+pub struct Bias2D<const C: usize, E: Dtype, D: DeviceStorage> {
+    pub bias: Tensor<Rank1<C>, E, D>,
+}
+
+impl<const C: usize, E: Dtype, D: Device<E>> BuildModule<D, E> for Bias2D<C, E, D> {
+    fn try_build(device: &D) -> Result<Self, <D>::Err> {
+        Ok(Self {
+            bias: device.try_zeros()?,
+        })
+    }
+}
+
+impl<const C: usize, E: Dtype, D: DeviceStorage> NonMutableModule for Bias2D<C, E, D> {}
+
+impl<const C: usize, E: Dtype, D1: Device<E>, D2: Device<E>> ToDevice<D2> for Bias2D<C, E, D1> {
+    type Output = Bias2D<C, E, D2>;
+
+    fn to_device(&self, device: &D2) -> Self::Output {
+        Bias2D {
+            bias: self.bias.to_device(device),
+        }
+    }
+}
+
+impl<const C: usize, E: Dtype, D: Device<E>> TensorCollection<E, D> for Bias2D<C, E, D> {
+    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(visitor: &mut V) -> Result<(), V::Err> {
+        visitor.visit_tensor(
+            "beta",
+            |s| &s.bias,
+            |s| &mut s.bias,
+            TensorOptions::reset_to_zeros(),
+        )
+    }
+}
+
+impl<const C: usize, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<D>>
+    Module<Tensor<(Const<C>, H, W), E, D, T>> for Bias2D<C, E, D>
+{
+    type Output = Tensor<(Const<C>, H, W), E, D, T>;
+    type Error = D::Err;
+
+    fn try_forward(
+        &self,
+        input: Tensor<(Const<C>, H, W), E, D, T>,
+    ) -> Result<Self::Output, D::Err> {
+        let s = *input.shape();
+        input.try_add(self.bias.retaped::<T>().try_broadcast_like(&s)?)
+    }
+}
+
+impl<B: Dim, const C: usize, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<D>>
+    Module<Tensor<(B, Const<C>, H, W), E, D, T>> for Bias2D<C, E, D>
+{
+    type Output = Tensor<(B, Const<C>, H, W), E, D, T>;
+    type Error = D::Err;
+
+    fn try_forward(
+        &self,
+        input: Tensor<(B, Const<C>, H, W), E, D, T>,
+    ) -> Result<Self::Output, D::Err> {
+        let s = *input.shape();
+        input.try_add(self.bias.retaped::<T>().try_broadcast_like(&s)?)
+    }
+}

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -1,9 +1,9 @@
 use num_traits::Float;
 use rand_distr::uniform::SampleUniform;
 
-use crate::{gradients::Tape, shapes::*, tensor::*, tensor_ops::*};
+use crate::{shapes::*, tensor::*, tensor_ops::*};
 
-use super::{tensor_collection::*, BuildModule, BuildOnDevice, Module, ModuleMut, ToDevice};
+use super::{tensor_collection::*, BuildModule, BuildOnDevice, NonMutableModule, ToDevice};
 
 pub mod builder {
     #[derive(Debug)]
@@ -29,9 +29,14 @@ where
     }
 }
 
-/// **Requires Nightly** Performs 2d convolutions on 3d and 4d images.
+/// **Requires Nightly** Performs *unbiased* 2d convolutions on 3d and 4d images.
 ///
-/// **Pytorch Equivalent**: `torch.nn.Conv2d`
+/// **Pytorch Equivalent**: `torch.nn.Conv2d(..., bias=False)`
+///
+/// To create a biased conv, combine with [crate::nn::modules::Bias2D]:
+/// ```rust
+/// type BiasedConv = (Conv2D<3, 5, 4>, Bias2D<5>);
+/// ```
 ///
 /// Generics:
 /// - `IN_CHAN`: The number of input channels in an image.
@@ -50,7 +55,6 @@ pub struct Conv2D<
     D: DeviceStorage,
 > {
     pub weight: Tensor<Rank4<OUT_CHAN, IN_CHAN, KERNEL_SIZE, KERNEL_SIZE>, E, D>,
-    pub bias: Tensor<Rank1<OUT_CHAN>, E, D>,
 }
 
 impl<const I: usize, const O: usize, const K: usize, const S: usize, const P: usize, E, D>
@@ -64,15 +68,6 @@ where
             "weight",
             |s| &s.weight,
             |s| &mut s.weight,
-            TensorOptions::reset_with(|t| {
-                let b = E::ONE / E::from_usize(I * K * K).unwrap().sqrt();
-                t.try_fill_with_distr(rand_distr::Uniform::new(-b, b))
-            }),
-        )?;
-        visitor.visit_tensor(
-            "bias",
-            |s| &s.bias,
-            |s| &mut s.bias,
             TensorOptions::reset_with(|t| {
                 let b = E::ONE / E::from_usize(I * K * K).unwrap().sqrt();
                 t.try_fill_with_distr(rand_distr::Uniform::new(-b, b))
@@ -92,7 +87,6 @@ where
         let bound = E::ONE / k.sqrt();
         Ok(Self {
             weight: device.try_sample(rand_distr::Uniform::new(-bound, bound))?,
-            bias: device.try_sample(rand_distr::Uniform::new(-bound, bound))?,
         })
     }
 }
@@ -109,87 +103,39 @@ where
     fn to_device(&self, device: &D2) -> Self::Output {
         Conv2D {
             weight: self.weight.to_device(device),
-            bias: self.bias.to_device(device),
         }
     }
 }
 
 #[cfg(feature = "nightly")]
 impl<const C: usize, const O: usize, const K: usize, const S: usize, const P: usize, E, D, Img>
-    Module<Img> for Conv2D<C, O, K, S, P, E, D>
+    super::Module<Img> for Conv2D<C, O, K, S, P, E, D>
 where
     E: Dtype,
     D: Device<E>,
     Img: TryConv2DTo<Tensor<Rank4<O, C, K, K>, E, D>, S, P> + HasErr<Err = D::Err>,
-    for<'a> Bias2D<'a, O, E, D>: Module<Img::Output, Output = Img::Output, Error = D::Err>,
 {
     type Output = Img::Output;
     type Error = D::Err;
 
     fn try_forward(&self, x: Img) -> Result<Self::Output, D::Err> {
-        Bias2D { beta: &self.bias }.try_forward(x.try_conv2d_to(self.weight.clone())?)
+        x.try_conv2d_to(self.weight.clone())
     }
 }
 
-impl<const I: usize, const O: usize, const K: usize, const S: usize, const P: usize, E, D, Img>
-    ModuleMut<Img> for Conv2D<I, O, K, S, P, E, D>
+impl<const I: usize, const O: usize, const K: usize, const S: usize, const P: usize, E, D>
+    NonMutableModule for Conv2D<I, O, K, S, P, E, D>
 where
     E: Dtype,
-    D: Device<E>,
-    Self: Module<Img, Error = D::Err>,
+    D: DeviceStorage,
 {
-    type Output = <Self as Module<Img>>::Output;
-    type Error = D::Err;
-
-    fn try_forward_mut(&mut self, input: Img) -> Result<Self::Output, D::Err> {
-        self.try_forward(input)
-    }
-}
-
-#[derive(Clone, Debug)]
-struct Bias2D<'a, const C: usize, E: Dtype, D: DeviceStorage> {
-    beta: &'a Tensor<Rank1<C>, E, D>,
-}
-
-impl<'a, const C: usize, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<D>>
-    Module<Tensor<(Const<C>, H, W), E, D, T>> for Bias2D<'a, C, E, D>
-{
-    type Output = Tensor<(Const<C>, H, W), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(
-        &self,
-        input: Tensor<(Const<C>, H, W), E, D, T>,
-    ) -> Result<Self::Output, D::Err> {
-        self.beta
-            .retaped::<T>()
-            .try_broadcast_like(input.shape())?
-            .try_add(input)
-    }
-}
-
-impl<'a, B: Dim, const C: usize, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<D>>
-    Module<Tensor<(B, Const<C>, H, W), E, D, T>> for Bias2D<'a, C, E, D>
-{
-    type Output = Tensor<(B, Const<C>, H, W), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(
-        &self,
-        input: Tensor<(B, Const<C>, H, W), E, D, T>,
-    ) -> Result<Self::Output, D::Err> {
-        self.beta
-            .retaped::<T>()
-            .try_broadcast_like(input.shape())?
-            .try_add(input)
-    }
 }
 
 #[cfg(feature = "nightly")]
 #[cfg(test)]
 mod tests {
     use crate::{
-        nn::DeviceBuildExt,
+        nn::{DeviceBuildExt, Module, ModuleMut},
         optim::*,
         tensor::{AsArray, SampleTensor, ZerosTensor},
         tests::*,
@@ -258,18 +204,15 @@ mod tests {
         let mut m = dev.build_module::<Conv2D<2, 4, 3>, TestDtype>();
 
         let weight_init = m.weight.clone();
-        let bias_init = m.bias.clone();
 
         let mut opt = Sgd::new(&m, Default::default());
-        let out = m.forward(dev.sample_normal::<Rank4<8, 2, 28, 28>>().trace());
+        let out = m.forward(dev.sample_normal::<Rank4<8, 2, 28, 28>>().traced());
         let g = out.square().mean().backward();
 
         assert_ne!(g.get(&m.weight).array(), [[[[0.0; 3]; 3]; 2]; 4]);
-        assert_ne!(g.get(&m.bias).array(), [0.0; 4]);
 
         opt.update(&mut m, g).expect("unused params");
 
         assert_ne!(weight_init.array(), m.weight.array());
-        assert_ne!(bias_init.array(), m.bias.array());
     }
 }

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -34,7 +34,8 @@ where
 /// **Pytorch Equivalent**: `torch.nn.Conv2d(..., bias=False)`
 ///
 /// To create a biased conv, combine with [crate::nn::modules::Bias2D]:
-/// ```rust
+/// ```ignore
+/// # use dfdx::prelude::*;
 /// type BiasedConv = (Conv2D<3, 5, 4>, Bias2D<5>);
 /// ```
 ///

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -111,6 +111,7 @@ pub mod tensor_collection;
 mod activations;
 mod add_into;
 mod batchnorm2d;
+mod bias2d;
 mod conv;
 mod dropout;
 mod embedding;
@@ -143,6 +144,7 @@ pub mod modules {
     pub use super::activations::*;
     pub use super::add_into::AddInto;
     pub use super::batchnorm2d::BatchNorm2D;
+    pub use super::bias2d::Bias2D;
     #[cfg(feature = "nightly")]
     pub use super::conv::Conv2D;
     pub use super::dropout::{Dropout, DropoutOneIn};
@@ -168,6 +170,7 @@ pub mod builders {
     pub use super::activations::*;
     pub use super::add_into::AddInto;
     pub use super::batchnorm2d::builder::BatchNorm2D;
+    pub use super::bias2d::builder::Bias2D;
     #[cfg(feature = "nightly")]
     pub use super::conv::builder::Conv2D;
     pub use super::dropout::{Dropout, DropoutOneIn};


### PR DESCRIPTION
Resolves #100 

Motivation: For most vision based networks these days, convolution layers are followed by batchnorm2d. Best practice is to always set `bias=False` in pytorch conv layers, since batchnorm2d will effectively nullify the bias with the normalization and also contains a bias of its own.

This PR removes bias from Conv2D, meaning dfdx is moving to you have to explicitly specify that its a biased conv by adding a `Bias2D` layer following:

```rust
type BiasedConv = (Conv2D<3, 5, 3>, Bias2D<5>);
```

Another change introduced because of this is that biases are now initialized to zero always, instead of the random uniform they were before. This is what tensorflow does with biases, so its still a standard initialization