### PR TITLE
Moving Reshape to use stable compile time asserts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,8 +255,3 @@ pub(crate) mod tests {
         a.assert_close(b, tolerance);
     }
 }
-
-/// Used to assert things about const generics
-pub struct Assert<const C: bool>;
-pub trait ConstTrue {}
-impl ConstTrue for Assert<true> {}

--- a/src/nn/flatten.rs
+++ b/src/nn/flatten.rs
@@ -14,7 +14,7 @@ impl NonMutableModule for Flatten2D {}
 impl<const C: usize, const H: usize, const W: usize, D: Device<E>, E: Dtype, T: Tape<E, D>>
     super::Module<Tensor<Rank3<C, H, W>, E, D, T>> for Flatten2D
 where
-    Rank3<C, H, W>: HasSameNumelAs<Rank1<{ C * H * W }>>,
+    Rank1<{ C * H * W }>: Sized,
 {
     type Output = Tensor<Rank1<{ C * H * W }>, E, D, T>;
     type Error = D::Err;
@@ -30,7 +30,7 @@ impl<const B: usize, const C: usize, const H: usize, const W: usize, D, E: Dtype
 where
     D: Device<E>,
     T: Tape<E, D>,
-    Rank4<B, C, H, W>: HasSameNumelAs<Rank2<B, { C * H * W }>>,
+    Rank2<B, { C * H * W }>: Sized,
 {
     type Output = Tensor<Rank2<B, { C * H * W }>, E, D, T>;
     type Error = D::Err;

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 #[cfg(feature = "nightly")]
-use crate::{gradients::Tape, shapes::*, Assert, ConstTrue};
+use crate::{gradients::Tape, shapes::*};
 
 pub mod builder {
     #[derive(Debug, Clone)]
@@ -139,10 +139,7 @@ impl<
         Tensor<Rank2<S2, M>, E, D>,
     )> for MultiHeadAttention<M, H, K, V, E, D>
 where
-    Assert<{ S1 * K == S1 * H * (K / H) }>: ConstTrue,
-    Assert<{ S2 * K == S2 * H * (K / H) }>: ConstTrue,
-    Assert<{ S2 * V == S2 * H * (V / H) }>: ConstTrue,
-    Assert<{ S1 * H * (V / H) == S1 * V }>: ConstTrue,
+    [[(); V / H]; K / H]: Sized,
 {
     type Output = Tensor<Rank2<S1, M>, E, D, T>;
     type Error = D::Err;
@@ -201,10 +198,7 @@ impl<
         Tensor<Rank3<B, S2, M>, E, D>,
     )> for MultiHeadAttention<M, H, K, V, E, D>
 where
-    Assert<{ B * S1 * K == B * S1 * H * (K / H) }>: ConstTrue,
-    Assert<{ B * S2 * K == B * S2 * H * (K / H) }>: ConstTrue,
-    Assert<{ B * S2 * V == B * S2 * H * (V / H) }>: ConstTrue,
-    Assert<{ B * S1 * H * (V / H) == B * S1 * V }>: ConstTrue,
+    [[(); V / H]; K / H]: Sized,
 {
     type Output = Tensor<Rank3<B, S1, M>, E, D, T>;
     type Error = D::Err;

--- a/src/shapes/mod.rs
+++ b/src/shapes/mod.rs
@@ -13,8 +13,7 @@ pub(crate) use broadcasts::{
 pub(crate) use permutes::{PermuteShapeTo, PermuteStridesTo};
 pub(crate) use replace_dim::{RemoveDimTo, ReplaceDimTo};
 
-#[allow(unused_imports)]
-pub(crate) use same_numel::HasSameNumelAs;
+pub(crate) use same_numel::AssertSameNumel;
 
 pub use axes::{Axes2, Axes3, Axes4, Axes5, Axes6, Axis, HasAxes};
 pub use shape::{Array, Const, ConstDim, Dim};

--- a/src/shapes/same_numel.rs
+++ b/src/shapes/same_numel.rs
@@ -1,32 +1,14 @@
-#![allow(unused_imports)]
-
-use crate::shapes::Const;
-use crate::{Assert, ConstTrue};
+use crate::shapes::ConstShape;
 
 /// Marker for shapes that have the same number of elements as `Dst`
-pub trait HasSameNumelAs<Dst> {}
-
-macro_rules! impl_same_num_elements {
-    ([$($SrcVs:tt),*], $SrcNumEl:tt, [$($DstVs:tt),*], $DstNumEl:tt) => {
-        #[cfg(feature = "nightly")]
-        impl<$(const $SrcVs: usize, )* $(const $DstVs: usize, )*> HasSameNumelAs<($(Const<$SrcVs>, )*)> for ($(Const<$DstVs>, )*)
-        where
-            Assert<{ $DstNumEl == $SrcNumEl }>: ConstTrue {}
-    };
+pub trait AssertSameNumel<Dst: ConstShape>: ConstShape {
+    const TYPE_CHECK: ();
+    fn assert_same_numel() {
+        #[allow(clippy::let_unit_value)]
+        let _ = <Self as AssertSameNumel<Dst>>::TYPE_CHECK;
+    }
 }
 
-macro_rules! impl_for {
-    ([$($SrcVs:tt),*], $SrcNumEl:tt) => {
-        impl_same_num_elements!([$($SrcVs),*], $SrcNumEl, [], (1));
-        impl_same_num_elements!([$($SrcVs),*], $SrcNumEl, [M], (M));
-        impl_same_num_elements!([$($SrcVs),*], $SrcNumEl, [M, N], (M * N));
-        impl_same_num_elements!([$($SrcVs),*], $SrcNumEl, [M, N, O], (M * N * O));
-        impl_same_num_elements!([$($SrcVs),*], $SrcNumEl, [M, N, O, P], (M * N * O * P));
-    };
+impl<Src: ConstShape, Dst: ConstShape> AssertSameNumel<Dst> for Src {
+    const TYPE_CHECK: () = assert!(Src::NUMEL == Dst::NUMEL);
 }
-
-impl_for!([], (1));
-impl_for!([S], (S));
-impl_for!([S, T], (S * T));
-impl_for!([S, T, U], (S * T * U));
-impl_for!([S, T, U, V], (S * T * U * V));

--- a/src/shapes/shape.rs
+++ b/src/shapes/shape.rs
@@ -84,7 +84,9 @@ pub trait Dim: 'static + Copy + Clone + std::fmt::Debug + Send + Sync + Eq + Par
 
 /// Represents a single dimension where all
 /// instances are guaranteed to be the same size at compile time.
-pub trait ConstDim: Default + Dim {}
+pub trait ConstDim: Default + Dim {
+    const SIZE: usize;
+}
 
 impl Dim for usize {
     #[inline(always)]
@@ -115,7 +117,9 @@ impl<const M: usize> Dim for Const<M> {
     }
 }
 
-impl<const M: usize> ConstDim for Const<M> {}
+impl<const M: usize> ConstDim for Const<M> {
+    const SIZE: usize = M;
+}
 
 impl<const N: usize> core::ops::Add<Const<N>> for usize {
     type Output = usize;
@@ -220,7 +224,9 @@ pub trait Shape:
 }
 
 /// Represents a [Shape] that has all [ConstDim]s
-pub trait ConstShape: Default + Shape {}
+pub trait ConstShape: Default + Shape {
+    const NUMEL: usize;
+}
 
 /// Represents something that has a [Shape].
 pub trait HasShape {
@@ -272,7 +278,9 @@ macro_rules! shape {
                 Some(($(Dim::from_size(concrete[$Idx])?, )*))
             }
         }
-        impl<$($D: ConstDim, )*> ConstShape for ($($D, )*) { }
+        impl<$($D: ConstDim, )*> ConstShape for ($($D, )*) {
+            const NUMEL: usize = $($D::SIZE * )* 1;
+         }
 
         impl Shape for [usize; $Num] {
             const NUM_DIMS: usize = $Num;
@@ -309,7 +317,9 @@ impl Shape for () {
         Some(())
     }
 }
-impl ConstShape for () {}
+impl ConstShape for () {
+    const NUMEL: usize = 1;
+}
 
 shape!((D1 0), rank=1, all=Axis);
 shape!((D1 0, D2 1), rank=2, all=Axes2);


### PR DESCRIPTION
Resolves #539, now with this error message:

```rust
error: failed to evaluate generic const expression
   --> C:\Users\clowm\Documents\programming\dfdx\src\nn\transformer\mha.rs:201:11
    |
201 |     [[(); V / H]; K / H]: Sized,
    |           ^^^^^
    |
    = note: the crate this constant originates from uses `#![feature(generic_const_exprs)]
```

This changes HasSameNumelAs to use a different compile time assertion approach, which simplifies it greatly.

Also enables reshape to not panic for runtime sizes by returning an option