### PR TITLE
[Spring cleaning] Removes GradientTape & impl Clone for Gradients

### DIFF
--- a/src/gradients.rs
+++ b/src/gradients.rs
@@ -11,14 +11,15 @@ use crate::tensor::{
 };
 use crate::unique_id::{unique_id, UniqueId};
 
-/// A generic container for keeping variable sized arrays associated with a [UniqueId].
+/// A generic container for keeping gradients of tensors keyed by the
+/// tensor's [UniqueId].
 ///
 /// You can:
 /// 1. Insert array values into it
 /// 2. Remove entries
 /// 3. Access references to arrays
 /// 4. Access mutable references to arrays
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Gradients<E: Unit, D: DeviceStorage> {
     gradient_by_id: HashMap<UniqueId, D::Vec<E>>,
 }
@@ -148,77 +149,33 @@ impl<E: Unit, D: DeviceStorage> Gradients<E, D> {
     }
 }
 
-/// Records gradient computations to execute later.
-///
-/// The only two things you can do with this are:
-/// 1. Adding an operation (an operation is a FnOnce that acts on &mut [Gradients])
-/// 2. Executing all the operations to produce [Gradients]
-///
-/// The reason for this design, which forces users to specify gradient computations, as opposed to having
-/// a fixed set of *kinds* of computations are these:
-/// 1. Different tensor sizes. The tensors size information would have to be stored inside the operation somehow.
-///     Instead, the operation themselves must query with a sized tensor, so sizes are still known at compile time instead of dynamically.
-/// 2. Slightly different operations. It'd have to support broadcasting operations, etc which can get needlessly complex.
-/// 3. Optimizations are harder. With operations having control over everything, they can be optimized by hand separately.
-///
-/// An example for how these two are used is the following from the negate operation (ie. multiply all values by -1).
-///
-/// ```ignore
-/// tape.add_backward_op(move |grads| {
-///     let (t_grad, result_grad) = grads.mut_and_ref(&t, &_result);
-///     // addmul_assign is equivalent to: t_grad += t.data() * result_grad;
-///     T::Device::addmul(t_grad, t.data(), result_grad);
-/// });
-/// ```
-///
-/// This is implementing the chain rule, which is normally defined as `gradient(t) += deriv * gradient(result)` with
-/// the following optimizations:
-/// 1. instead of allocating new data for the derivative (which is just -1 everywhere), we can reuse the `t` tensor since the negate
-///     function owns it.
-/// 2. We can combine computing the derivative and multiplying by the `gradient(result)` by just setting `t` to `-gradient(result)`
-///
-/// This would not be possible if these chain rule operations were inside of GradientTape!
-pub struct GradientTape<E: Unit, D: DeviceStorage> {
+/// Contains a [Gradients] and list of backward operations.
+pub struct OwnedTape<E: Unit, D: DeviceStorage> {
     /// A list of (Time, BackwardOp) pairs. The Time is used to ensure operations
     /// from merged tapes are executed in the correct order.
     operations: Vec<(UniqueId, BackwardOp<E, D, D::Err>)>,
     gradients: Gradients<E, D>,
 }
 
-type BackwardOp<E, D, Err> = Box<dyn FnOnce(&mut Gradients<E, D>) -> Result<(), Err>>;
-
-impl<E: Unit, D: DeviceStorage> Default for GradientTape<E, D> {
+impl<E: Unit, D: DeviceStorage> Default for OwnedTape<E, D> {
     fn default() -> Self {
         Self {
-            operations: Vec::new(),
+            operations: Default::default(),
             gradients: Default::default(),
         }
     }
 }
 
-impl<E: Unit, D: DeviceStorage> std::fmt::Debug for GradientTape<E, D> {
+impl<E: Unit, D: DeviceStorage> std::fmt::Debug for OwnedTape<E, D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GradientTape")
+        f.debug_struct("OwnedTape")
             .field("num_operations", &self.operations.len())
+            .field("gradients", &self.gradients)
             .finish()
     }
 }
 
-impl<E: Unit, D: DeviceStorage> GradientTape<E, D> {
-    /// Add an operation to be executed later. Implementation is all left to the caller,
-    /// but the operation should likely call [Gradients::ref_gradient] and [Gradients::mut_gradient].
-    ///
-    /// # Arguments
-    /// * `operation` - A FnOnce that acts on [Gradients].
-    ///
-    /// See src/tensor_ops for implementation examples.
-    pub(crate) fn add_backward_op<F>(&mut self, operation: F)
-    where
-        F: 'static + FnOnce(&mut Gradients<E, D>) -> Result<(), D::Err>,
-    {
-        self.operations.push((unique_id(), Box::new(operation)));
-    }
-
+impl<E: Unit, D: DeviceStorage> OwnedTape<E, D> {
     /// Compute the [Gradients]! This just runs all the operations on a new [Gradients] struct.
     ///
     /// Note that this method takes ownership of self, so it can't be called twice!
@@ -232,20 +189,9 @@ impl<E: Unit, D: DeviceStorage> GradientTape<E, D> {
         }
         Ok(self.gradients)
     }
-
-    /// Moves all the operations from `other` into self. Leaves `other` empty.
-    pub(crate) fn append(&mut self, other: &mut Self) {
-        self.gradients
-            .gradient_by_id
-            .extend(other.gradients.gradient_by_id.drain());
-        self.operations.append(&mut other.operations);
-    }
 }
 
-/// Contains a boxed [GradientTape]. When [Tape::add_backward_op] is called,
-/// this function passes the operation directly to [GradientTape].
-#[derive(Debug, Default)]
-pub struct OwnedTape<E: Unit, D: DeviceStorage>(pub(crate) Box<GradientTape<E, D>>);
+type BackwardOp<E, D, Err> = Box<dyn FnOnce(&mut Gradients<E, D>) -> Result<(), Err>>;
 
 /// Contains nothing. When [Tape::add_backward_op] is called, this struct does nothing.
 #[derive(Default, Debug, Clone, Copy)]
@@ -267,10 +213,10 @@ impl<E: Unit, D: DeviceStorage> Tape<E, D> for OwnedTape<E, D> {
     where
         F: 'static + FnOnce(&mut Gradients<E, D>) -> Result<(), D::Err>,
     {
-        self.0.add_backward_op(operation)
+        self.operations.push((unique_id(), Box::new(operation)));
     }
     fn try_alloc_grad<S: Shape>(&mut self, t: &Tensor<S, E, D>) -> Result<(), D::Err> {
-        self.0.gradients.try_alloc_for(t)
+        self.gradients.try_alloc_for(t)
     }
 }
 
@@ -306,7 +252,10 @@ impl<E: Unit, D: DeviceStorage> Merge<NoneTape> for OwnedTape<E, D> {
 
 impl<E: Unit, D: DeviceStorage> Merge<OwnedTape<E, D>> for OwnedTape<E, D> {
     fn merge(mut self, mut other: Self) -> Self {
-        self.0.append(other.0.as_mut());
+        self.gradients
+            .gradient_by_id
+            .extend(other.gradients.gradient_by_id.drain());
+        self.operations.append(&mut other.operations);
         self
     }
 }

--- a/src/tensor/storage_traits.rs
+++ b/src/tensor/storage_traits.rs
@@ -17,7 +17,7 @@ pub trait AsVec<E> {
 }
 
 /// Something that can store nd arrays for a given [Shape] and [Dtype]
-pub trait DeviceStorage: 'static + Default + Clone + HasErr {
+pub trait DeviceStorage: 'static + std::fmt::Debug + Default + Clone + HasErr {
     /// Generic storage type
     type Vec<E: Unit>: 'static + std::fmt::Debug + Clone + Send + Sync;
 

--- a/src/tensor_ops/utilities/backward.rs
+++ b/src/tensor_ops/utilities/backward.rs
@@ -18,6 +18,6 @@ impl<E: Dtype, D: OneFillStorage<E>> Backward<E, D> for Tensor<Rank0, E, D, Owne
     fn try_backward(self) -> Result<Gradients<E, D>, Self::Err> {
         let (t, mut tape) = self.split_tape();
         tape.add_backward_op(move |grads| t.device.try_fill_with_ones(grads.get_mut(&t)));
-        tape.0.execute()
+        tape.execute()
     }
 }


### PR DESCRIPTION
Moves GradientTape fields directly into OwnedTape, instead of having OwnedTape hold a GradientTape