### PR TITLE
feat: add upper/lower triangles (tril and triu) allocations

### DIFF
--- a/src/tensor/cpu/allocate.rs
+++ b/src/tensor/cpu/allocate.rs
@@ -87,7 +87,7 @@ impl<E: Unit> TriangleTensor<E> for Cpu {
     ) -> Result<Tensor<S::Shape, E, Self>, Self::Err> {
         let shape = *src.shape();
         let strides = shape.strides();
-        let mut data = self.try_alloc_zeros::<E>(shape.num_elements())?;
+        let mut data = self.try_alloc_elem::<E>(shape.num_elements(), val)?;
         // Get the shape of the last two axes.
         let [num_rows, num_cols] = [
             (S::Shape::NUM_DIMS > 1)
@@ -102,9 +102,9 @@ impl<E: Unit> TriangleTensor<E> for Cpu {
 
         // Get the first 2D matrix in this data. This will be copied to each subsequent matrix.
         let (mut mat2d, mut rest) = data.as_mut_slice().split_at_mut(mat_size);
-        for r in 0..num_rows {
-            for c in (r as isize + offset).max(0) as usize..num_cols {
-                mat2d[r * num_cols + c] = val;
+        for r in (-offset).max(0) as usize..num_rows {
+            for c in 0..((r as isize + offset).max(0) as usize).min(num_cols) {
+                mat2d[r * num_cols + c] = E::default();
             }
         }
         while !rest.is_empty() {
@@ -130,7 +130,7 @@ impl<E: Unit> TriangleTensor<E> for Cpu {
     ) -> Result<Tensor<S::Shape, E, Self>, Self::Err> {
         let shape = *src.shape();
         let strides = shape.strides();
-        let mut data = self.try_alloc_zeros::<E>(shape.num_elements())?;
+        let mut data = self.try_alloc_elem::<E>(shape.num_elements(), val)?;
         // Get the shape of the last two axes.
         let [num_rows, num_cols] = [
             (S::Shape::NUM_DIMS > 1)
@@ -145,9 +145,9 @@ impl<E: Unit> TriangleTensor<E> for Cpu {
 
         // Get the first 2D matrix in this data. This will be copied to each subsequent matrix.
         let (mut mat2d, mut rest) = data.as_mut_slice().split_at_mut(mat_size);
-        for r in (-offset).max(0) as usize..num_rows {
-            for c in 0..((r as isize + offset + 1).max(0) as usize).min(num_cols) {
-                mat2d[r * num_cols + c] = val;
+        for r in 0..num_rows {
+            for c in (r as isize + offset + 1).max(0) as usize..num_cols {
+                mat2d[r * num_cols + c] = E::default();
             }
         }
         while !rest.is_empty() {

--- a/src/tensor/cpu/allocate.rs
+++ b/src/tensor/cpu/allocate.rs
@@ -102,10 +102,6 @@ impl<E: Unit> TriangleTensor<E> for Cpu {
 
         // Get the first 2D matrix in this data. This will be copied to each subsequent matrix.
         let (mut mat2d, mut rest) = data.as_mut_slice().split_at_mut(mat_size);
-        // [0., 0., vl, vl, vl],
-        // [0., 0., 0., vl, vl],
-        // [0., 0., 0., 0., vl],
-        // [0., 0., 0., 0., 0.],
         for r in 0..num_rows {
             for c in (r as isize + offset).max(0) as usize..num_cols {
                 mat2d[r * num_cols + c] = val;

--- a/src/tensor/cpu/allocate.rs
+++ b/src/tensor/cpu/allocate.rs
@@ -79,7 +79,7 @@ impl<E: Unit> OnesTensor<E> for Cpu {
 }
 
 impl<E: Unit> TriangleTensor<E> for Cpu {
-    fn try_triu_like<S: HasShape>(
+    fn try_upper_tri_like<S: HasShape>(
         &self,
         src: &S,
         val: E,
@@ -114,7 +114,7 @@ impl<E: Unit> TriangleTensor<E> for Cpu {
         })
     }
 
-    fn try_tril_like<S: HasShape>(
+    fn try_lower_tri_like<S: HasShape>(
         &self,
         src: &S,
         val: E,

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -146,7 +146,7 @@ pub use cuda::{Cuda, CudaError};
 
 pub use storage_traits::{AsArray, CopySlice, TensorFrom, TensorFromVec};
 pub use storage_traits::{DeviceStorage, HasErr};
-pub use storage_traits::{OnesTensor, SampleTensor, ZerosTensor};
+pub use storage_traits::{OnesTensor, SampleTensor, TriangleTensor, ZerosTensor};
 
 #[cfg(feature = "cuda")]
 pub use tensor_impls::OnCuda;
@@ -256,5 +256,131 @@ mod tests {
     fn test_sample_normal() {
         let dev: TestDevice = Default::default();
         let _: Tensor<Rank1<1000>, f32, _> = dev.sample_normal();
+    }
+
+    #[test]
+    fn test_triu() {
+        let dev: TestDevice = Default::default();
+        let vl = 42.0;
+
+        assert_eq!(
+            dev.triu::<Rank2<3, 4>>(vl, None).array(),
+            [[vl, vl, vl, vl], [0., vl, vl, vl], [0., 0., vl, vl]]
+        );
+        assert_eq!(
+            dev.triu::<Rank2<4, 4>>(vl, -1).array(),
+            [
+                [vl, vl, vl, vl],
+                [vl, vl, vl, vl],
+                [0., vl, vl, vl],
+                [0., 0., vl, vl]
+            ]
+        );
+        assert_eq!(
+            dev.triu::<Rank2<4, 4>>(vl, -2).array(),
+            [
+                [vl, vl, vl, vl],
+                [vl, vl, vl, vl],
+                [vl, vl, vl, vl],
+                [0., vl, vl, vl]
+            ]
+        );
+        assert_eq!(
+            dev.triu::<Rank2<4, 3>>(vl, 1).array(),
+            [[0., vl, vl], [0., 0., vl], [0., 0., 0.], [0., 0., 0.]]
+        );
+        assert_eq!(
+            dev.triu::<Rank3<2, 5, 5>>(vl, None).array(),
+            [[
+                [vl, vl, vl, vl, vl],
+                [0., vl, vl, vl, vl],
+                [0., 0., vl, vl, vl],
+                [0., 0., 0., vl, vl],
+                [0., 0., 0., 0., vl]
+            ]; 2]
+        );
+        assert_eq!(
+            dev.triu::<Rank3<4, 5, 5>>(vl, 2).array(),
+            [[
+                [0., 0., vl, vl, vl],
+                [0., 0., 0., vl, vl],
+                [0., 0., 0., 0., vl],
+                [0., 0., 0., 0., 0.],
+                [0., 0., 0., 0., 0.]
+            ]; 4]
+        );
+        assert_eq!(
+            dev.triu::<Rank4<3, 4, 5, 6>>(vl, None).array(),
+            [[[
+                [vl, vl, vl, vl, vl, vl],
+                [0., vl, vl, vl, vl, vl],
+                [0., 0., vl, vl, vl, vl],
+                [0., 0., 0., vl, vl, vl],
+                [0., 0., 0., 0., vl, vl]
+            ]; 4]; 3]
+        );
+    }
+
+    #[test]
+    fn test_tril() {
+        let dev: TestDevice = Default::default();
+        let vl = 42.0;
+
+        assert_eq!(
+            dev.tril::<Rank2<3, 4>>(vl, None).array(),
+            [[vl, 0., 0., 0.], [vl, vl, 0., 0.], [vl, vl, vl, 0.]]
+        );
+        assert_eq!(
+            dev.tril::<Rank2<4, 4>>(vl, -1).array(),
+            [
+                [0., 0., 0., 0.],
+                [vl, 0., 0., 0.],
+                [vl, vl, 0., 0.],
+                [vl, vl, vl, 0.]
+            ]
+        );
+        assert_eq!(
+            dev.tril::<Rank2<4, 4>>(vl, -2).array(),
+            [
+                [0., 0., 0., 0.],
+                [0., 0., 0., 0.],
+                [vl, 0., 0., 0.],
+                [vl, vl, 0., 0.]
+            ]
+        );
+        assert_eq!(
+            dev.tril::<Rank2<4, 3>>(vl, 1).array(),
+            [[vl, vl, 0.], [vl, vl, vl], [vl, vl, vl], [vl, vl, vl]]
+        );
+        assert_eq!(
+            dev.tril::<Rank3<2, 5, 5>>(vl, None).array(),
+            [[
+                [vl, 0., 0., 0., 0.],
+                [vl, vl, 0., 0., 0.],
+                [vl, vl, vl, 0., 0.],
+                [vl, vl, vl, vl, 0.],
+                [vl, vl, vl, vl, vl]
+            ]; 2]
+        );
+        assert_eq!(
+            dev.tril::<Rank3<4, 5, 5>>(vl, 2).array(),
+            [[
+                [vl, vl, vl, 0., 0.],
+                [vl, vl, vl, vl, 0.],
+                [vl, vl, vl, vl, vl],
+                [vl, vl, vl, vl, vl],
+                [vl, vl, vl, vl, vl]
+            ]; 4]
+        );
+        assert_eq!(
+            dev.tril::<Rank4<3, 4, 5, 6>>(vl, None).array(),
+            [[[
+                [vl, 0., 0., 0., 0., 0.],
+                [vl, vl, 0., 0., 0., 0.],
+                [vl, vl, vl, 0., 0., 0.],
+                [vl, vl, vl, vl, 0., 0.],
+                [vl, vl, vl, vl, vl, 0.]
+            ]; 4]; 3]
+        );
     }
 }

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -263,9 +263,27 @@ mod tests {
         let dev: TestDevice = Default::default();
         let vl = 42.0;
 
+        assert_eq!(dev.upper_tri::<Rank0>(vl, None).array(), vl);
+        assert_eq!(dev.upper_tri::<Rank0>(vl, 1).array(), 0.);
+
+        assert_eq!(dev.upper_tri::<Rank1<3>>(vl, None).array(), [vl, vl, vl]);
+        assert_eq!(dev.upper_tri::<Rank1<3>>(vl, 1).array(), [0., vl, vl]);
+
         assert_eq!(
             dev.upper_tri::<Rank2<3, 4>>(vl, None).array(),
             [[vl, vl, vl, vl], [0., vl, vl, vl], [0., 0., vl, vl]]
+        );
+        assert_eq!(
+            dev.upper_tri::<Rank2<3, 1>>(vl, None).array(),
+            [[vl], [0.], [0.]]
+        );
+        assert_eq!(
+            dev.upper_tri::<Rank2<3, 1>>(vl, 1).array(),
+            [[0.], [0.], [0.]]
+        );
+        assert_eq!(
+            dev.upper_tri::<Rank2<3, 1>>(vl, -1).array(),
+            [[vl], [vl], [0.]]
         );
         assert_eq!(
             dev.upper_tri::<Rank2<4, 4>>(vl, -1).array(),
@@ -326,9 +344,27 @@ mod tests {
         let dev: TestDevice = Default::default();
         let vl = 42.0;
 
+        assert_eq!(dev.lower_tri::<Rank0>(vl, None).array(), vl);
+        assert_eq!(dev.lower_tri::<Rank0>(vl, -1).array(), 0.);
+
+        assert_eq!(dev.lower_tri::<Rank1<3>>(vl, None).array(), [vl, 0., 0.]);
+        assert_eq!(dev.lower_tri::<Rank1<3>>(vl, 1).array(), [vl, vl, 0.]);
+
         assert_eq!(
             dev.lower_tri::<Rank2<3, 4>>(vl, None).array(),
             [[vl, 0., 0., 0.], [vl, vl, 0., 0.], [vl, vl, vl, 0.]]
+        );
+        assert_eq!(
+            dev.lower_tri::<Rank2<3, 1>>(vl, None).array(),
+            [[vl], [vl], [vl]]
+        );
+        assert_eq!(
+            dev.lower_tri::<Rank2<3, 1>>(vl, 1).array(),
+            [[vl], [vl], [vl]]
+        );
+        assert_eq!(
+            dev.lower_tri::<Rank2<3, 1>>(vl, -1).array(),
+            [[0.], [vl], [vl]]
         );
         assert_eq!(
             dev.lower_tri::<Rank2<4, 4>>(vl, -1).array(),

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -259,7 +259,7 @@ mod tests {
     }
 
     #[test]
-    fn test_triu() {
+    fn test_upper_tri() {
         let dev: TestDevice = Default::default();
         let vl = 42.0;
 
@@ -322,7 +322,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tril() {
+    fn test_lower_tri() {
         let dev: TestDevice = Default::default();
         let vl = 42.0;
 

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -264,11 +264,11 @@ mod tests {
         let vl = 42.0;
 
         assert_eq!(
-            dev.triu::<Rank2<3, 4>>(vl, None).array(),
+            dev.upper_tri::<Rank2<3, 4>>(vl, None).array(),
             [[vl, vl, vl, vl], [0., vl, vl, vl], [0., 0., vl, vl]]
         );
         assert_eq!(
-            dev.triu::<Rank2<4, 4>>(vl, -1).array(),
+            dev.upper_tri::<Rank2<4, 4>>(vl, -1).array(),
             [
                 [vl, vl, vl, vl],
                 [vl, vl, vl, vl],
@@ -277,7 +277,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            dev.triu::<Rank2<4, 4>>(vl, -2).array(),
+            dev.upper_tri::<Rank2<4, 4>>(vl, -2).array(),
             [
                 [vl, vl, vl, vl],
                 [vl, vl, vl, vl],
@@ -286,11 +286,11 @@ mod tests {
             ]
         );
         assert_eq!(
-            dev.triu::<Rank2<4, 3>>(vl, 1).array(),
+            dev.upper_tri::<Rank2<4, 3>>(vl, 1).array(),
             [[0., vl, vl], [0., 0., vl], [0., 0., 0.], [0., 0., 0.]]
         );
         assert_eq!(
-            dev.triu::<Rank3<2, 5, 5>>(vl, None).array(),
+            dev.upper_tri::<Rank3<2, 5, 5>>(vl, None).array(),
             [[
                 [vl, vl, vl, vl, vl],
                 [0., vl, vl, vl, vl],
@@ -300,7 +300,7 @@ mod tests {
             ]; 2]
         );
         assert_eq!(
-            dev.triu::<Rank3<4, 5, 5>>(vl, 2).array(),
+            dev.upper_tri::<Rank3<4, 5, 5>>(vl, 2).array(),
             [[
                 [0., 0., vl, vl, vl],
                 [0., 0., 0., vl, vl],
@@ -310,7 +310,7 @@ mod tests {
             ]; 4]
         );
         assert_eq!(
-            dev.triu::<Rank4<3, 4, 5, 6>>(vl, None).array(),
+            dev.upper_tri::<Rank4<3, 4, 5, 6>>(vl, None).array(),
             [[[
                 [vl, vl, vl, vl, vl, vl],
                 [0., vl, vl, vl, vl, vl],
@@ -327,11 +327,11 @@ mod tests {
         let vl = 42.0;
 
         assert_eq!(
-            dev.tril::<Rank2<3, 4>>(vl, None).array(),
+            dev.lower_tri::<Rank2<3, 4>>(vl, None).array(),
             [[vl, 0., 0., 0.], [vl, vl, 0., 0.], [vl, vl, vl, 0.]]
         );
         assert_eq!(
-            dev.tril::<Rank2<4, 4>>(vl, -1).array(),
+            dev.lower_tri::<Rank2<4, 4>>(vl, -1).array(),
             [
                 [0., 0., 0., 0.],
                 [vl, 0., 0., 0.],
@@ -340,7 +340,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            dev.tril::<Rank2<4, 4>>(vl, -2).array(),
+            dev.lower_tri::<Rank2<4, 4>>(vl, -2).array(),
             [
                 [0., 0., 0., 0.],
                 [0., 0., 0., 0.],
@@ -349,11 +349,11 @@ mod tests {
             ]
         );
         assert_eq!(
-            dev.tril::<Rank2<4, 3>>(vl, 1).array(),
+            dev.lower_tri::<Rank2<4, 3>>(vl, 1).array(),
             [[vl, vl, 0.], [vl, vl, vl], [vl, vl, vl], [vl, vl, vl]]
         );
         assert_eq!(
-            dev.tril::<Rank3<2, 5, 5>>(vl, None).array(),
+            dev.lower_tri::<Rank3<2, 5, 5>>(vl, None).array(),
             [[
                 [vl, 0., 0., 0., 0.],
                 [vl, vl, 0., 0., 0.],
@@ -363,7 +363,7 @@ mod tests {
             ]; 2]
         );
         assert_eq!(
-            dev.tril::<Rank3<4, 5, 5>>(vl, 2).array(),
+            dev.lower_tri::<Rank3<4, 5, 5>>(vl, 2).array(),
             [[
                 [vl, vl, vl, 0., 0.],
                 [vl, vl, vl, vl, 0.],
@@ -373,7 +373,7 @@ mod tests {
             ]; 4]
         );
         assert_eq!(
-            dev.tril::<Rank4<3, 4, 5, 6>>(vl, None).array(),
+            dev.lower_tri::<Rank4<3, 4, 5, 6>>(vl, None).array(),
             [[[
                 [vl, 0., 0., 0., 0., 0.],
                 [vl, vl, 0., 0., 0., 0.],

--- a/src/tensor/storage_traits.rs
+++ b/src/tensor/storage_traits.rs
@@ -173,9 +173,9 @@ pub trait TriangleTensor<E: Unit>: DeviceStorage {
     fn upper_tri<S: ConstShape>(
         &self,
         val: E,
-        dim: impl Into<Option<isize>>,
+        diagonal: impl Into<Option<isize>>,
     ) -> Tensor<S, E, Self> {
-        self.try_upper_tri_like::<S>(&Default::default(), val, dim)
+        self.try_upper_tri_like::<S>(&Default::default(), val, diagonal)
             .unwrap()
     }
 
@@ -183,9 +183,9 @@ pub trait TriangleTensor<E: Unit>: DeviceStorage {
     fn try_upper_tri<S: ConstShape>(
         &self,
         val: E,
-        dim: impl Into<Option<isize>>,
+        diagonal: impl Into<Option<isize>>,
     ) -> Result<Tensor<S, E, Self>, Self::Err> {
-        self.try_upper_tri_like::<S>(&Default::default(), val, dim)
+        self.try_upper_tri_like::<S>(&Default::default(), val, diagonal)
     }
 
     /// Build an upper triangular tensor with the given shape.
@@ -193,9 +193,9 @@ pub trait TriangleTensor<E: Unit>: DeviceStorage {
         &self,
         src: &S,
         val: E,
-        dim: impl Into<Option<isize>>,
+        diagonal: impl Into<Option<isize>>,
     ) -> Tensor<S::Shape, E, Self> {
-        self.try_upper_tri_like(src, val, dim).unwrap()
+        self.try_upper_tri_like(src, val, diagonal).unwrap()
     }
 
     /// Fallible version of [TriangleTensor::upper_tri_like]
@@ -203,15 +203,15 @@ pub trait TriangleTensor<E: Unit>: DeviceStorage {
         &self,
         src: &S,
         val: E,
-        dim: impl Into<Option<isize>>,
+        diagonal: impl Into<Option<isize>>,
     ) -> Result<Tensor<S::Shape, E, Self>, Self::Err>;
 
     fn lower_tri<S: ConstShape>(
         &self,
         val: E,
-        dim: impl Into<Option<isize>>,
+        diagonal: impl Into<Option<isize>>,
     ) -> Tensor<S, E, Self> {
-        self.try_lower_tri_like::<S>(&Default::default(), val, dim)
+        self.try_lower_tri_like::<S>(&Default::default(), val, diagonal)
             .unwrap()
     }
 
@@ -219,9 +219,9 @@ pub trait TriangleTensor<E: Unit>: DeviceStorage {
     fn try_lower_tri<S: ConstShape>(
         &self,
         val: E,
-        dim: impl Into<Option<isize>>,
+        diagonal: impl Into<Option<isize>>,
     ) -> Result<Tensor<S, E, Self>, Self::Err> {
-        self.try_lower_tri_like::<S>(&Default::default(), val, dim)
+        self.try_lower_tri_like::<S>(&Default::default(), val, diagonal)
     }
 
     /// Build a lower triangular tensor with the given shape.
@@ -229,9 +229,9 @@ pub trait TriangleTensor<E: Unit>: DeviceStorage {
         &self,
         src: &S,
         val: E,
-        dim: impl Into<Option<isize>>,
+        diagonal: impl Into<Option<isize>>,
     ) -> Tensor<S::Shape, E, Self> {
-        self.try_lower_tri_like(src, val, dim).unwrap()
+        self.try_lower_tri_like(src, val, diagonal).unwrap()
     }
 
     /// Fallible version of [TriangleTensor::lower_tri_like]
@@ -239,7 +239,7 @@ pub trait TriangleTensor<E: Unit>: DeviceStorage {
         &self,
         src: &S,
         val: E,
-        dim: impl Into<Option<isize>>,
+        diagonal: impl Into<Option<isize>>,
     ) -> Result<Tensor<S::Shape, E, Self>, Self::Err>;
 }
 

--- a/src/tensor/storage_traits.rs
+++ b/src/tensor/storage_traits.rs
@@ -170,64 +170,72 @@ pub trait OneFillStorage<E: Unit>: DeviceStorage {
 }
 
 pub trait TriangleTensor<E: Unit>: DeviceStorage {
-    fn triu<S: ConstShape>(&self, val: E, dim: impl Into<Option<isize>>) -> Tensor<S, E, Self> {
-        self.try_triu_like::<S>(&Default::default(), val, dim)
+    fn upper_tri<S: ConstShape>(
+        &self,
+        val: E,
+        dim: impl Into<Option<isize>>,
+    ) -> Tensor<S, E, Self> {
+        self.try_upper_tri_like::<S>(&Default::default(), val, dim)
             .unwrap()
     }
 
-    /// Fallible version of [TriangleTensor::triu]
-    fn try_triu<S: ConstShape>(
+    /// Fallible version of [TriangleTensor::upper_tri]
+    fn try_upper_tri<S: ConstShape>(
         &self,
         val: E,
         dim: impl Into<Option<isize>>,
     ) -> Result<Tensor<S, E, Self>, Self::Err> {
-        self.try_triu_like::<S>(&Default::default(), val, dim)
+        self.try_upper_tri_like::<S>(&Default::default(), val, dim)
     }
 
     /// Build an upper triangular tensor with the given shape.
-    fn triu_like<S: HasShape>(
+    fn upper_tri_like<S: HasShape>(
         &self,
         src: &S,
         val: E,
         dim: impl Into<Option<isize>>,
     ) -> Tensor<S::Shape, E, Self> {
-        self.try_triu_like(src, val, dim).unwrap()
+        self.try_upper_tri_like(src, val, dim).unwrap()
     }
 
-    /// Fallible version of [TriangleTensor::triu_like]
-    fn try_triu_like<S: HasShape>(
+    /// Fallible version of [TriangleTensor::upper_tri_like]
+    fn try_upper_tri_like<S: HasShape>(
         &self,
         src: &S,
         val: E,
         dim: impl Into<Option<isize>>,
     ) -> Result<Tensor<S::Shape, E, Self>, Self::Err>;
 
-    fn tril<S: ConstShape>(&self, val: E, dim: impl Into<Option<isize>>) -> Tensor<S, E, Self> {
-        self.try_tril_like::<S>(&Default::default(), val, dim)
+    fn lower_tri<S: ConstShape>(
+        &self,
+        val: E,
+        dim: impl Into<Option<isize>>,
+    ) -> Tensor<S, E, Self> {
+        self.try_lower_tri_like::<S>(&Default::default(), val, dim)
             .unwrap()
     }
 
-    /// Fallible version of [TriangleTensor::tril]
-    fn try_tril<S: ConstShape>(
+    /// Fallible version of [TriangleTensor::lower_tri]
+    fn try_lower_tri<S: ConstShape>(
         &self,
         val: E,
         dim: impl Into<Option<isize>>,
     ) -> Result<Tensor<S, E, Self>, Self::Err> {
-        self.try_tril_like::<S>(&Default::default(), val, dim)
+        self.try_lower_tri_like::<S>(&Default::default(), val, dim)
     }
 
     /// Build a lower triangular tensor with the given shape.
-    fn tril_like<S: HasShape>(
+    fn lower_tri_like<S: HasShape>(
         &self,
         src: &S,
         val: E,
         dim: impl Into<Option<isize>>,
     ) -> Tensor<S::Shape, E, Self> {
-        self.try_tril_like(src, val, dim).unwrap()
+        self.try_lower_tri_like(src, val, dim).unwrap()
     }
 
-    /// Fallible version of [TriangleTensor::tril_like]
-    fn try_tril_like<S: HasShape>(
+    /// Fallible version of [TriangleTensor::lower_tri_like]
+    fn try_lower_tri_like<S: HasShape>(
         &self,
         src: &S,
         val: E,

--- a/src/tensor/storage_traits.rs
+++ b/src/tensor/storage_traits.rs
@@ -169,6 +169,72 @@ pub trait OneFillStorage<E: Unit>: DeviceStorage {
     fn try_fill_with_ones(&self, storage: &mut Self::Vec<E>) -> Result<(), Self::Err>;
 }
 
+pub trait TriangleTensor<E: Unit>: DeviceStorage {
+    fn triu<S: ConstShape>(&self, val: E, dim: impl Into<Option<isize>>) -> Tensor<S, E, Self> {
+        self.try_triu_like::<S>(&Default::default(), val, dim)
+            .unwrap()
+    }
+
+    /// Fallible version of [TriangleTensor::triu]
+    fn try_triu<S: ConstShape>(
+        &self,
+        val: E,
+        dim: impl Into<Option<isize>>,
+    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+        self.try_triu_like::<S>(&Default::default(), val, dim)
+    }
+
+    /// Build an upper triangular tensor with the given shape.
+    fn triu_like<S: HasShape>(
+        &self,
+        src: &S,
+        val: E,
+        dim: impl Into<Option<isize>>,
+    ) -> Tensor<S::Shape, E, Self> {
+        self.try_triu_like(src, val, dim).unwrap()
+    }
+
+    /// Fallible version of [TriangleTensor::triu_like]
+    fn try_triu_like<S: HasShape>(
+        &self,
+        src: &S,
+        val: E,
+        dim: impl Into<Option<isize>>,
+    ) -> Result<Tensor<S::Shape, E, Self>, Self::Err>;
+
+    fn tril<S: ConstShape>(&self, val: E, dim: impl Into<Option<isize>>) -> Tensor<S, E, Self> {
+        self.try_tril_like::<S>(&Default::default(), val, dim)
+            .unwrap()
+    }
+
+    /// Fallible version of [TriangleTensor::tril]
+    fn try_tril<S: ConstShape>(
+        &self,
+        val: E,
+        dim: impl Into<Option<isize>>,
+    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+        self.try_tril_like::<S>(&Default::default(), val, dim)
+    }
+
+    /// Build a lower triangular tensor with the given shape.
+    fn tril_like<S: HasShape>(
+        &self,
+        src: &S,
+        val: E,
+        dim: impl Into<Option<isize>>,
+    ) -> Tensor<S::Shape, E, Self> {
+        self.try_tril_like(src, val, dim).unwrap()
+    }
+
+    /// Fallible version of [TriangleTensor::tril_like]
+    fn try_tril_like<S: HasShape>(
+        &self,
+        src: &S,
+        val: E,
+        dim: impl Into<Option<isize>>,
+    ) -> Result<Tensor<S::Shape, E, Self>, Self::Err>;
+}
+
 /// Constructs tensors filled with random values from a given distribution.
 pub trait SampleTensor<E: Unit>: DeviceStorage {
     /// Samples a const tensor from a uniform distribution


### PR DESCRIPTION
# Description

This PR adds allocation functions for upper and lower triangle masks.

## Related Issues

- #436

## Open Questions

Pytorch equivalents `triu` and `tril` operate on existing tensors. I could add functions like so:

```rust
pub fn lower_tri<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>>(
    t: Tensor<S, E, D, T>,
    diagonal: impl Into<Option<isize>>,
) -> Tensor<S, E, D, T> {
    t.lower_tri(diagonal)
}

pub fn upper_tri<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>>(
    t: Tensor<S, E, D, T>,
    diagonal: impl Into<Option<isize>>,
) -> Tensor<S, E, D, T> {
    t.upper_tri(diagonal)
}
```

However, I am not yet familiar enough with the lib to know exactly how this operation should be performed.