### PR TITLE
Some enhancements to saving mechanism

### DIFF
--- a/examples/numpy-save-load.rs
+++ b/examples/numpy-save-load.rs
@@ -5,6 +5,7 @@ fn main() {
     use dfdx::{
         shapes::{Rank0, Rank1, Rank2},
         tensor::{AsArray, Tensor, TensorFrom, ZerosTensor},
+        nn::{SaveToNpz, LoadFromNpz}
     };
 
     #[cfg(not(feature = "cuda"))]
@@ -27,6 +28,10 @@ fn main() {
         .save_to_npy("2d-rs.npy")
         .expect("Saving failed");
 
+    dev.tensor([3.0f32, 2.0, 1.0])
+        .save("1d-rs.npz")
+        .expect("Saving failed");
+
     let mut a: Tensor<Rank0, f32, _> = dev.zeros();
     a.load_from_npy("0d-rs.npy").expect("Loading failed");
     assert_eq!(a.array(), 1.234);
@@ -38,6 +43,10 @@ fn main() {
     let mut c: Tensor<Rank2<2, 3>, f32, _> = dev.zeros();
     c.load_from_npy("2d-rs.npy").expect("Loading failed");
     assert_eq!(c.array(), [[1.0, 2.0, 3.0], [-1.0, -2.0, -3.0]]);
+
+    let mut d: Tensor<Rank1<3>, f32, _> = dev.zeros();
+    d.load("1d-rs.npz").expect("Loading failed");
+    assert_eq!(d.array(), [3.0, 2.0, 1.0]);
 
     println!("Tensors were stored and loaded successfully");
 }

--- a/src/nn/npz.rs
+++ b/src/nn/npz.rs
@@ -317,14 +317,17 @@ mod tests {
         saved.running_var.fill_with_distr(Standard);
         saved.scale.fill_with_distr(Standard);
         saved.bias.fill_with_distr(Standard);
+        saved.epsilon.fill_with_distr(Standard);
         let y = saved.forward(x.clone());
 
         assert_ne!(loaded.forward(x.clone()).array(), y.array());
+        assert_ne!(saved.epsilon.array(), loaded.epsilon.array());
 
         saved.save(file.path()).expect("");
         loaded.load(file.path()).expect("");
 
         assert_eq!(loaded.forward(x).array(), y.array());
+        assert_eq!(saved.epsilon.array(), loaded.epsilon.array());
     }
 
     #[cfg(feature = "nightly")]

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -107,7 +107,7 @@
 //!
 //! See [Tensor::save_to_npy] and [Tensor::load_from_npy].
 //!
-//! You can also use [Tensor::write_to_npz] and [Tensor::read_from_npz] when working with
+//! You can also use [Tensor::write_path] and [Tensor::read_path] when working with
 //! zip archives.
 
 pub(crate) mod cpu;

--- a/src/tensor/numpy.rs
+++ b/src/tensor/numpy.rs
@@ -17,7 +17,7 @@ const VERSION: &[u8] = &[1, 0];
 
 impl<S: Shape, E: Dtype + NumpyDtype, D: DeviceStorage + CopySlice<E>, T> Tensor<S, E, D, T> {
     /// Writes `data` to a new file in a zip archive named `filename`.
-    pub fn write_to_npz<W: Write + Seek>(
+    pub fn write_path<W: Write + Seek>(
         &self,
         w: &mut zip::ZipWriter<W>,
         filename: String,
@@ -28,7 +28,7 @@ impl<S: Shape, E: Dtype + NumpyDtype, D: DeviceStorage + CopySlice<E>, T> Tensor
     }
 
     /// Reads `data` from a file already in a zip archive named `filename`.
-    pub fn read_from_npz<R: Read + Seek>(
+    pub fn read_path<R: Read + Seek>(
         &mut self,
         r: &mut zip::ZipArchive<R>,
         filename: String,
@@ -38,7 +38,7 @@ impl<S: Shape, E: Dtype + NumpyDtype, D: DeviceStorage + CopySlice<E>, T> Tensor
         Ok(())
     }
 
-    /// Attemps to load the data from a `.npy` file at `path`
+    /// Attempts to load the data from a `.npy` file at `path`
     pub fn load_from_npy<P: AsRef<Path>>(&mut self, path: P) -> Result<(), NpyError> {
         let mut f = BufReader::new(File::open(path)?);
         self.read_from(&mut f)


### PR DESCRIPTION
## Content

This PR
- adds the ability to specify base path for `ZipWriter` saving.
- adds a way to exclude tensors in a `TensorCollection` from saving and loading.
- fixes #485 for the named examples by following the described suggestion.