### PR TITLE
Adding nice error message when MHA num heads doesn't divide K/H

### DIFF
--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -22,7 +22,7 @@ pub mod builder {
     impl<const M: usize, const H: usize, const K: usize, const V: usize>
         MultiHeadAttention<M, H, K, V>
     {
-        pub const KEY_AND_VALUE_DIVIDED_BY_NUM_HEADS: () = assert!(
+        pub const TYPE_CHECK: () = assert!(
             K % H == 0 && V % H == 0,
             "NUM_HEADS must divide K_DIM & V_DIM evenly! If you haven't specified K_DIM & V_DIM, they default to EMBED_DIM, which means NUM_HEADS must divide EMBED_DIM evenly."
         );
@@ -37,7 +37,7 @@ where
     type Built = MultiHeadAttention<M, H, K, V, E, D>;
     fn try_build_on_device(device: &D) -> Result<Self::Built, <D>::Err> {
         #[allow(clippy::let_unit_value)]
-        let _ = Self::KEY_AND_VALUE_DIVIDED_BY_NUM_HEADS;
+        let _ = Self::TYPE_CHECK;
         Self::Built::try_build(device)
     }
 }
@@ -79,7 +79,7 @@ where
 {
     fn try_build(device: &D) -> Result<Self, <D>::Err> {
         #[allow(clippy::let_unit_value)]
-        let _ = builder::MultiHeadAttention::<M, H, K, V>::KEY_AND_VALUE_DIVIDED_BY_NUM_HEADS;
+        let _ = builder::MultiHeadAttention::<M, H, K, V>::TYPE_CHECK;
         Ok(Self {
             w_q: BuildModule::try_build(device)?,
             w_k: BuildModule::try_build(device)?,

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -19,6 +19,14 @@ pub mod builder {
         const K_DIM: usize = EMBED_DIM,
         const V_DIM: usize = EMBED_DIM,
     >;
+    impl<const M: usize, const H: usize, const K: usize, const V: usize>
+        MultiHeadAttention<M, H, K, V>
+    {
+        pub const KEY_AND_VALUE_DIVIDED_BY_NUM_HEADS: () = assert!(
+            K % H == 0 && V % H == 0,
+            "NUM_HEADS must divide K_DIM & V_DIM evenly! If you haven't specified K_DIM & V_DIM, they default to EMBED_DIM, which means NUM_HEADS must divide EMBED_DIM evenly."
+        );
+    }
 }
 
 impl<const M: usize, const H: usize, const K: usize, const V: usize, E: Dtype, D: Device<E>>
@@ -28,6 +36,8 @@ where
 {
     type Built = MultiHeadAttention<M, H, K, V, E, D>;
     fn try_build_on_device(device: &D) -> Result<Self::Built, <D>::Err> {
+        #[allow(clippy::let_unit_value)]
+        let _ = Self::KEY_AND_VALUE_DIVIDED_BY_NUM_HEADS;
         Self::Built::try_build(device)
     }
 }
@@ -68,6 +78,8 @@ where
     E: Dtype + Float + SampleUniform,
 {
     fn try_build(device: &D) -> Result<Self, <D>::Err> {
+        #[allow(clippy::let_unit_value)]
+        let _ = builder::MultiHeadAttention::<M, H, K, V>::KEY_AND_VALUE_DIVIDED_BY_NUM_HEADS;
         Ok(Self {
             w_q: BuildModule::try_build(device)?,
             w_k: BuildModule::try_build(device)?,


### PR DESCRIPTION
Resolves #540 

Here's the program:
```rust
#![feature(generic_const_exprs)]
use dfdx::prelude::*;

fn main() {
    let dev: Cpu = Default::default();
    type Model = Transformer<512, 10, 3, 3, 10>;
    let m = dev.build_module::<Model, f32>();
}
```
And here's the error **at compile time**:

```rust
error[E0080]: evaluation of `dfdx::prelude::MultiHeadAttention::<512, 10>::KEY_AND_VALUE_DIVIDED_BY_NUM_HEADS` failed
  --> C:\Users\clowm\Documents\programming\dfdx\src\nn\transformer\mha.rs:25:60
   |
25 |           pub const KEY_AND_VALUE_DIVIDED_BY_NUM_HEADS: () = assert!(
   |  ____________________________________________________________^
26 | |             K % H == 0 && V % H == 0,
27 | |             "NUM_HEADS must divide K_DIM & V_DIM evenly! If you haven't specified K_DIM & V_DIM, they default to EMBED_DIM, which means NUM_HEADS mu... 
28 | |         );
   | |_________^ the evaluated program panicked at 'NUM_HEADS must divide K_DIM & V_DIM evenly! If you haven't specified K_DIM & V_DIM, they default to EMBED_DIM, which means NUM_HEADS must divide EMBED_DIM evenly.', C:\Users\clowm\Documents\programming\dfdx\src\nn\transformer\mha.rs:25:60
   |
   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `assert` (in Nightly builds, run with -Z 
macro-backtrace for more info)

note: the above error was encountered while instantiating `fn <dfdx::nn::modules::MultiHeadAttention<512, 10, 512, 512, f32, dfdx::tensor::Cpu> as dfdx::nn::BuildModule<dfdx::tensor::Cpu, f32>>::try_build`
   --> C:\Users\clowm\Documents\programming\dfdx\src\nn\transformer\encoder.rs:108:24
    |
108 |             self_attn: BuildModule::try_build(device)?,
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0080`.
warning: `dfdx` (example "tmp") generated 3 warnings
error: could not compile `dfdx` due to previous error; 3 warnings emitted
```

The approach was mentioned here: https://stackoverflow.com/questions/74680410/how-to-assert-that-a-structs-associated-constant-satisfies-a-condition