### PR TITLE
Easier preprocessing

### DIFF
--- a/examples/06-mnist.rs
+++ b/examples/06-mnist.rs
@@ -108,7 +108,7 @@ fn main() {
             .map(preprocess)
             .batch(Const::<BATCH_SIZE>)
             .collate()
-            .map(|(img, lbl)| (img.stack(), lbl.stack()))
+            .stack()
             .progress()
         {
             let logits = model.forward_mut(img.traced_into(grads));

--- a/examples/06-mnist.rs
+++ b/examples/06-mnist.rs
@@ -90,19 +90,27 @@ fn main() {
     let dataset = MnistTrainSet::new(&mnist_path);
     println!("Found {:?} training images", dataset.len());
 
+    let preprocess = |(img, lbl): <MnistTrainSet as ExactSizeDataset>::Item<'_>| {
+        let mut one_hotted = [0.0; 10];
+        one_hotted[lbl] = 1.0;
+        (
+            dev.tensor_from_vec(img, (Const::<784>,)),
+            dev.tensor(one_hotted),
+        )
+    };
+
     for i_epoch in 0..10 {
         let mut total_epoch_loss = 0.0;
         let mut num_batches = 0;
         let start = Instant::now();
         for (img, lbl) in dataset
             .shuffled(&mut rng)
+            .map(preprocess)
             .batch(Const::<BATCH_SIZE>)
             .collate()
+            .map(|(img, lbl)| (img.stack(), lbl.stack()))
             .progress()
         {
-            let img = img.map(|x| dev.tensor((x, (Const::<784>,)))).stack();
-            let lbl = dev.one_hot_encode(Const::<10>, lbl);
-
             let logits = model.forward_mut(img.traced_into(grads));
             let loss = cross_entropy_with_logits_loss(logits, lbl);
 

--- a/src/data/collate.rs
+++ b/src/data/collate.rs
@@ -84,22 +84,22 @@ where
 
 /// Collate an [Iterator] where Self::Item impls [Collate].
 pub trait IteratorCollateExt: Iterator {
-    /// Collates items - depends on implementation of [Collate] by the items.
+    /// Collates (unzips) items - very similar to [std::iter::Iterator::unzip],
+    /// but works on items that are Vecs or arrays
+    ///
+    /// For example:
+    /// - An item of `Vec<(usize, usize)>` becomes `(Vec<usize>, Vec<usize>)`
+    /// - An item of `[(usize, usize); N]` becomes `([usize; N], [usize; N]`
     ///
     /// Example implementations:
     /// ```rust
     /// # use dfdx::data::IteratorCollateExt;
-    /// // batches of data where the items in the batch are (i32, i32):
-    /// let data = [[(1, 2), (3, 4), (5, 6)], [(7, 8), (9, 10), (11, 12)]];
+    /// let data = [[('a', 'b'); 10], [('c', 'd'); 10], [('e', 'f'); 10]];
     /// // we use collate to transform each batch:
-    /// let batches: Vec<([i32; 3], [i32; 3])> = data.into_iter().collate().collect();
-    /// assert_eq!(
-    ///     &batches,
-    ///     &[
-    ///         ([1, 3, 5], [2, 4, 6]),
-    ///         ([7, 9, 11], [8, 10, 12]),
-    ///     ],
-    /// );
+    /// let mut iter = data.into_iter().collate();
+    /// assert_eq!(iter.next().unwrap(), (['a'; 10], ['b'; 10]));
+    /// assert_eq!(iter.next().unwrap(), (['c'; 10], ['d'; 10]));
+    /// assert_eq!(iter.next().unwrap(), (['e'; 10], ['f'; 10]));
     /// ```
     fn collate(self) -> Collator<Self>
     where

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -3,9 +3,11 @@ mod batch;
 mod collate;
 mod dataset;
 mod one_hot_encode;
+mod stack;
 
 pub use arange::Arange;
 pub use batch::IteratorBatchExt;
 pub use collate::{Collate, IteratorCollateExt};
 pub use dataset::ExactSizeDataset;
 pub use one_hot_encode::OneHotEncode;
+pub use stack::IteratorStackExt;

--- a/src/data/stack.rs
+++ b/src/data/stack.rs
@@ -1,0 +1,46 @@
+use crate::tensor_ops::TryStack;
+
+pub struct Stacker<I> {
+    iter: I,
+}
+
+impl<I: Iterator> Iterator for Stacker<I>
+where
+    I::Item: TryStack,
+{
+    type Item = <I::Item as TryStack>::Stacked;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|i| i.stack())
+    }
+}
+
+impl<I: ExactSizeIterator> ExactSizeIterator for Stacker<I>
+where
+    Self: Iterator,
+{
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+/// Stack items of an [Iterator] where Self::Item impls [TryStack].
+pub trait IteratorStackExt: Iterator {
+    /// Stacks items - depends on implementation of [TryStack] by the items.
+    ///
+    /// Example implementations:
+    /// ```rust
+    /// # use dfdx::{data::IteratorStackExt, prelude::*};
+    /// # let dev: Cpu = Default::default();
+    /// let a: Tensor<Rank1<3>, f32, _> = dev.zeros();
+    /// let data = [[a.clone(), a.clone(), a]];
+    /// // we can call stack on each item in the iterator:
+    /// let _: Vec<Tensor<Rank2<3, 3>, f32, _>> = data.into_iter().stack().collect();
+    /// ```
+    fn stack(self) -> Stacker<Self>
+    where
+        Self: Sized,
+    {
+        Stacker { iter: self }
+    }
+}
+impl<I: Iterator> IteratorStackExt for I {}

--- a/src/tensor_ops/stack/mod.rs
+++ b/src/tensor_ops/stack/mod.rs
@@ -70,6 +70,14 @@ where
     }
 }
 
+impl<A: TryStack, B: TryStack<Err = A::Err>> TryStack for (A, B) {
+    type Stacked = (A::Stacked, B::Stacked);
+    type Err = A::Err;
+    fn try_stack(self) -> Result<Self::Stacked, Self::Err> {
+        Ok((self.0.try_stack()?, self.1.try_stack()?))
+    }
+}
+
 pub trait AddDim<D: Dim>: Shape {
     type Larger: Shape;
     fn add_dim(&self, dim: D) -> Self::Larger;

--- a/src/tensor_ops/stack/mod.rs
+++ b/src/tensor_ops/stack/mod.rs
@@ -11,8 +11,9 @@ mod cpu_kernel;
 mod cuda_kernel;
 
 /// Stack an array or vec of tensors together along a new dimension.
-pub trait TryStack<E: Dtype, D: DeviceStorage>: Sized {
+pub trait TryStack: Sized {
     type Stacked;
+    type Err: std::fmt::Debug;
 
     /// Stack an array or vec of tensors together along a new dimension.
     ///
@@ -42,28 +43,29 @@ pub trait TryStack<E: Dtype, D: DeviceStorage>: Sized {
         self.try_stack().unwrap()
     }
     /// Fallible version of [TryStack::stack]
-    fn try_stack(self) -> Result<Self::Stacked, D::Err>;
+    fn try_stack(self) -> Result<Self::Stacked, Self::Err>;
 }
 
-impl<S: Shape, E: Dtype, D: StackKernel<E>, T, const N: usize> TryStack<E, D>
-    for [Tensor<S, E, D, T>; N]
+impl<S: Shape, E: Dtype, D: StackKernel<E>, T, const N: usize> TryStack for [Tensor<S, E, D, T>; N]
 where
     S: AddDim<Const<N>>,
     T: Tape<E, D>,
 {
     type Stacked = Tensor<S::Larger, E, D, T>;
-    fn try_stack(self) -> Result<Self::Stacked, D::Err> {
+    type Err = D::Err;
+    fn try_stack(self) -> Result<Self::Stacked, Self::Err> {
         try_stack(self)
     }
 }
 
-impl<S: Shape, E: Dtype, D: StackKernel<E>, T> TryStack<E, D> for std::vec::Vec<Tensor<S, E, D, T>>
+impl<S: Shape, E: Dtype, D: StackKernel<E>, T> TryStack for std::vec::Vec<Tensor<S, E, D, T>>
 where
     S: AddDim<usize>,
     T: Tape<E, D>,
 {
     type Stacked = Tensor<S::Larger, E, D, T>;
-    fn try_stack(self) -> Result<Self::Stacked, D::Err> {
+    type Err = D::Err;
+    fn try_stack(self) -> Result<Self::Stacked, Self::Err> {
         try_stack(self)
     }
 }


### PR DESCRIPTION
1. Updates mnist example to show using a preprocess fn in .map
2. Adds .stack for iterators
3. Simplifies TryStack trait
4. Adds TryStack for (A, B)