### PR TITLE
Fixing bool tests with safetensors (serde compatibility)

### DIFF
--- a/src/tensor_ops/boolean/mod.rs
+++ b/src/tensor_ops/boolean/mod.rs
@@ -282,7 +282,7 @@ mod tests {
         let r3 = &a & false;
         assert_eq!(r1.array(), [[false, false, false, true]; 2]);
         assert_eq!(r2.array(), a.array());
-        assert_eq!(r3.array(), dev.zeros_like(&a).array());
+        assert_eq!(r3.array(), [[false; 4]; 2]);
     }
 
     #[test]
@@ -295,7 +295,7 @@ mod tests {
         let r2 = &a | true;
         let r3 = &a | false;
         assert_eq!(r1.array(), [[false, true, true, true]; 2]);
-        assert_eq!(r2.array(), dev.ones_like(&a).array());
+        assert_eq!(r2.array(), [[true; 4]; 2]);
         assert_eq!(r3.array(), a.array());
     }
 


### PR DESCRIPTION
@Narsil apparently serde messes with the bool tests:

```rust
error[E0283]: type annotations needed
   --> src\tensor_ops\boolean\mod.rs:285:51
    |
285 |         assert_eq!(r3.array(), dev.zeros_like(&a).array());
    |         ------------------------------------------^^^^^--- type must be known at this point
    |
    = note: multiple `impl`s satisfying `bool: PartialEq<_>` found in the following crates: `core`, `serde_json`:
            - impl PartialEq for bool;
            - impl PartialEq<serde_json::value::Value> for bool;
```

Weird error, I'm not exactly sure why rust thinks serde_json::value::Value is a possible for zeros_like.