### PR TITLE
Making K dimension of matmul dynamic.

### DIFF
--- a/src/tensor_ops/matmul/cpu_kernel.rs
+++ b/src/tensor_ops/matmul/cpu_kernel.rs
@@ -170,6 +170,11 @@ where
         rhs: &Self::Storage<(K, N), F>,
     ) -> Result<Self::Storage<(M, N), F>, Self::Err> {
         let mut out = StridedArray::new((lhs.shape.0, rhs.shape.1))?;
+        let k = lhs.shape().1;
+        let k2 = rhs.shape().0;
+        if k != k2 {
+            return Err(CpuError::WrongNumElements);
+        }
         Self::matmul(lhs.view(), rhs.view(), &mut out.view_mut());
         Ok(out)
     }
@@ -197,8 +202,11 @@ where
         lhs: &Self::Storage<(B, M, K), F>,
         rhs: &Self::Storage<(K, N), F>,
     ) -> Result<Self::Storage<(B, M, N), F>, Self::Err> {
-        let (batch, seq, _) = *lhs.shape();
-        let (_, n) = *rhs.shape();
+        let (batch, seq, k) = *lhs.shape();
+        let (k2, n) = *rhs.shape();
+        if k != k2 {
+            return Err(CpuError::WrongNumElements);
+        }
         let mut out = StridedArray::new((batch, seq, n))?;
         let a = lhs.view();
         let b = rhs.view();
@@ -290,6 +298,11 @@ where
     ) -> Result<Self::Storage<(Const<B>, Const<S>, M, N), F>, Self::Err> {
         let m: M = lhs.shape.2;
         let n: N = rhs.shape.3;
+        let k = lhs.shape().3;
+        let k2 = rhs.shape().2;
+        if k != k2 {
+            return Err(CpuError::WrongNumElements);
+        }
         let mut out = StridedArray::new((Const, Const, m, n))?;
         let lhs = lhs.view();
         let rhs = rhs.view();

--- a/src/tensor_ops/matmul/cpu_kernel.rs
+++ b/src/tensor_ops/matmul/cpu_kernel.rs
@@ -136,21 +136,21 @@ impl<F: Dtype> super::VecMatKernel<F> for Cpu
 where
     Self: MatMulImpl<F>,
 {
-    fn forward<const K: usize, N: Dim>(
+    fn forward<K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(Const<K>,), F>,
-        rhs: &Self::Storage<(Const<K>, N), F>,
+        lhs: &Self::Storage<(K,), F>,
+        rhs: &Self::Storage<(K, N), F>,
     ) -> Result<Self::Storage<(N,), F>, Self::Err> {
         let mut out = StridedArray::new((rhs.shape.1,))?;
         Self::matmul(lhs.view().br0(), rhs.view(), &mut out.view_mut().br0());
         Ok(out)
     }
-    fn backward<const K: usize, N: Dim>(
+    fn backward<K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(Const<K>,), F>,
-        grad_lhs: &mut Self::Storage<(Const<K>,), F>,
-        rhs: &Self::Storage<(Const<K>, N), F>,
-        grad_rhs: &mut Self::Storage<(Const<K>, N), F>,
+        lhs: &Self::Storage<(K,), F>,
+        grad_lhs: &mut Self::Storage<(K,), F>,
+        rhs: &Self::Storage<(K, N), F>,
+        grad_rhs: &mut Self::Storage<(K, N), F>,
         grad_out: &Self::Storage<(N,), F>,
     ) -> Result<(), Self::Err> {
         let grad_out = grad_out.view().br0();
@@ -164,21 +164,21 @@ impl<F: Dtype> super::MatMatKernel<F> for Cpu
 where
     Self: MatMulImpl<F>,
 {
-    fn forward<M: Dim, const K: usize, N: Dim>(
+    fn forward<M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(M, Const<K>), F>,
-        rhs: &Self::Storage<(Const<K>, N), F>,
+        lhs: &Self::Storage<(M, K), F>,
+        rhs: &Self::Storage<(K, N), F>,
     ) -> Result<Self::Storage<(M, N), F>, Self::Err> {
         let mut out = StridedArray::new((lhs.shape.0, rhs.shape.1))?;
         Self::matmul(lhs.view(), rhs.view(), &mut out.view_mut());
         Ok(out)
     }
-    fn backward<M: Dim, const K: usize, N: Dim>(
+    fn backward<M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(M, Const<K>), F>,
-        grad_lhs: &mut Self::Storage<(M, Const<K>), F>,
-        rhs: &Self::Storage<(Const<K>, N), F>,
-        grad_rhs: &mut Self::Storage<(Const<K>, N), F>,
+        lhs: &Self::Storage<(M, K), F>,
+        grad_lhs: &mut Self::Storage<(M, K), F>,
+        rhs: &Self::Storage<(K, N), F>,
+        grad_rhs: &mut Self::Storage<(K, N), F>,
         grad_out: &Self::Storage<(M, N), F>,
     ) -> Result<(), Self::Err> {
         let grad_out = grad_out.view();
@@ -192,10 +192,10 @@ impl<F: Dtype> super::MatMatBrKernel<F> for Cpu
 where
     Self: MatMulImpl<F>,
 {
-    fn forward<B: Dim, M: Dim, const K: usize, N: Dim>(
+    fn forward<B: Dim, M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(B, M, Const<K>), F>,
-        rhs: &Self::Storage<(Const<K>, N), F>,
+        lhs: &Self::Storage<(B, M, K), F>,
+        rhs: &Self::Storage<(K, N), F>,
     ) -> Result<Self::Storage<(B, M, N), F>, Self::Err> {
         let (batch, seq, _) = *lhs.shape();
         let (_, n) = *rhs.shape();
@@ -208,12 +208,12 @@ where
         }
         Ok(out)
     }
-    fn backward<B: Dim, M: Dim, const K: usize, N: Dim>(
+    fn backward<B: Dim, M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(B, M, Const<K>), F>,
-        grad_lhs: &mut Self::Storage<(B, M, Const<K>), F>,
-        rhs: &Self::Storage<(Const<K>, N), F>,
-        grad_rhs: &mut Self::Storage<(Const<K>, N), F>,
+        lhs: &Self::Storage<(B, M, K), F>,
+        grad_lhs: &mut Self::Storage<(B, M, K), F>,
+        rhs: &Self::Storage<(K, N), F>,
+        grad_rhs: &mut Self::Storage<(K, N), F>,
         grad_out: &Self::Storage<(B, M, N), F>,
     ) -> Result<(), Self::Err> {
         let batch_size = lhs.shape().0.size();
@@ -283,10 +283,10 @@ impl<F: Dtype> super::MatMatBatch4Kernel<F> for Cpu
 where
     Self: MatMulImpl<F>,
 {
-    fn forward<const B: usize, const S: usize, M: Dim, const K: usize, N: Dim>(
+    fn forward<const B: usize, const S: usize, M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(Const<B>, Const<S>, M, Const<K>), F>,
-        rhs: &Self::Storage<(Const<B>, Const<S>, Const<K>, N), F>,
+        lhs: &Self::Storage<(Const<B>, Const<S>, M, K), F>,
+        rhs: &Self::Storage<(Const<B>, Const<S>, K, N), F>,
     ) -> Result<Self::Storage<(Const<B>, Const<S>, M, N), F>, Self::Err> {
         let m: M = lhs.shape.2;
         let n: N = rhs.shape.3;
@@ -304,12 +304,12 @@ where
         }
         Ok(out)
     }
-    fn backward<const B: usize, const S: usize, M: Dim, const K: usize, N: Dim>(
+    fn backward<const B: usize, const S: usize, M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(Const<B>, Const<S>, M, Const<K>), F>,
-        grad_lhs: &mut Self::Storage<(Const<B>, Const<S>, M, Const<K>), F>,
-        rhs: &Self::Storage<(Const<B>, Const<S>, Const<K>, N), F>,
-        grad_rhs: &mut Self::Storage<(Const<B>, Const<S>, Const<K>, N), F>,
+        lhs: &Self::Storage<(Const<B>, Const<S>, M, K), F>,
+        grad_lhs: &mut Self::Storage<(Const<B>, Const<S>, M, K), F>,
+        rhs: &Self::Storage<(Const<B>, Const<S>, K, N), F>,
+        grad_rhs: &mut Self::Storage<(Const<B>, Const<S>, K, N), F>,
         grad_out: &Self::Storage<(Const<B>, Const<S>, M, N), F>,
     ) -> Result<(), Self::Err> {
         let lhs = lhs.view();

--- a/src/tensor_ops/matmul/cuda_kernel.rs
+++ b/src/tensor_ops/matmul/cuda_kernel.rs
@@ -326,8 +326,11 @@ where
         lhs: &Self::Storage<(M, K), E>,
         rhs: &Self::Storage<(K, N), E>,
     ) -> Result<Self::Storage<(M, N), E>, Self::Err> {
-        let (m, _) = lhs.shape;
-        let (k, n) = rhs.shape;
+        let (m, k) = lhs.shape;
+        let (k2, n) = rhs.shape;
+        if k != k2 {
+            return Err(CudaError::Cpu(CpuError::WrongNumElements));
+        }
         let shape = (m, n);
         let strides = shape.strides();
         let mut storage = unsafe { self.dev.alloc_async::<E>(shape.num_elements()) }?;
@@ -361,8 +364,11 @@ where
         grad_rhs: &mut Self::Storage<(K, N), E>,
         grad_out: &Self::Storage<(M, N), E>,
     ) -> Result<(), Self::Err> {
-        let (m, _) = lhs.shape;
-        let (k, n) = rhs.shape;
+        let (m, k) = lhs.shape;
+        let (k2, n) = rhs.shape;
+        if k != k2 {
+            return Err(CudaError::Cpu(CpuError::WrongNumElements));
+        }
         unsafe {
             // grad_lhs += grad_out * rhs^T
             sgemm(
@@ -403,8 +409,11 @@ where
         lhs: &Self::Storage<(B, M, K), E>,
         rhs: &Self::Storage<(K, N), E>,
     ) -> Result<Self::Storage<(B, M, N), E>, Self::Err> {
-        let (batch, m, _) = lhs.shape;
-        let (k, n) = rhs.shape;
+        let (batch, m, k) = lhs.shape;
+        let (k2, n) = rhs.shape;
+        if k != k2 {
+            return Err(CudaError::Cpu(CpuError::WrongNumElements));
+        }
         let shape = (batch, m, n);
         let strides = shape.strides();
         let mut storage = unsafe { self.dev.alloc_async::<E>(shape.num_elements()) }?;
@@ -437,8 +446,11 @@ where
         grad_out: &Self::Storage<(B, M, N), E>,
     ) -> Result<(), Self::Err> {
         assert_ne!(grad_lhs.strides[0], 0);
-        let (batch, m, _) = lhs.shape;
-        let (k, n) = rhs.shape;
+        let (batch, m, k) = lhs.shape;
+        let (k2, n) = rhs.shape;
+        if k != k2 {
+            return Err(CudaError::Cpu(CpuError::WrongNumElements));
+        }
         unsafe {
             // grad_lhs += grad_out * rhs^T
             sgemm_batch(
@@ -565,8 +577,11 @@ where
         lhs: &Self::Storage<(Const<B>, Const<S>, M, K), E>,
         rhs: &Self::Storage<(Const<B>, Const<S>, K, N), E>,
     ) -> Result<Self::Storage<(Const<B>, Const<S>, M, N), E>, Self::Err> {
-        let (batch, seq, m, _) = lhs.shape;
-        let (_, _, k, n) = rhs.shape;
+        let (batch, seq, m, k) = lhs.shape;
+        let (_, _, k2, n) = rhs.shape;
+        if k != k2 {
+            return Err(CudaError::Cpu(CpuError::WrongNumElements));
+        }
         let shape = (batch, seq, m, n);
         let strides = shape.strides();
         let mut storage = unsafe { self.dev.alloc_async::<E>(shape.num_elements()) }?;
@@ -607,8 +622,11 @@ where
         assert_ne!(gl.strides[1], 0);
         assert_ne!(gr.strides[1], 0);
 
-        let (batch, seq, m, _) = lhs.shape;
-        let (_, _, k, n) = rhs.shape;
+        let (batch, seq, m, k) = lhs.shape;
+        let (_, _, k2, n) = rhs.shape;
+        if k != k2 {
+            return Err(CudaError::Cpu(CpuError::WrongNumElements));
+        }
         // TODO use streams
         let gl_buf = Arc::make_mut(&mut gl.data);
         let gr_buf = Arc::make_mut(&mut gr.data);

--- a/src/tensor_ops/matmul/cuda_kernel.rs
+++ b/src/tensor_ops/matmul/cuda_kernel.rs
@@ -245,10 +245,10 @@ impl<E: Dtype> super::VecMatKernel<E> for Cuda
 where
     CudaBlas: Gemm<E>,
 {
-    fn forward<const K: usize, N: Dim>(
+    fn forward<K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(Const<K>,), E>,
-        rhs: &Self::Storage<(Const<K>, N), E>,
+        lhs: &Self::Storage<(K,), E>,
+        rhs: &Self::Storage<(K, N), E>,
     ) -> Result<Self::Storage<(N,), E>, Self::Err> {
         let m = Const::<1>;
         let (k, n) = rhs.shape;
@@ -276,12 +276,12 @@ where
             strides: shape.strides(),
         })
     }
-    fn backward<const K: usize, N: Dim>(
+    fn backward<K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(Const<K>,), E>,
-        grad_lhs: &mut Self::Storage<(Const<K>,), E>,
-        rhs: &Self::Storage<(Const<K>, N), E>,
-        grad_rhs: &mut Self::Storage<(Const<K>, N), E>,
+        lhs: &Self::Storage<(K,), E>,
+        grad_lhs: &mut Self::Storage<(K,), E>,
+        rhs: &Self::Storage<(K, N), E>,
+        grad_rhs: &mut Self::Storage<(K, N), E>,
         grad_out: &Self::Storage<(N,), E>,
     ) -> Result<(), Self::Err> {
         let m = Const::<1>;
@@ -321,10 +321,10 @@ impl<E: Dtype> super::MatMatKernel<E> for Cuda
 where
     CudaBlas: Gemm<E>,
 {
-    fn forward<M: Dim, const K: usize, N: Dim>(
+    fn forward<M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(M, Const<K>), E>,
-        rhs: &Self::Storage<(Const<K>, N), E>,
+        lhs: &Self::Storage<(M, K), E>,
+        rhs: &Self::Storage<(K, N), E>,
     ) -> Result<Self::Storage<(M, N), E>, Self::Err> {
         let (m, _) = lhs.shape;
         let (k, n) = rhs.shape;
@@ -353,12 +353,12 @@ where
         })
     }
 
-    fn backward<M: Dim, const K: usize, N: Dim>(
+    fn backward<M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(M, Const<K>), E>,
-        grad_lhs: &mut Self::Storage<(M, Const<K>), E>,
-        rhs: &Self::Storage<(Const<K>, N), E>,
-        grad_rhs: &mut Self::Storage<(Const<K>, N), E>,
+        lhs: &Self::Storage<(M, K), E>,
+        grad_lhs: &mut Self::Storage<(M, K), E>,
+        rhs: &Self::Storage<(K, N), E>,
+        grad_rhs: &mut Self::Storage<(K, N), E>,
         grad_out: &Self::Storage<(M, N), E>,
     ) -> Result<(), Self::Err> {
         let (m, _) = lhs.shape;
@@ -398,10 +398,10 @@ impl<E: Dtype> super::MatMatBrKernel<E> for Cuda
 where
     CudaBlas: Gemm<E>,
 {
-    fn forward<B: Dim, M: Dim, const K: usize, N: Dim>(
+    fn forward<B: Dim, M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(B, M, Const<K>), E>,
-        rhs: &Self::Storage<(Const<K>, N), E>,
+        lhs: &Self::Storage<(B, M, K), E>,
+        rhs: &Self::Storage<(K, N), E>,
     ) -> Result<Self::Storage<(B, M, N), E>, Self::Err> {
         let (batch, m, _) = lhs.shape;
         let (k, n) = rhs.shape;
@@ -428,12 +428,12 @@ where
             strides,
         })
     }
-    fn backward<B: Dim, M: Dim, const K: usize, N: Dim>(
+    fn backward<B: Dim, M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(B, M, Const<K>), E>,
-        grad_lhs: &mut Self::Storage<(B, M, Const<K>), E>,
-        rhs: &Self::Storage<(Const<K>, N), E>,
-        grad_rhs: &mut Self::Storage<(Const<K>, N), E>,
+        lhs: &Self::Storage<(B, M, K), E>,
+        grad_lhs: &mut Self::Storage<(B, M, K), E>,
+        rhs: &Self::Storage<(K, N), E>,
+        grad_rhs: &mut Self::Storage<(K, N), E>,
         grad_out: &Self::Storage<(B, M, N), E>,
     ) -> Result<(), Self::Err> {
         assert_ne!(grad_lhs.strides[0], 0);
@@ -560,10 +560,10 @@ impl<E: Dtype> super::MatMatBatch4Kernel<E> for Cuda
 where
     CudaBlas: Gemm<E>,
 {
-    fn forward<const B: usize, const S: usize, M: Dim, const K: usize, N: Dim>(
+    fn forward<const B: usize, const S: usize, M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(Const<B>, Const<S>, M, Const<K>), E>,
-        rhs: &Self::Storage<(Const<B>, Const<S>, Const<K>, N), E>,
+        lhs: &Self::Storage<(Const<B>, Const<S>, M, K), E>,
+        rhs: &Self::Storage<(Const<B>, Const<S>, K, N), E>,
     ) -> Result<Self::Storage<(Const<B>, Const<S>, M, N), E>, Self::Err> {
         let (batch, seq, m, _) = lhs.shape;
         let (_, _, k, n) = rhs.shape;
@@ -594,12 +594,12 @@ where
         })
     }
 
-    fn backward<const B: usize, const S: usize, M: Dim, const K: usize, N: Dim>(
+    fn backward<const B: usize, const S: usize, M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(Const<B>, Const<S>, M, Const<K>), E>,
-        gl: &mut Self::Storage<(Const<B>, Const<S>, M, Const<K>), E>,
-        rhs: &Self::Storage<(Const<B>, Const<S>, Const<K>, N), E>,
-        gr: &mut Self::Storage<(Const<B>, Const<S>, Const<K>, N), E>,
+        lhs: &Self::Storage<(Const<B>, Const<S>, M, K), E>,
+        gl: &mut Self::Storage<(Const<B>, Const<S>, M, K), E>,
+        rhs: &Self::Storage<(Const<B>, Const<S>, K, N), E>,
+        gr: &mut Self::Storage<(Const<B>, Const<S>, K, N), E>,
         go: &Self::Storage<(Const<B>, Const<S>, M, N), E>,
     ) -> Result<(), Self::Err> {
         assert_ne!(gl.strides[0], 0);

--- a/src/tensor_ops/matmul/mod.rs
+++ b/src/tensor_ops/matmul/mod.rs
@@ -217,34 +217,31 @@ where
 }
 
 pub trait MatMatBatch3Kernel<E: Dtype>: DeviceStorage {
-    fn forward<const B: usize, M: Dim, const K: usize, N: Dim>(
+    fn forward<const B: usize, M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(Const<B>, M, Const<K>), E>,
-        rhs: &Self::Storage<(Const<B>, Const<K>, N), E>,
+        lhs: &Self::Storage<(Const<B>, M, K), E>,
+        rhs: &Self::Storage<(Const<B>, K, N), E>,
     ) -> Result<Self::Storage<(Const<B>, M, N), E>, Self::Err>;
 
-    fn backward<const B: usize, M: Dim, const K: usize, N: Dim>(
+    fn backward<const B: usize, M: Dim, K: Dim, N: Dim>(
         &self,
-        lhs: &Self::Storage<(Const<B>, M, Const<K>), E>,
-        grad_lhs: &mut Self::Storage<(Const<B>, M, Const<K>), E>,
-        rhs: &Self::Storage<(Const<B>, Const<K>, N), E>,
-        grad_rhs: &mut Self::Storage<(Const<B>, Const<K>, N), E>,
+        lhs: &Self::Storage<(Const<B>, M, K), E>,
+        grad_lhs: &mut Self::Storage<(Const<B>, M, K), E>,
+        rhs: &Self::Storage<(Const<B>, K, N), E>,
+        grad_rhs: &mut Self::Storage<(Const<B>, K, N), E>,
         grad_out: &Self::Storage<(Const<B>, M, N), E>,
     ) -> Result<(), Self::Err>;
 }
 
-impl<const B: usize, M: Dim, const K: usize, N: Dim, E: Dtype, D, T, R>
-    TryMatMul<Tensor<(Const<B>, Const<K>, N), E, D, R>> for Tensor<(Const<B>, M, Const<K>), E, D, T>
+impl<const B: usize, M: Dim, K: Dim, N: Dim, E: Dtype, D, T, R>
+    TryMatMul<Tensor<(Const<B>, K, N), E, D, R>> for Tensor<(Const<B>, M, K), E, D, T>
 where
     D: MatMatBatch3Kernel<E>,
     T: Tape<D> + Merge<R>,
     R: Tape<D>,
 {
     type Output = Tensor<(Const<B>, M, N), E, D, T>;
-    fn try_matmul(
-        self,
-        rhs: Tensor<(Const<B>, Const<K>, N), E, D, R>,
-    ) -> Result<Self::Output, Self::Err> {
+    fn try_matmul(self, rhs: Tensor<(Const<B>, K, N), E, D, R>) -> Result<Self::Output, Self::Err> {
         try_binary_op(self, rhs, D::forward, D::backward)
     }
 }


### PR DESCRIPTION
This one is a bit more controversial I think.

Within `transformers` models, in generative mode (`gpt2`, `chatGPT`,
`whisper` etc..), there is a need for `past_keys_values` which is
a cache for the attention layer, reducing the size of matmuls.

The one matmul where something happens is `matmul(qk, v)`.

Q is of shape (NUM_HEADS, SEQ, HEAD_DIM)
K is of shape (NUM_HEADS, HEAD_DIM, PAST + SEQ)
So

QK is of shape (NUM_HEADS, SEQ, PAST + SEQ)

V is of shape (NUM_HEADS, PAST + SEQ, HEAD_DIM)

Where SEQ is the sequence_length of the input string.
      PAST is the sequence of the cached attention.

Therefore we here have a matrix multiplication where the inner dimension
(denoted K in dfdx traits) is actually dynamic and not compile time static.

This PR only modifies 1 kernel, but probably all kernels should be
modified if that is deemed worthy. But doing so might actually defeat
the purpose of getting compile time static shapes. (Does it though?
there should still be errors at compile time.)

My personal take/understanding, is that it would be OK to implement
everything dynamic for `try_kernel` functions, and keep the `kernel`
only for the ones that cannot fail.
However, there are other issues like striding that could cause fail on
ConstShape kernels too (rendering `kernel` functions potentially
panicking).