### PR TITLE
Allow Modules to be constructed with the TensorCollection trait

### DIFF
--- a/src/nn/add_into.rs
+++ b/src/nn/add_into.rs
@@ -1,4 +1,4 @@
-use crate::{shapes::Dtype, tensor::*};
+use crate::{prelude::Device, shapes::Dtype, tensor::*};
 
 use super::traits::*;
 
@@ -33,9 +33,17 @@ impl<T: BuildModule<D, E>, D: DeviceStorage, E: Dtype> BuildModule<D, E> for Add
     }
 }
 
-impl<E: Dtype, D: DeviceStorage, T: TensorCollection<E, D>> TensorCollection<E, D> for AddInto<T> {
-    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(visitor: &mut V) -> Result<(), V::Err> {
-        visitor.visit_module("0", |s| &s.0, |s| &mut s.0)
+impl<E: Dtype, D: Device<E>, T: TensorCollection<E, D>> TensorCollection<E, D> for AddInto<T> {
+    type Output<E2: Dtype, D2: Device<E2>> = AddInto<T::Output<E2, D2>>;
+
+    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(
+        visitor: &mut V,
+    ) -> ModuleVisitorOutput<V::Func, Self, E, D> {
+        Ok(Some(AddInto(crate::try_option!(visitor.visit_module(
+            "0",
+            |s| &s.0,
+            |s| &mut s.0
+        )?))))
     }
 }
 

--- a/src/nn/batchnorm1d.rs
+++ b/src/nn/batchnorm1d.rs
@@ -5,6 +5,8 @@ use super::{
     traits::*,
 };
 
+use num_traits::FromPrimitive;
+
 pub mod builder {
     #[derive(Debug, Copy, Clone, Eq, PartialEq)]
     pub struct BatchNorm1D<const C: usize>;
@@ -181,31 +183,44 @@ impl<const C: usize, E: Dtype, D: Device<E>> BuildModule<D, E> for BatchNorm1D<C
 }
 
 impl<const C: usize, E: Dtype, D: Device<E>> TensorCollection<E, D> for BatchNorm1D<C, E, D> {
-    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(visitor: &mut V) -> Result<(), V::Err> {
-        visitor.visit_tensor(
+    type Output<E2: Dtype, D2: Device<E2>> = BatchNorm1D<C, E2, D2>;
+
+    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(
+        visitor: &mut V,
+    ) -> ModuleVisitorOutput<V::Func, Self, E, D> {
+        let scale = visitor.visit_tensor(
             "scale",
             |s| &s.scale,
             |s| &mut s.scale,
             TensorOptions::reset_to_ones(),
         )?;
-        visitor.visit_tensor(
+        let bias = visitor.visit_tensor(
             "bias",
             |s| &s.bias,
             |s| &mut s.bias,
             TensorOptions::reset_to_zeros(),
         )?;
-        visitor.visit_tensor(
+        let running_mean = visitor.visit_tensor(
             "running_mean",
             |s| &s.running_mean,
             |s| &mut s.running_mean,
             TensorOptions::detached(|t| t.try_fill_with_zeros()),
         )?;
-        visitor.visit_tensor(
+        let running_var = visitor.visit_tensor(
             "running_var",
             |s| &s.running_var,
             |s| &mut s.running_var,
             TensorOptions::detached(|t| t.try_fill_with_ones()),
-        )
+        )?;
+
+        Ok(Some(BatchNorm1D {
+            scale: crate::try_option!(scale),
+            bias: crate::try_option!(bias),
+            running_mean: crate::try_option!(running_mean),
+            running_var: crate::try_option!(running_var),
+            epsilon: <V::Func as TensorFunction<E, D>>::OutE::from_f32(1e-5).unwrap(),
+            momentum: <V::Func as TensorFunction<E, D>>::OutE::from_f32(0.1).unwrap(),
+        }))
     }
 }
 

--- a/src/nn/bias2d.rs
+++ b/src/nn/bias2d.rs
@@ -62,13 +62,21 @@ impl<const C: usize, E: Dtype, D1: Device<E>, D2: Device<E>> ToDevice<D2> for Bi
 }
 
 impl<const C: usize, E: Dtype, D: Device<E>> TensorCollection<E, D> for Bias2D<C, E, D> {
-    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(visitor: &mut V) -> Result<(), V::Err> {
-        visitor.visit_tensor(
-            "beta",
+    type Output<E2: Dtype, D2: Device<E2>> = Bias2D<C, E2, D2>;
+
+    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(
+        visitor: &mut V,
+    ) -> ModuleVisitorOutput<V::Func, Self, E, D> {
+        let bias = visitor.visit_tensor(
+            "bias",
             |s| &s.bias,
             |s| &mut s.bias,
             TensorOptions::reset_to_zeros(),
-        )
+        )?;
+
+        Ok(Some(Bias2D {
+            bias: crate::try_option!(bias),
+        }))
     }
 }
 

--- a/src/nn/module.rs
+++ b/src/nn/module.rs
@@ -1,9 +1,9 @@
-use crate::shapes::Dtype;
 #[cfg(feature = "cuda")]
 pub use crate::tensor::OnCuda;
 pub use crate::tensor::{DeviceStorage, OnCpu, OnDevice, ToDevice};
+use crate::{prelude::Device, shapes::Dtype};
 
-use super::tensor_collection::{ModuleVisitor, TensorCollection};
+use super::tensor_collection::*;
 
 /// Immutable forward of `Input` that produces [Module::Output].
 /// See [ModuleMut] for mutable forward.
@@ -89,9 +89,13 @@ impl<E: Dtype, D: DeviceStorage, T: ZeroSizedModule> BuildModule<D, E> for T {
     }
 }
 
-impl<E: Dtype, D: DeviceStorage, T: ZeroSizedModule> TensorCollection<E, D> for T {
-    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(_: &mut V) -> Result<(), V::Err> {
-        Ok(())
+impl<E: Dtype, D: Device<E>, T: ZeroSizedModule> TensorCollection<E, D> for T {
+    type Output<E2: Dtype, D2: Device<E2>> = T;
+
+    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(
+        _visitor: &mut V,
+    ) -> ModuleVisitorOutput<V::Func, Self, E, D> {
+        Ok(Some(Default::default()))
     }
 }
 

--- a/src/nn/npz.rs
+++ b/src/nn/npz.rs
@@ -1,8 +1,9 @@
 use crate::{
+    prelude::Device,
     shapes::{Dtype, Shape},
     tensor::{
         numpy::{NpzError, NumpyDtype},
-        CopySlice, Tensor,
+        Tensor,
     },
 };
 
@@ -21,7 +22,7 @@ use zip::{
 /// Something that can be saved to a `.npz` (which is a `.zip`).
 ///
 /// All [super::Module]s in nn implement SaveToNpz, and the zips are formatted in a `.npz` fashion.
-pub trait SaveToNpz<E: Dtype + NumpyDtype, D: CopySlice<E>>: TensorCollection<E, D> {
+pub trait SaveToNpz<E: Dtype + NumpyDtype, D: Device<E>>: TensorCollection<E, D> {
     /// Save this object into the `.npz` file determined located at `path`.
     ///
     /// Example:
@@ -61,15 +62,16 @@ pub trait SaveToNpz<E: Dtype + NumpyDtype, D: CopySlice<E>>: TensorCollection<E,
         Self::iter_tensors(&mut RecursiveWalker {
             m: (self, String::new()),
             f: w,
-        })
+        })?;
+        Ok(())
     }
 }
-impl<E: Dtype + NumpyDtype, D: CopySlice<E>, T: TensorCollection<E, D>> SaveToNpz<E, D> for T {}
+impl<E: Dtype + NumpyDtype, D: Device<E>, T: TensorCollection<E, D>> SaveToNpz<E, D> for T {}
 
 /// Something that can be loaded from a `.npz` file (which is a `zip` file).
 ///
 /// All [super::Module]s in nn implement LoadFromNpz, and the zips are formatted in a `.npz` fashion.
-pub trait LoadFromNpz<E: Dtype + NumpyDtype, D: CopySlice<E>>: TensorCollection<E, D> {
+pub trait LoadFromNpz<E: Dtype + NumpyDtype, D: Device<E>>: TensorCollection<E, D> {
     /// Loads data from a `.npz` zip archive at the specified `path`.
     ///
     /// Example:
@@ -105,12 +107,13 @@ pub trait LoadFromNpz<E: Dtype + NumpyDtype, D: CopySlice<E>>: TensorCollection<
         Self::iter_tensors(&mut RecursiveWalker {
             m: (self, String::new()),
             f: r,
-        })
+        })?;
+        Ok(())
     }
 }
-impl<E: Dtype + NumpyDtype, D: CopySlice<E>, T: TensorCollection<E, D>> LoadFromNpz<E, D> for T {}
+impl<E: Dtype + NumpyDtype, D: Device<E>, T: TensorCollection<E, D>> LoadFromNpz<E, D> for T {}
 
-impl<W: Write + Seek, E: Dtype + NumpyDtype, D: CopySlice<E>> TensorVisitor<E, D>
+impl<W: Write + Seek, E: Dtype + NumpyDtype, D: Device<E>> TensorVisitor<E, D>
     for zip::ZipWriter<W>
 {
     type Viewer = (ViewTensorRef, ViewTensorName);
@@ -125,7 +128,7 @@ impl<W: Write + Seek, E: Dtype + NumpyDtype, D: CopySlice<E>> TensorVisitor<E, D
     }
 }
 
-impl<R: Read + Seek, E: Dtype + NumpyDtype, D: CopySlice<E>> TensorVisitor<E, D>
+impl<R: Read + Seek, E: Dtype + NumpyDtype, D: Device<E>> TensorVisitor<E, D>
     for zip::ZipArchive<R>
 {
     type Viewer = (ViewTensorMut, ViewTensorName);
@@ -143,7 +146,7 @@ impl<R: Read + Seek, E: Dtype + NumpyDtype, D: CopySlice<E>> TensorVisitor<E, D>
 #[cfg(test)]
 mod tests {
     use crate::{
-        nn::{builders::*, *},
+        nn::builders::*,
         shapes::*,
         tensor::{numpy::NumpyDtype, AsArray, SampleTensor, Tensor},
         tensor_ops::Device,

--- a/src/nn/num_params.rs
+++ b/src/nn/num_params.rs
@@ -1,9 +1,9 @@
 use super::tensor_collection::*;
 
-use crate::{shapes::*, tensor::*};
+use crate::{prelude::Device, shapes::*, tensor::*};
 
 struct Counter(usize);
-impl<E: Dtype, D: DeviceStorage> TensorVisitor<E, D> for Counter {
+impl<E: Dtype, D: Device<E>> TensorVisitor<E, D> for Counter {
     type Viewer = ViewTensorRef;
     type Err = D::Err;
 
@@ -18,7 +18,7 @@ impl<E: Dtype, D: DeviceStorage> TensorVisitor<E, D> for Counter {
         Ok(())
     }
 }
-pub trait NumParams<E: Dtype, D: DeviceStorage>: TensorCollection<E, D> {
+pub trait NumParams<E: Dtype, D: Device<E>>: TensorCollection<E, D> {
     fn num_trainable_params(&self) -> usize {
         let mut op = Counter(0);
         Self::iter_tensors(&mut RecursiveWalker {
@@ -29,4 +29,4 @@ pub trait NumParams<E: Dtype, D: DeviceStorage>: TensorCollection<E, D> {
         op.0
     }
 }
-impl<E: Dtype, D: DeviceStorage, M: TensorCollection<E, D>> NumParams<E, D> for M {}
+impl<E: Dtype, D: Device<E>, M: TensorCollection<E, D>> NumParams<E, D> for M {}

--- a/src/nn/reset_params.rs
+++ b/src/nn/reset_params.rs
@@ -1,9 +1,9 @@
 use super::tensor_collection::*;
 
-use crate::{shapes::*, tensor::*};
+use crate::{prelude::Device, shapes::*, tensor::*};
 
 struct Resetter;
-impl<E: Dtype, D: DeviceStorage> TensorVisitor<E, D> for Resetter {
+impl<E: Dtype, D: Device<E>> TensorVisitor<E, D> for Resetter {
     type Viewer = ViewTensorMut;
     type Err = D::Err;
 
@@ -15,7 +15,7 @@ impl<E: Dtype, D: DeviceStorage> TensorVisitor<E, D> for Resetter {
         (opts.reset)(t)
     }
 }
-pub trait ResetParams<E: Dtype, D: DeviceStorage>: TensorCollection<E, D> {
+pub trait ResetParams<E: Dtype, D: Device<E>>: TensorCollection<E, D> {
     fn reset_params(&mut self) {
         self.try_reset_params().unwrap();
     }
@@ -23,7 +23,8 @@ pub trait ResetParams<E: Dtype, D: DeviceStorage>: TensorCollection<E, D> {
         Self::iter_tensors(&mut RecursiveWalker {
             m: self,
             f: &mut Resetter,
-        })
+        })?;
+        Ok(())
     }
 }
-impl<E: Dtype, D: DeviceStorage, M: TensorCollection<E, D>> ResetParams<E, D> for M {}
+impl<E: Dtype, D: Device<E>, M: TensorCollection<E, D>> ResetParams<E, D> for M {}

--- a/src/nn/safetensors.rs
+++ b/src/nn/safetensors.rs
@@ -1,4 +1,5 @@
 use crate::{
+    prelude::Device,
     shapes::{Dtype, HasShape, Shape},
     tensor::{
         safetensors::{Error, SafeDtype},
@@ -61,7 +62,7 @@ impl Writer {
     }
 }
 
-impl<E: Dtype + SafeDtype, D: CopySlice<E>> TensorVisitor<E, D> for Writer {
+impl<E: Dtype + SafeDtype, D: Device<E>> TensorVisitor<E, D> for Writer {
     type Viewer = (ViewTensorRef, ViewTensorName);
     type Err = SafeTensorError;
 
@@ -78,7 +79,7 @@ impl<E: Dtype + SafeDtype, D: CopySlice<E>> TensorVisitor<E, D> for Writer {
 /// Something that can be saved to a `.safetensors`.
 ///
 /// All [super::Module]s in nn implement SaveToSafetensors.
-pub trait SaveToSafetensors<E: Dtype + SafeDtype, D: CopySlice<E>>: TensorCollection<E, D> {
+pub trait SaveToSafetensors<E: Dtype + SafeDtype, D: Device<E>>: TensorCollection<E, D> {
     /// Save this object into the `.safetensors` file determined located at `path`.
     ///
     /// Example:
@@ -98,17 +99,12 @@ pub trait SaveToSafetensors<E: Dtype + SafeDtype, D: CopySlice<E>>: TensorCollec
         Ok(())
     }
 }
-impl<E: Dtype + SafeDtype, D: CopySlice<E>, T: TensorCollection<E, D>> SaveToSafetensors<E, D>
-    for T
-{
-}
+impl<E: Dtype + SafeDtype, D: Device<E>, T: TensorCollection<E, D>> SaveToSafetensors<E, D> for T {}
 
 /// Something that can be loaded from a `.safetensors` file.
 ///
 /// All [super::Module]s in nn implement LoadFromSafetensors.
-pub trait LoadFromSafetensors<E: Dtype + SafeDtype, D: CopySlice<E>>:
-    TensorCollection<E, D>
-{
+pub trait LoadFromSafetensors<E: Dtype + SafeDtype, D: Device<E>>: TensorCollection<E, D> {
     /// Loads data from a `.safetensors` at the specified `path`.
     ///
     /// Example:
@@ -131,12 +127,12 @@ pub trait LoadFromSafetensors<E: Dtype + SafeDtype, D: CopySlice<E>>:
     }
 }
 
-impl<E: Dtype + SafeDtype, D: CopySlice<E>, T: TensorCollection<E, D>> LoadFromSafetensors<E, D>
+impl<E: Dtype + SafeDtype, D: Device<E>, T: TensorCollection<E, D>> LoadFromSafetensors<E, D>
     for T
 {
 }
 
-impl<'data, E: Dtype + SafeDtype, D: CopySlice<E>> TensorVisitor<E, D> for SafeTensors<'data> {
+impl<'data, E: Dtype + SafeDtype, D: Device<E>> TensorVisitor<E, D> for SafeTensors<'data> {
     type Viewer = (ViewTensorMut, ViewTensorName);
     type Err = Error;
 
@@ -152,7 +148,7 @@ impl<'data, E: Dtype + SafeDtype, D: CopySlice<E>> TensorVisitor<E, D> for SafeT
 #[cfg(test)]
 mod tests {
     use crate::{
-        nn::{builders::*, *},
+        nn::builders::*,
         shapes::*,
         tensor::{safetensors::SafeDtype, AsArray, SampleTensor, Tensor},
         tensor_ops::Device,

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -1,4 +1,4 @@
-use crate::{shapes::Dtype, tensor::*};
+use crate::{prelude::Device, shapes::Dtype, tensor::*};
 
 use super::traits::*;
 
@@ -32,11 +32,17 @@ impl<T: BuildModule<D, E>, D: DeviceStorage, E: Dtype> BuildModule<D, E> for Spl
     }
 }
 
-impl<E: Dtype, D: DeviceStorage, T: TensorCollection<E, D>> TensorCollection<E, D>
-    for SplitInto<T>
-{
-    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(visitor: &mut V) -> Result<(), V::Err> {
-        visitor.visit_module("0", |s| &s.0, |s| &mut s.0)
+impl<E: Dtype, D: Device<E>, T: TensorCollection<E, D>> TensorCollection<E, D> for SplitInto<T> {
+    type Output<E2: Dtype, D2: Device<E2>> = SplitInto<T::Output<E2, D2>>;
+
+    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(
+        visitor: &mut V,
+    ) -> ModuleVisitorOutput<V::Func, Self, E, D> {
+        Ok(Some(SplitInto(crate::try_option!(visitor.visit_module(
+            "0",
+            |s| &s.0,
+            |s| &mut s.0
+        )?))))
     }
 }
 

--- a/src/nn/tensor_collection/collection.rs
+++ b/src/nn/tensor_collection/collection.rs
@@ -1,20 +1,54 @@
 #![allow(clippy::type_complexity)]
 
 use crate::{
+    prelude::Device,
     shapes::{Dtype, Shape},
-    tensor::{DeviceStorage, OneFillStorage, Tensor, ZeroFillStorage},
+    tensor::{OneFillStorage, Tensor, ZeroFillStorage},
 };
+
+use super::visitor::TensorFunction;
+
+#[macro_export]
+macro_rules! try_option {
+    ($e:expr) => {
+        if let Some(x) = $e {
+            x
+        } else {
+            return Ok(None);
+        }
+    };
+}
+
+pub type ModuleVisitorOutput<F, M, E, D> = Result<
+    Option<
+        <M as TensorCollection<E, D>>::Output<
+            <F as TensorFunction<E, D>>::OutE,
+            <F as TensorFunction<E, D>>::OutD,
+        >,
+    >,
+    <F as TensorFunction<E, D>>::Err,
+>;
+
+pub type TensorFunctionOutput<F, S, E, D> = Result<
+    Option<Tensor<S, <F as TensorFunction<E, D>>::OutE, <F as TensorFunction<E, D>>::OutD>>,
+    <F as TensorFunction<E, D>>::Err,
+>;
 
 /// A collection of named tensors. Implementing this trait will enable anything
 /// that operates on tensors, like resetting, EMA, counting number of params,
 /// gradient updates, etc.
-pub trait TensorCollection<E: Dtype, D: DeviceStorage>: Sized {
-    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(visitor: &mut V) -> Result<(), V::Err>;
+pub trait TensorCollection<E: Dtype, D: Device<E>>: Sized {
+    type Output<E2: Dtype, D2: Device<E2>>;
+
+    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(
+        visitor: &mut V,
+    ) -> ModuleVisitorOutput<V::Func, Self, E, D>;
 }
 
 /// An object that can visit [TensorCollection]s and [Tensor]s recursively.
-pub trait ModuleVisitor<T, E: Dtype, D: DeviceStorage>: Sized {
+pub trait ModuleVisitor<T: TensorCollection<E, D>, E: Dtype, D: Device<E>>: Sized {
     type Err;
+    type Func: TensorFunction<E, D>;
 
     /// Visit a [TensorCollection]
     fn visit_module<Field, GetRef, GetMut>(
@@ -22,7 +56,7 @@ pub trait ModuleVisitor<T, E: Dtype, D: DeviceStorage>: Sized {
         name: &str,
         get_refs: GetRef,
         get_muts: GetMut,
-    ) -> Result<(), Self::Err>
+    ) -> ModuleVisitorOutput<Self::Func, Field, E, D>
     where
         GetRef: FnMut(&T) -> &Field,
         GetMut: FnMut(&mut T) -> &mut Field,
@@ -35,14 +69,18 @@ pub trait ModuleVisitor<T, E: Dtype, D: DeviceStorage>: Sized {
         get_refs: GetRef,
         get_muts: GetMut,
         opts: TensorOptions<S, E, D>,
-    ) -> Result<(), Self::Err>
+    ) -> TensorFunctionOutput<Self::Func, S, E, D>
     where
         GetRef: FnMut(&T) -> &Tensor<S, E, D>,
         GetMut: FnMut(&mut T) -> &mut Tensor<S, E, D>;
 }
 
-impl<S: Shape, E: Dtype, D: DeviceStorage> TensorCollection<E, D> for Tensor<S, E, D> {
-    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(visitor: &mut V) -> Result<(), V::Err> {
+impl<S: Shape, E: Dtype, D: Device<E>> TensorCollection<E, D> for Tensor<S, E, D> {
+    type Output<E2: Dtype, D2: Device<E2>> = Tensor<S, E2, D2>;
+
+    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(
+        visitor: &mut V,
+    ) -> ModuleVisitorOutput<V::Func, Self, E, D> {
         visitor.visit_tensor(
             "",
             |s| s,
@@ -57,7 +95,7 @@ impl<S: Shape, E: Dtype, D: DeviceStorage> TensorCollection<E, D> for Tensor<S, 
 
 /// Options to change behavior of [ModuleVisitor]
 #[non_exhaustive]
-pub struct TensorOptions<S: Shape, E: Dtype, D: DeviceStorage> {
+pub struct TensorOptions<S: Shape, E: Dtype, D: Device<E>> {
     /// Whether the tensor should be updated with gradients
     pub do_gradient_update: bool,
 
@@ -65,7 +103,7 @@ pub struct TensorOptions<S: Shape, E: Dtype, D: DeviceStorage> {
     pub reset: fn(&'_ mut Tensor<S, E, D>) -> Result<(), D::Err>,
 }
 
-impl<S: Shape, E: Dtype, D: DeviceStorage> TensorOptions<S, E, D> {
+impl<S: Shape, E: Dtype, D: Device<E>> TensorOptions<S, E, D> {
     /// A tensor that should be updated with gradients & reset to 0
     pub fn reset_to_zeros() -> Self
     where

--- a/src/nn/tensor_collection/mod.rs
+++ b/src/nn/tensor_collection/mod.rs
@@ -4,7 +4,10 @@
 mod collection;
 mod visitor;
 
-pub use collection::{ModuleVisitor, TensorCollection, TensorOptions};
+pub use collection::{
+    ModuleVisitor, ModuleVisitorOutput, TensorCollection, TensorFunctionOutput, TensorOptions,
+};
 pub use visitor::{
-    RecursiveWalker, TensorViewer, TensorVisitor, ViewTensorMut, ViewTensorName, ViewTensorRef,
+    RecursiveWalker, TensorFunction, TensorViewer, TensorVisitor, ViewTensorMut, ViewTensorName,
+    ViewTensorRef,
 };

--- a/src/nn/transformer/mod.rs
+++ b/src/nn/transformer/mod.rs
@@ -98,9 +98,18 @@ where
     E: Dtype + Float + SampleUniform,
     D: Device<E>,
 {
-    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(visitor: &mut V) -> Result<(), V::Err> {
-        visitor.visit_module("encoder", |s| &s.encoder, |s| &mut s.encoder)?;
-        visitor.visit_module("decoder", |s| &s.decoder, |s| &mut s.decoder)
+    type Output<E2: Dtype, D2: Device<E2>> = Transformer<M, H, A, B, F, E2, D2>;
+
+    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(
+        visitor: &mut V,
+    ) -> ModuleVisitorOutput<V::Func, Self, E, D> {
+        let encoder = visitor.visit_module("encoder", |s| &s.encoder, |s| &mut s.encoder)?;
+        let decoder = visitor.visit_module("decoder", |s| &s.decoder, |s| &mut s.decoder)?;
+
+        Ok(Some(Transformer {
+            encoder: crate::try_option!(encoder),
+            decoder: crate::try_option!(decoder),
+        }))
     }
 }
 

--- a/src/nn/zero_grads.rs
+++ b/src/nn/zero_grads.rs
@@ -1,6 +1,6 @@
 use super::tensor_collection::*;
 
-use crate::{gradients::Gradients, shapes::*, tensor::*, unique_id::UniqueId};
+use crate::{gradients::Gradients, prelude::Device, shapes::*, tensor::*, unique_id::UniqueId};
 
 use std::vec::Vec;
 
@@ -13,7 +13,7 @@ use std::vec::Vec;
 /// let mut grads: Gradients<f32, _> = model.alloc_grads();
 /// model.zero_grads(&mut grads);
 /// ```
-pub trait ZeroGrads<E: Dtype, D: ZeroFillStorage<E>>: TensorCollection<E, D> {
+pub trait ZeroGrads<E: Dtype, D: Device<E>>: TensorCollection<E, D> {
     /// Allocates gradients for this tensor collection. **This marks all other
     /// gradients as temporary, so they are dropped after .backward()**
     fn alloc_grads(&self) -> Gradients<E, D> {
@@ -48,14 +48,14 @@ pub trait ZeroGrads<E: Dtype, D: ZeroFillStorage<E>>: TensorCollection<E, D> {
         Ok(())
     }
 }
-impl<E: Dtype, D: ZeroFillStorage<E>, M: TensorCollection<E, D>> ZeroGrads<E, D> for M {}
+impl<E: Dtype, D: Device<E>, M: TensorCollection<E, D>> ZeroGrads<E, D> for M {}
 
 struct ZeroGradOp<'a, E: Unit, D: DeviceStorage> {
     updated: Vec<UniqueId>,
     gradients: &'a mut Gradients<E, D>,
 }
 
-impl<'a, E: Dtype, D: ZeroFillStorage<E>> TensorVisitor<E, D> for ZeroGradOp<'a, E, D> {
+impl<'a, E: Dtype, D: Device<E>> TensorVisitor<E, D> for ZeroGradOp<'a, E, D> {
     type Viewer = ViewTensorRef;
     type Err = D::Err;
 

--- a/src/optim/adam/mod.rs
+++ b/src/optim/adam/mod.rs
@@ -8,6 +8,7 @@ use std::{marker::PhantomData, sync::Arc};
 use crate::{
     gradients::Gradients,
     nn::tensor_collection::*,
+    prelude::Device,
     shapes::{Dtype, Shape},
     tensor::DeviceStorage,
 };
@@ -95,7 +96,7 @@ impl<M, E: Dtype, D: DeviceStorage> Adam<M, E, D> {
     }
 }
 
-pub(super) trait AdamKernel<E: Dtype>: DeviceStorage {
+pub trait AdamKernel<E: Dtype>: DeviceStorage {
     fn update(
         &self,
         t: i32,
@@ -107,7 +108,7 @@ pub(super) trait AdamKernel<E: Dtype>: DeviceStorage {
     ) -> Result<(), Self::Err>;
 }
 
-impl<M, D: AdamKernel<E>, E: Dtype> TensorVisitor<E, D>
+impl<M, D: Device<E>, E: Dtype> TensorVisitor<E, D>
     for (&mut Adam<M, E, D>, &Gradients<E, D>, UnusedTensors)
 {
     type Viewer = ViewTensorMut;
@@ -127,7 +128,8 @@ impl<M, D: AdamKernel<E>, E: Dtype> TensorVisitor<E, D>
             Some(g) => {
                 let m_t = self.0.moment1.get_or_alloc_mut(p)?;
                 let v_t = self.0.moment2.get_or_alloc_mut(p)?;
-                p.device.update(
+                AdamKernel::update(
+                    &p.device,
                     self.0.t,
                     &self.0.cfg,
                     Arc::make_mut(&mut p.data),
@@ -141,7 +143,7 @@ impl<M, D: AdamKernel<E>, E: Dtype> TensorVisitor<E, D>
     }
 }
 
-impl<M: TensorCollection<E, D>, D: AdamKernel<E>, E: Dtype> Optimizer<M, D, E> for Adam<M, E, D> {
+impl<M: TensorCollection<E, D>, D: Device<E>, E: Dtype> Optimizer<M, D, E> for Adam<M, E, D> {
     fn update(
         &mut self,
         module: &mut M,

--- a/src/optim/mod.rs
+++ b/src/optim/mod.rs
@@ -33,11 +33,11 @@ mod optimizer;
 mod rmsprop;
 mod sgd;
 
-pub use adam::{Adam, AdamConfig};
+pub use adam::{Adam, AdamConfig, AdamKernel};
 pub use optimizer::{Momentum, WeightDecay};
 pub use optimizer::{Optimizer, OptimizerUpdateError, UnusedTensors};
-pub use rmsprop::{RMSprop, RMSpropConfig};
-pub use sgd::{Sgd, SgdConfig};
+pub use rmsprop::{RMSprop, RMSpropConfig, RMSpropKernel};
+pub use sgd::{Sgd, SgdConfig, SgdKernel};
 
 pub mod prelude {
     pub use super::{Optimizer, OptimizerUpdateError, UnusedTensors};

--- a/src/shapes/shape.rs
+++ b/src/shapes/shape.rs
@@ -65,11 +65,12 @@ pub trait Dtype:
     + std::ops::MulAssign
     + std::ops::DivAssign
     + num_traits::FromPrimitive
+    + num_traits::Float
+    + rand_distr::uniform::SampleUniform
 {
 }
 impl Dtype for f32 {}
 impl Dtype for f64 {}
-impl Dtype for usize {}
 
 /// Represents something that has a [Dtype].
 pub trait HasDtype {

--- a/src/tensor/tensor_impls.rs
+++ b/src/tensor/tensor_impls.rs
@@ -155,7 +155,7 @@ pub trait SplitTape {
     fn with_empty_tape(&self) -> Self;
 }
 
-impl<S: Shape, E: Dtype, D: DeviceStorage, T: Default> SplitTape for Tensor<S, E, D, T> {
+impl<S: Shape, E: Unit, D: DeviceStorage, T: Default> SplitTape for Tensor<S, E, D, T> {
     type Tape = T;
     type NoTape = Tensor<S, E, D>;
     fn split_tape(self) -> (Self::NoTape, Self::Tape) {

--- a/src/tensor_ops/broadcast_to.rs
+++ b/src/tensor_ops/broadcast_to.rs
@@ -43,7 +43,7 @@ pub trait BroadcastTo: HasErr + HasShape {
         Self::Shape: BroadcastShapeTo<Dst, Ax>;
 }
 
-impl<S: Shape, E: Dtype, D: DeviceStorage, T: Tape<E, D>> BroadcastTo for Tensor<S, E, D, T> {
+impl<S: Shape, E: Unit, D: DeviceStorage, T: Tape<E, D>> BroadcastTo for Tensor<S, E, D, T> {
     fn try_broadcast_like<Dst: Shape, Ax: Axes>(
         self,
         dst: &Dst,

--- a/src/tensor_ops/permute_to.rs
+++ b/src/tensor_ops/permute_to.rs
@@ -22,7 +22,7 @@ pub trait PermuteTo: HasErr + HasShape {
         Self::Shape: PermuteShapeTo<Dst, Ax>;
 }
 
-impl<S: Shape, E: Dtype, D: DeviceStorage, T: Tape<E, D>> PermuteTo for Tensor<S, E, D, T> {
+impl<S: Shape, E: Unit, D: DeviceStorage, T: Tape<E, D>> PermuteTo for Tensor<S, E, D, T> {
     fn try_permute<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
     where
         Self::Shape: PermuteShapeTo<Dst, Ax>,

--- a/src/tensor_ops/utilities/device.rs
+++ b/src/tensor_ops/utilities/device.rs
@@ -13,6 +13,11 @@ pub trait Device<E: Dtype>:
 
     + crate::tensor_ops::stack::StackKernel<E>
 
+    // optimizers
+    + crate::optim::AdamKernel<E>
+    + crate::optim::SgdKernel<E>
+    + crate::optim::RMSpropKernel<E>
+
     // allocation
     + crate::tensor::ZerosTensor<E>
     + crate::tensor::OnesTensor<E>


### PR DESCRIPTION
Expands the definition of TensorCollection to allow it to build Modules to allow implementing BuildModule, ToDevice, and ToDtype with TensorCollection. To facilitate this, TensorVisitor has been split in TensorFunction and TensorVisitor, and usize is no longer a Dtype.

Tasks:
- [ ] Implement BuildModule
- [ ] Implement ToDevice
- [ ] Implement ToDtype (#475)