### PR TITLE
Use Recursive Macros to Implement Shape Operation Traits.

### DIFF
--- a/src/shapes/broadcasts.rs
+++ b/src/shapes/broadcasts.rs
@@ -34,6 +34,8 @@ macro_rules! broadcast_to_array {
 }
 
 macro_rules! broadcast_to {
+    ($SrcNum:literal, ($($SrcDims:tt),*), $DstNum:literal, ($($DstDims:tt),*), ()<>) => {
+    };
     ($SrcNum:literal, ($($SrcDims:tt),*), $DstNum:literal, ($($DstDims:tt),*), $Axes:ty) => {
         impl<$($DstDims: Dim, )*> ReduceShapeTo<($($SrcDims, )*), $Axes> for ($($DstDims, )*) {}
         impl<$($DstDims: Dim, )*> ReduceShape<$Axes> for ($($DstDims, )*) {
@@ -42,50 +44,40 @@ macro_rules! broadcast_to {
         broadcast_to_array!($SrcNum, ($($SrcDims),*), $DstNum, ($($DstDims),*), $Axes);
     };
 }
-broadcast_to!(0, (), 1, (M), Axis<0>);
-broadcast_to!(0, (), 2, (M, N), Axes2<0, 1>);
-broadcast_to!(0, (), 3, (M, N, O), Axes3<0, 1, 2>);
-broadcast_to!(0, (), 4, (M, N, O, P), Axes4<0, 1, 2, 3>);
-broadcast_to!(0, (), 5, (M, N, O, P, Q), Axes5<0, 1, 2, 3, 4>);
-broadcast_to!(0, (), 6, (M, N, O, P, Q, R), Axes6<0, 1, 2, 3, 4, 5>);
 
-broadcast_to!(1, (M), 2, (M, N), Axis<1>);
-broadcast_to!(1, (N), 2, (M, N), Axis<0>);
-broadcast_to!(1, (M), 3, (M, N, O), Axes2<1, 2>);
-broadcast_to!(1, (N), 3, (M, N, O), Axes2<0, 2>);
-broadcast_to!(1, (O), 3, (M, N, O), Axes2<0, 1>);
-broadcast_to!(1, (M), 4, (M, N, O, P), Axes3<1, 2, 3>);
-broadcast_to!(1, (N), 4, (M, N, O, P), Axes3<0, 2, 3>);
-broadcast_to!(1, (O), 4, (M, N, O, P), Axes3<0, 1, 3>);
-broadcast_to!(1, (P), 4, (M, N, O, P), Axes3<0, 1, 2>);
+// Defines all reduce/broadcast rules recursively
+macro_rules! broadcast_to_all {
+    (
+        [$($s1:ident)*]
+        [$($s2:ident)*]
+        [$($ax:tt)*]
+        []
+        [$len1:tt $($lens1:tt)*]
+        [$len2:tt $($lens2:tt)*]
+        [$axis:tt $($axes:tt)*]
+    ) => {
+        broadcast_to!($len1, ($($s1),*), $len2, ($($s2),*), $axis<$($ax),*>);
+    };
+    (
+        [$($s1:ident)*]
+        [$($s2:ident)*]
+        [$($ax:tt)*]
+        [$sh:ident $($shs:ident)*]
+        [$len1:tt $($lens1:tt)*]
+        [$len2:tt $($lens2:tt)*]
+        [$axis:tt $($axes:tt)*]
+    ) => {
+        broadcast_to!($len1, ($($s1),*), $len2, ($($s2),*), $axis<$($ax),*>);
 
-broadcast_to!(2, (M, N), 3, (M, N, O), Axis<2>);
-broadcast_to!(2, (M, O), 3, (M, N, O), Axis<1>);
-broadcast_to!(2, (N, O), 3, (M, N, O), Axis<0>);
-broadcast_to!(2, (M, N), 4, (M, N, O, P), Axes2<2, 3>);
-broadcast_to!(2, (M, O), 4, (M, N, O, P), Axes2<1, 3>);
-broadcast_to!(2, (N, O), 4, (M, N, O, P), Axes2<0, 3>);
-broadcast_to!(2, (M, P), 4, (M, N, O, P), Axes2<1, 2>);
-broadcast_to!(2, (N, P), 4, (M, N, O, P), Axes2<0, 2>);
-broadcast_to!(2, (O, P), 4, (M, N, O, P), Axes2<0, 1>);
+        // Add a broadcasted dimension to the end of s2 
+        broadcast_to_all!([$($s1)*] [$($s2)* $sh] [$($ax)* $len2] [$($shs)*] [$len1 $($lens1)*] [$($lens2)*] [$($axes)*]);
 
-broadcast_to!(3, (M, N, O), 4, (M, N, O, P), Axis<3>);
-broadcast_to!(3, (M, N, P), 4, (M, N, O, P), Axis<2>);
-broadcast_to!(3, (M, O, P), 4, (M, N, O, P), Axis<1>);
-broadcast_to!(3, (N, O, P), 4, (M, N, O, P), Axis<0>);
+        // Add a dimension to both s1 and s2
+        broadcast_to_all!([$($s1)* $sh] [$($s2)* $sh] [$($ax)*] [$($shs)*] [$($lens1)*] [$($lens2)*] [$axis $($axes)*]);
+    }
+}
 
-broadcast_to!(4, (M, N, O, P), 5, (M, N, O, P, Q), Axis<4>);
-broadcast_to!(4, (M, N, O, Q), 5, (M, N, O, P, Q), Axis<3>);
-broadcast_to!(4, (M, N, P, Q), 5, (M, N, O, P, Q), Axis<2>);
-broadcast_to!(4, (M, O, P, Q), 5, (M, N, O, P, Q), Axis<1>);
-broadcast_to!(4, (N, O, P, Q), 5, (M, N, O, P, Q), Axis<0>);
-
-broadcast_to!(5, (M, N, O, P, Q), 6, (M, N, O, P, Q, R), Axis<5>);
-broadcast_to!(5, (M, N, O, P, R), 6, (M, N, O, P, Q, R), Axis<4>);
-broadcast_to!(5, (M, N, O, Q, R), 6, (M, N, O, P, Q, R), Axis<3>);
-broadcast_to!(5, (M, N, P, Q, R), 6, (M, N, O, P, Q, R), Axis<2>);
-broadcast_to!(5, (M, O, P, Q, R), 6, (M, N, O, P, Q, R), Axis<1>);
-broadcast_to!(5, (N, O, P, Q, R), 6, (M, N, O, P, Q, R), Axis<0>);
+broadcast_to_all!([] [] [] [A B C D E F] [0 1 2 3 4 5 6] [0 1 2 3 4 5 6] [() Axis Axes2 Axes3 Axes4 Axes5 Axes6]);
 
 /// Internal implementation for broadcasting strides
 pub trait BroadcastStridesTo<S: Shape, Ax>: Shape + BroadcastShapeTo<S, Ax> {

--- a/src/shapes/broadcasts.rs
+++ b/src/shapes/broadcasts.rs
@@ -69,7 +69,7 @@ macro_rules! broadcast_to_all {
     ) => {
         broadcast_to!($len1, ($($s1),*), $len2, ($($s2),*), $axis<$($ax),*>);
 
-        // Add a broadcasted dimension to the end of s2 
+        // Add a broadcasted dimension to the end of s2
         broadcast_to_all!([$($s1)*] [$($s2)* $sh] [$($ax)* $len2] [$($shs)*] [$len1 $($lens1)*] [$($lens2)*] [$($axes)*]);
 
         // Add a dimension to both s1 and s2

--- a/src/shapes/replace_dim.rs
+++ b/src/shapes/replace_dim.rs
@@ -105,34 +105,22 @@ impl<$($DimVars: Dim, )*> RemoveDimTo<$Dst, $Idx> for ($($DimVars, )*) {
     };
 }
 
-replace!((D1), Axis<0>, (New,), (New,));
-removed!((D1), Axis<0>, (), ());
+macro_rules! replace_and_remove_all {
+    ($(@ $x:tt)? [] $i:tt) => {
+    };
+    (@ [$($befores:ident)*] [$cur:ident $($afters:ident)*] [$idx:tt $($idxs:tt)*]) => {
+        replace!(($($befores,)* $cur $(,$afters)*), Axis<$idx>, ($($befores,)* New, $($afters),*), ($($befores,)* New,));
+        removed!(($($befores,)* $cur $(,$afters)*), Axis<$idx>, ($($befores,)* $($afters,)*), ($($befores,)*));
 
-replace!((D1, D2), Axis<0>, (New, D2), (New,));
-removed!((D1, D2), Axis<0>, (D2,), ());
-replace!((D1, D2), Axis<1>, (D1, New), (D1, New,));
-removed!((D1, D2), Axis<1>, (D1,), (D1,));
+        replace_and_remove_all!(@ [$($befores)* $cur] [$($afters)*] [$($idxs)*]);
+    };
+    ([$cur:ident $($afters:ident)*] [$($idxs:tt)*]) => {
+        replace_and_remove_all!(@ [] [$cur $($afters)*] [$($idxs)*]);
+        replace_and_remove_all!([$($afters)*] [$($idxs)*]);
+    }
+}
 
-replace!((D1, D2, D3), Axis<0>, (New, D2, D3), (New,));
-removed!((D1, D2, D3), Axis<0>, (D2, D3), ());
-replace!((D1, D2, D3), Axis<1>, (D1, New, D3), (D1, New,));
-removed!((D1, D2, D3), Axis<1>, (D1, D3), (D1,));
-replace!((D1, D2, D3), Axis<2>, (D1, D2, New), (D1, D2, New));
-removed!((D1, D2, D3), Axis<2>, (D1, D2,), (D1, D2));
-
-replace!((D1, D2, D3, D4), Axis<0>, (New, D2, D3, D4), (New,));
-removed!((D1, D2, D3, D4), Axis<0>, (D2, D3, D4), ());
-replace!((D1, D2, D3, D4), Axis<1>, (D1, New, D3, D4), (D1, New));
-removed!((D1, D2, D3, D4), Axis<1>, (D1, D3, D4), (D1,));
-replace!((D1, D2, D3, D4), Axis<2>, (D1, D2, New, D4), (D1, D2, New));
-removed!((D1, D2, D3, D4), Axis<2>, (D1, D2, D4), (D1, D2));
-replace!(
-    (D1, D2, D3, D4),
-    Axis<3>,
-    (D1, D2, D3, New),
-    (D1, D2, D3, New)
-);
-removed!((D1, D2, D3, D4), Axis<3>, (D1, D2, D3), (D1, D2, D3));
+replace_and_remove_all!([A B C D E F] [0 1 2 3 4 5]);
 
 // batched select
 impl<Batch: Dim, Seq: Dim, S1: Dim, S2: Dim> ReplaceDimTo<(Batch, Seq, S2), (Batch, Seq)>


### PR DESCRIPTION
Add macros to define all valid broadcasts, reductions, dimension replace dimension, and remove dimension trait implementations. This change marks all valid operations of these types as valid, which was not the case before.