### PR TITLE
Better cuda conv2d kernel

### DIFF
--- a/benches/conv2d.rs
+++ b/benches/conv2d.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "nightly")]
 fn main() {
-    use std::time::{Instant, Duration};
+    use std::time::{Duration, Instant};
 
     use dfdx::prelude::*;
 
@@ -29,7 +29,7 @@ fn main() {
     let mut sum_s = (0.0, 0.0);
 
     let tests = 1000;
-    let tf = (tests-1) as f32;
+    let tf = (tests - 1) as f32;
 
     let true_s = Instant::now();
     for i in 0..tests {
@@ -62,8 +62,16 @@ fn main() {
     // 86.6 with new backward
 
     // println!("{sum:?} {sum_s:?} {}", (sum_s.0/100. - sum.0*sum.0/10_000.).sqrt());
-    println!("fwd_mean={:?} fwd_sd={:?}", Duration::from_secs_f32(sum.0/tf), Duration::from_secs_f32((sum_s.0/tf - sum.0*sum.0/tf/tf).sqrt()));
-    println!("bwd_mean={:?} bwd_sd={:?}", Duration::from_secs_f32(sum.1/tf), Duration::from_secs_f32((sum_s.1/tf - sum.1*sum.1/tf/tf).sqrt()));
+    println!(
+        "fwd_mean={:?} fwd_sd={:?}",
+        Duration::from_secs_f32(sum.0 / tf),
+        Duration::from_secs_f32((sum_s.0 / tf - sum.0 * sum.0 / tf / tf).sqrt())
+    );
+    println!(
+        "bwd_mean={:?} bwd_sd={:?}",
+        Duration::from_secs_f32(sum.1 / tf),
+        Duration::from_secs_f32((sum_s.1 / tf - sum.1 * sum.1 / tf / tf).sqrt())
+    );
 }
 
 #[cfg(not(feature = "nightly"))]

--- a/benches/conv2d.rs
+++ b/benches/conv2d.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "nightly")]
 fn main() {
-    use std::time::Instant;
+    use std::time::{Instant, Duration};
 
     use dfdx::prelude::*;
 
@@ -12,9 +12,9 @@ fn main() {
     #[cfg(not(feature = "cuda"))]
     type Dev = Cpu;
 
-    type Model = Conv2D<128, 256, 4>;
+    type Model = Conv2D<3, 16, 5>;
     type Dtype = f32;
-    type InputShape = Rank4<64, 128, 28, 28>;
+    type InputShape = Rank4<4, 3, 640, 400>;
 
     println!("Benchmarking `Conv2D`");
     println!("Device {}", std::any::type_name::<Dev>());
@@ -25,11 +25,18 @@ fn main() {
     let dev: Dev = Default::default();
     let mut m = dev.build_module::<Model, Dtype>();
 
-    loop {
-        let img: Tensor<InputShape, Dtype, _> = dev.sample_normal();
+    let mut sum = (0.0, 0.0);
+    let mut sum_s = (0.0, 0.0);
+
+    let tests = 1000;
+    let tf = (tests-1) as f32;
+
+    let true_s = Instant::now();
+    for i in 0..tests {
+        let img: Tensor<InputShape, Dtype, _, _> = dev.sample_normal().leaky_traced();
 
         let start = Instant::now();
-        let out = m.forward_mut(img.leaky_traced());
+        let out = m.forward_mut(img);
         let loss = out.square().mean();
         let fwd_dur = start.elapsed();
 
@@ -37,7 +44,26 @@ fn main() {
         let _ = loss.backward();
         let bwd_dur = start.elapsed();
         println!("fwd={:?} bwd={:?}", fwd_dur, bwd_dur);
+
+        if i != 0 {
+            sum.0 += fwd_dur.as_secs_f32();
+            sum_s.0 += fwd_dur.as_secs_f32().powi(2);
+
+            sum.1 += bwd_dur.as_secs_f32();
+            sum_s.1 += bwd_dur.as_secs_f32().powi(2);
+        }
     }
+    println!("{:?}", true_s.elapsed());
+    // 152.2 without forward
+    // 171.8 with forward
+
+    // 65.9 without backward
+    // 171.5 with backward
+    // 86.6 with new backward
+
+    // println!("{sum:?} {sum_s:?} {}", (sum_s.0/100. - sum.0*sum.0/10_000.).sqrt());
+    println!("fwd_mean={:?} fwd_sd={:?}", Duration::from_secs_f32(sum.0/tf), Duration::from_secs_f32((sum_s.0/tf - sum.0*sum.0/tf/tf).sqrt()));
+    println!("bwd_mean={:?} bwd_sd={:?}", Duration::from_secs_f32(sum.1/tf), Duration::from_secs_f32((sum_s.1/tf - sum.1*sum.1/tf/tf).sqrt()));
 }
 
 #[cfg(not(feature = "nightly"))]

--- a/examples/02-ops.rs
+++ b/examples/02-ops.rs
@@ -2,7 +2,7 @@
 
 use dfdx::{
     shapes::{Rank0, Rank1, Rank2},
-    tensor::{AsArray, AutoDevice, SampleTensor, Tensor},
+    tensor::{AsArray, AutoDevice, SampleTensor, Tensor, Cpu},
     tensor_ops::{MeanTo, TryMatMul},
 };
 

--- a/examples/02-ops.rs
+++ b/examples/02-ops.rs
@@ -2,7 +2,7 @@
 
 use dfdx::{
     shapes::{Rank0, Rank1, Rank2},
-    tensor::{AsArray, AutoDevice, SampleTensor, Tensor, Cpu},
+    tensor::{AsArray, AutoDevice, Cpu, SampleTensor, Tensor},
     tensor_ops::{MeanTo, TryMatMul},
 };
 

--- a/src/tensor_ops/conv2d/cpu_kernel.rs
+++ b/src/tensor_ops/conv2d/cpu_kernel.rs
@@ -111,8 +111,6 @@ impl Cpu {
                         for y in 0..op.h_in {
                             for x in 0..op.w_in {
                                 if let Some([oh, ow]) = op.unfold_idx([k1, k2, y, x]) {
-                                    //println!("did 0 {o} {k1} {k2} {oh} {ow}");
-                                    println!("did {i} {}", o * (op.h_out * op.w_out) + oh * op.w_out + ow);
                                     buf[i] =
                                         grad_out[o * (op.h_out * op.w_out) + oh * op.w_out + ow];
                                 }

--- a/src/tensor_ops/conv2d/cpu_kernel.rs
+++ b/src/tensor_ops/conv2d/cpu_kernel.rs
@@ -111,6 +111,8 @@ impl Cpu {
                         for y in 0..op.h_in {
                             for x in 0..op.w_in {
                                 if let Some([oh, ow]) = op.unfold_idx([k1, k2, y, x]) {
+                                    //println!("did 0 {o} {k1} {k2} {oh} {ow}");
+                                    println!("did {i} {}", o * (op.h_out * op.w_out) + oh * op.w_out + ow);
                                     buf[i] =
                                         grad_out[o * (op.h_out * op.w_out) + oh * op.w_out + ow];
                                 }

--- a/src/tensor_ops/conv2d/cuda_kernel.rs
+++ b/src/tensor_ops/conv2d/cuda_kernel.rs
@@ -63,7 +63,7 @@ where
         }
 
         let patches_numel = op.batch * op.chan_in * op.kernel * op.kernel * op.h_out * op.w_out;
-        let mut patches = self.dev.alloc_zeros::<E>(patches_numel)?;
+        let mut patches = unsafe { self.dev.alloc::<E>(patches_numel)? };
         let img_strides = self.dev.htod_copy(make_4d::<L>(lhs.strides).into())?;
         let unfold_fn = self.dev.get_func(Self::MOD, Self::FNS[0]).unwrap();
         let cfg = LaunchConfig::for_num_elems(patches.len() as u32);
@@ -104,7 +104,7 @@ where
     ) -> Result<(), Self::Err> {
         let image_numel = op.batch * op.chan_out * op.h_in * op.w_in;
         let patches_numel = op.kernel * op.kernel * image_numel;
-        let mut patches = self.dev.alloc_zeros::<E>(patches_numel)?;
+        let mut patches = unsafe { self.dev.alloc::<E>(patches_numel)? };
 
         {
             // unfold grad_out into patches
@@ -114,7 +114,7 @@ where
         }
 
         let filters_numel = op.batch * op.chan_in * op.chan_out * op.kernel * op.kernel;
-        let mut f_b1023 = self.dev.alloc_zeros::<E>(filters_numel)?;
+        let mut f_b1023 = unsafe { self.dev.alloc::<E>(filters_numel)? };
         let mut grad_f_b1023 = self.dev.alloc_zeros::<E>(filters_numel)?;
         let f_strides = self.dev.htod_copy(rhs.strides.into())?;
 

--- a/src/tensor_ops/conv2d/cuda_kernel.rs
+++ b/src/tensor_ops/conv2d/cuda_kernel.rs
@@ -109,7 +109,7 @@ where
         {
             // unfold grad_out into patches
             let unfold_fn = self.dev.get_func(Self::MOD, Self::FNS[1]).unwrap();
-            let cfg = LaunchConfig::for_num_elems(image_numel as u32);
+            let cfg = LaunchConfig{ grid_dim: ((image_numel as u32+32-1)/32, 1, 1), block_dim: (32,1,1), shared_mem_bytes: 0 };
             unsafe { unfold_fn.launch(cfg, (op, grad_out, &mut patches)) }?;
         }
 

--- a/src/tensor_ops/conv2d/mod.rs
+++ b/src/tensor_ops/conv2d/mod.rs
@@ -252,6 +252,7 @@ mod tests {
             &[[[0.24369538, 0.71453357]], [[-0.69169492, -0.06172103]]],
         );
         let g = result.exp().mean().backward();
+        //assert_close(&g.get(&x).sum::<(),_>().array(), &-0.36341519);
         assert_close(
             &g.get(&x).array(),
             &[[


### PR DESCRIPTION
This optimizes the Conv2D kernel.
Some of these changes should be reverted as they were just how I benchmarked my changes.
I tested this on a GTX 1650 Ti and it improved from taking 171.5 seconds to 86.6 seconds.
Fixes #578 