### PR TITLE
Fix bug in gather cuda kernel

### DIFF
--- a/src/tensor_ops/select_and_gather/gather.cu
+++ b/src/tensor_ops/select_and_gather/gather.cu
@@ -20,7 +20,8 @@ __device__ unsigned int get_gathered_index(
     }
 
     unsigned int elem_size = 1; // the size of each indexed element
-    unsigned int row_len = inp_dims[ax]; // the size of the indexed dimension
+    unsigned int inp_row_len = inp_dims[ax]; // the size of the indexed dimension in the input
+    unsigned int out_row_len = idx_dims[ax]; // the size of the indexed dimension in the output
 
     for (unsigned int d = 0; d < inp_num_dims - ax - 1; d++) {
         unsigned int dim_idx = inp_num_dims - 1 - d;
@@ -31,13 +32,13 @@ __device__ unsigned int get_gathered_index(
     unsigned int idx_idx = get_strided_index(index / elem_size, idx_num_dims, idx_dims, idx_strides);
 
     // indices for dimensions before, at, and after the indexed dimension
-    unsigned int idx_before = index / (elem_size * row_len);
+    unsigned int idx_before = index / (elem_size * out_row_len);
     unsigned int idx_mid = idx[idx_idx];
     assert(idx_mid < inp_dims[ax]);
     unsigned int idx_after = index % elem_size;
 
     // recombine
-    unsigned int new_idx = (idx_before * row_len + idx_mid) * elem_size + idx_after;
+    unsigned int new_idx = (idx_before * inp_row_len + idx_mid) * elem_size + idx_after;
     return get_strided_index(new_idx, inp_num_dims, inp_dims, inp_strides);
 }
 
@@ -65,6 +66,7 @@ __device__ void gather_fwd(
         get_gathered_index(i, inp_num_dims, inp_dims, inp_strides, idx, idx_num_dims, idx_dims, idx_strides, out_num_dims);
 
     out[out_i] = inp[inp_i];
+    // out[out_i] = inp_i;
 }
 
 template<typename T>


### PR DESCRIPTION
Fixes bug in #587, which was caused by the gather cuda kernel using the width of the indexed row of the input rather than the output when scaling down idx_before, which is incorrect because `index` is an index into the output.