### PR TITLE
Hotfixing the safetensors impl.

### DIFF
--- a/examples/safetensors-save-load.rs
+++ b/examples/safetensors-save-load.rs
@@ -27,7 +27,7 @@ fn main() {
 
     // wget -O gpt2.safetensors https://huggingface.co/gpt2/resolve/main/model.safetensors
 
-    let mut gpt2 = dev.build_module::<Linear<728, 50257>, f32>();
+    let mut gpt2 = dev.build_module::<Linear<768, 50257>, f32>();
     let filename = "gpt2.safetensors";
     let f = std::fs::File::open(filename).expect("Couldn't read file, have you downloaded gpt2 ? `wget -O gpt2.safetensors https://huggingface.co/gpt2/resolve/main/model.safetensors`");
     let buffer = unsafe { MmapOptions::new().map(&f).expect("Could not mmap") };

--- a/src/nn/safetensors.rs
+++ b/src/nn/safetensors.rs
@@ -1,7 +1,10 @@
 use crate::{
     prelude::DeviceStorage,
     shapes::{Dtype, HasShape, Shape},
-    tensor::{safetensors::SafeDtype, CopySlice, Tensor},
+    tensor::{
+        safetensors::{Error, SafeDtype},
+        CopySlice, Tensor,
+    },
 };
 use memmap2::MmapOptions;
 use safetensors::{
@@ -118,7 +121,7 @@ pub trait LoadFromSafetensors<E: Dtype + SafeDtype, D: CopySlice<E>>:
     /// let mut model = dev.build_module::<Linear<15, 5>, f32>();
     /// model.load_safetensors("model.safetensors").unwrap();
     /// ```
-    fn load_safetensors<P: AsRef<Path>>(&mut self, path: P) -> Result<(), SafeTensorError> {
+    fn load_safetensors<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
         let f = std::fs::File::open(path)?;
         let buffer = unsafe { MmapOptions::new().map(&f)? };
         let mut tensors = SafeTensors::deserialize(&buffer)?;
@@ -139,7 +142,7 @@ impl<E: Dtype + SafeDtype, D: CopySlice<E>, T: TensorCollection<E, D>> LoadFromS
 
 impl<'data, E: Dtype + SafeDtype, D: CopySlice<E>> TensorVisitor<E, D> for SafeTensors<'data> {
     type Viewer = ViewTensorMut;
-    type Err = SafeTensorError;
+    type Err = Error;
 
     fn visit<S: Shape>(
         &mut self,


### PR DESCRIPTION
- Checking the actual shapes before loading the data.
- Requires changing the error types since this is specific type of
  error.