### PR TITLE
Adding `no-std` feature flag, matrixmultiply/threading behind feature flag. numpy no longer default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ keywords = [
 features = ["nightly", "numpy"]
 
 [dependencies]
+no-std-compat = { version = "0.4.1", default-features = false, features = [ "alloc", "compat_hash" ], optional = true }
 rand = { version = "0.8.5", default-features = false, features = ["std_rng"] }
 rand_distr = { version = "0.4.3", default-features = false, features = ["std_math"] }
 matrixmultiply = { version = "0.3.2", default-features = false }
@@ -43,6 +44,7 @@ glob = { version = "0.3.1", optional = true }
 
 [features]
 default = ["std", "fast-alloc"]
+no-std = ["no-std-compat"]
 std = ["cudarc?/std"]
 threaded-cpu = ["std", "matrixmultiply/threading"]
 fast-alloc = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ keywords = [
 features = ["nightly", "numpy"]
 
 [dependencies]
-no-std-compat = { version = "0.4.1", default-features = false, features = [ "alloc", "compat_hash" ] }
 rand = { version = "0.8.5", default-features = false, features = ["std_rng"] }
 rand_distr = { version = "0.4.3", default-features = false, features = ["std_math"] }
 matrixmultiply = { version = "0.3.2", default-features = false }
@@ -34,28 +33,27 @@ libc = { version = "0.2", default-features = false, optional = true }
 cudarc = { version = "0.8.0", default-features = false, optional = true }
 num-traits = { version = "0.2.15", default-features = false }
 
+[dev-dependencies]
+tempfile = "3.3.0"
+mnist = "0.5.0"
+indicatif = "0.17.3"
+
+[build-dependencies]
+glob = { version = "0.3.1", optional = true }
+
 [features]
-default = ["std", "numpy", "fast_alloc"]
-std = ["no-std-compat/std", "rand/std", "rand_distr/std", "cudarc?/std", "matrixmultiply/threading"]
-fast_alloc = ["std"]
+default = ["std", "fast-alloc"]
+std = ["cudarc?/std"]
+threaded-cpu = ["std", "matrixmultiply/threading"]
+fast-alloc = ["std"]
 nightly = []
 numpy = ["dep:zip", "std"]
 cblas = ["dep:cblas-sys", "dep:libc"]
 intel-mkl = ["cblas"]
-cuda = ["dep:cudarc"]
+cuda = ["dep:cudarc", "dep:glob"]
 test-cuda = ["cuda"]
 test-f64 = []
 ci-check = ["cudarc?/ci-check"]
-
-[dev-dependencies]
-rand = "0.8.5"
-tempfile = "3.3.0"
-mnist = "0.5.0"
-indicatif = "0.16.2"
-
-[build-dependencies]
-rustc_version = "0.4.0"
-glob = "0.3.0"
 
 [[bench]]
 name = "batchnorm2d"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,17 @@
 //! opt.update(&mut model, &gradients);
 //! ```
 
+#![cfg_attr(feature = "no-std", no_std)]
 #![allow(incomplete_features)]
 #![cfg_attr(feature = "nightly", feature(generic_const_exprs))]
+
+#[cfg(feature = "no-std")]
+extern crate alloc;
+#[cfg(feature = "no-std")]
+extern crate no_std_compat as std;
+
+#[cfg(all(feature = "std", feature = "no-std"))]
+compile_error!("Can't enable both std and no-std. Set default-features = false to disable std");
 
 pub mod data;
 pub mod feature_flags;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,12 +97,8 @@
 //! opt.update(&mut model, &gradients);
 //! ```
 
-#![no_std]
 #![allow(incomplete_features)]
 #![cfg_attr(feature = "nightly", feature(generic_const_exprs))]
-
-extern crate alloc;
-extern crate no_std_compat as std;
 
 pub mod data;
 pub mod feature_flags;

--- a/src/optim/adam/mod.rs
+++ b/src/optim/adam/mod.rs
@@ -115,7 +115,7 @@ impl<M, D: AdamKernel<E>, E: Dtype> TensorVisitor<E, D>
 
     fn visit<S: Shape>(
         &mut self,
-        _: alloc::string::String,
+        _: std::string::String,
         opts: TensorOptions<S, E, D>,
         p: &mut crate::prelude::Tensor<S, E, D>,
     ) -> Result<(), <D>::Err> {

--- a/src/optim/rmsprop/mod.rs
+++ b/src/optim/rmsprop/mod.rs
@@ -124,7 +124,7 @@ impl<M, E: Dtype, D: RMSpropKernel<E> + OneFillStorage<E>> TensorVisitor<E, D>
 
     fn visit<S: Shape>(
         &mut self,
-        _: alloc::string::String,
+        _: std::string::String,
         opts: TensorOptions<S, E, D>,
         p: &mut Tensor<S, E, D>,
     ) -> Result<(), <D>::Err> {

--- a/src/optim/sgd/mod.rs
+++ b/src/optim/sgd/mod.rs
@@ -150,7 +150,7 @@ impl<E: Dtype, D: SgdKernel<E>, M> TensorVisitor<E, D>
 
     fn visit<S: Shape>(
         &mut self,
-        _: alloc::string::String,
+        _: std::string::String,
         opts: TensorOptions<S, E, D>,
         p: &mut Tensor<S, E, D>,
     ) -> Result<(), D::Err> {

--- a/src/tensor/cpu/allocate.rs
+++ b/src/tensor/cpu/allocate.rs
@@ -23,12 +23,12 @@ impl Cpu {
         numel: usize,
         elem: E,
     ) -> Result<Vec<E>, CpuError> {
-        #[cfg(feature = "fast_alloc")]
+        #[cfg(feature = "fast-alloc")]
         {
             Ok(std::vec![elem; numel])
         }
 
-        #[cfg(not(feature = "fast_alloc"))]
+        #[cfg(not(feature = "fast-alloc"))]
         {
             let mut data: Vec<E> = Vec::new();
             data.try_reserve(numel).map_err(|_| CpuError::OutOfMemory)?;

--- a/src/tensor_ops/matmul/cpu_kernel.rs
+++ b/src/tensor_ops/matmul/cpu_kernel.rs
@@ -1,9 +1,9 @@
 use crate::shapes::*;
 use crate::tensor::{Cpu, Tensor, ZerosTensor};
 
-use alloc::sync::Arc;
 #[cfg(not(feature = "cblas"))]
 use matrixmultiply::{dgemm, sgemm};
+use std::sync::Arc;
 
 #[cfg(feature = "cblas")]
 use cblas_sys::{


### PR DESCRIPTION
1. no-std-compat added 4 additional dependencies to compile, when most people don't actually use it. Instead, users should disable default feature flags and enable the new `no-std` feature flag.
2. numpy added 4 dependencies because of zip, so moving that to feature flag.
3. matrixmultiply/threading added 4 dependencies, which wouldn't be used for cuda, so moving that to feature f lag

`cargo tree` before:
```
dfdx v0.10.0 (C:\Users\clowm\Documents\programming\dfdx)
├── matrixmultiply v0.3.2
│   ├── num_cpus v1.15.0
│   ├── once_cell v1.12.0
│   ├── rawpointer v0.2.1
│   └── thread-tree v0.3.3
│       └── crossbeam-channel v0.5.6
│           ├── cfg-if v1.0.0
│           └── crossbeam-utils v0.8.12
│               └── cfg-if v1.0.0
├── no-std-compat v0.4.1
│   └── hashbrown v0.8.2
│       └── ahash v0.3.8
│       [build-dependencies]
│       └── autocfg v1.0.1
├── num-traits v0.2.15
│   └── libm v0.2.1
│   [build-dependencies]
│   └── autocfg v1.0.1
├── rand v0.8.5
│   ├── rand_chacha v0.3.1
│   │   ├── ppv-lite86 v0.2.10
│   │   └── rand_core v0.6.3
│   │       └── getrandom v0.2.8
│   │           └── cfg-if v1.0.0
│   └── rand_core v0.6.3 (*)
├── rand_distr v0.4.3
│   ├── num-traits v0.2.15 (*)
│   └── rand v0.8.5 (*)
└── zip v0.6.2
    ├── byteorder v1.4.3
    └── crc32fast v1.3.2
        └── cfg-if v1.0.0
```

And after:
```
dfdx v0.10.0 (C:\Users\clowm\Documents\programming\dfdx)
├── matrixmultiply v0.3.2
│   └── rawpointer v0.2.1
├── num-traits v0.2.15
│   └── libm v0.2.1
│   [build-dependencies]
│   └── autocfg v1.0.1
├── rand v0.8.5
│   ├── rand_chacha v0.3.1
│   │   ├── ppv-lite86 v0.2.10
│   │   └── rand_core v0.6.3
│   └── rand_core v0.6.3
└── rand_distr v0.4.3
    ├── num-traits v0.2.15 (*)
    └── rand v0.8.5 (*)
```