### PR TITLE
Allow conv2d and pool2d to use dynamic dimensions for width and height.

### DIFF
--- a/src/tensor_ops/conv2d/mod.rs
+++ b/src/tensor_ops/conv2d/mod.rs
@@ -100,7 +100,7 @@ impl<const K: usize, const S: usize, const P: usize> ConvAlgebra<K, S, P> for us
     type Convolved = usize;
 
     fn convolve_dim(&self) -> Self::Convolved {
-        (self.size() + 2 * P - K) / S + 1
+        (self.size() + 2 * P).checked_sub(K).unwrap() / S + 1
     }
 }
 

--- a/src/tensor_ops/conv2d/mod.rs
+++ b/src/tensor_ops/conv2d/mod.rs
@@ -96,16 +96,13 @@ where
     }
 }
 
-impl<const K: usize, const S: usize, const P: usize> ConvAlgebra<K, S, P>
-    for usize
-{
+impl<const K: usize, const S: usize, const P: usize> ConvAlgebra<K, S, P> for usize {
     type Convolved = usize;
 
     fn convolve_dim(&self) -> Self::Convolved {
         (self.size() + 2 * P - K) / S + 1
     }
 }
-
 
 pub trait TryConv2DTo<F, const S: usize, const P: usize>: HasErr {
     type Output;
@@ -148,16 +145,7 @@ impl<
         T: 'static + Tape<E, D>,
     > TryConv2DTo<Tensor<Rank4<O, C, K, K>, E, D>, S, P> for Tensor<(Const<C>, H, W), E, D, T>
 {
-    type Output = Tensor<
-        (
-            Const<O>,
-            H::Convolved,
-            W::Convolved,
-        ),
-        E,
-        D,
-        T,
-    >;
+    type Output = Tensor<(Const<O>, H::Convolved, W::Convolved), E, D, T>;
 
     fn try_conv2d_to(
         self,
@@ -199,20 +187,9 @@ impl<
         E: Dtype,
         D: Conv2DKernel<E> + ZerosTensor<E>,
         T: 'static + Tape<E, D>,
-    > TryConv2DTo<Tensor<Rank4<O, C, K, K>, E, D>, S, P>
-    for Tensor<(B, Const<C>, H, W), E, D, T>
+    > TryConv2DTo<Tensor<Rank4<O, C, K, K>, E, D>, S, P> for Tensor<(B, Const<C>, H, W), E, D, T>
 {
-    type Output = Tensor<
-        (
-            B,
-            Const<O>,
-            H::Convolved,
-            W::Convolved,
-        ),
-        E,
-        D,
-        T,
-    >;
+    type Output = Tensor<(B, Const<O>, H::Convolved, W::Convolved), E, D, T>;
     fn try_conv2d_to(
         self,
         filters: Tensor<Rank4<O, C, K, K>, E, D>,

--- a/src/tensor_ops/pool2d/mod.rs
+++ b/src/tensor_ops/pool2d/mod.rs
@@ -85,24 +85,21 @@ macro_rules! pool2d {
 
         impl<
                 C: Dim,
-                const H: usize,
-                const W: usize,
+                H: Dim + ConvAlgebra<K, S, P>,
+                W: Dim + ConvAlgebra<K, S, P>,
                 E: Dtype,
                 D: $Kernel<E> + ZerosTensor<E>,
                 T: 'static + Tape<E, D>,
                 const K: usize,
                 const S: usize,
                 const P: usize,
-            > $ConstTrait<K, S, P> for Tensor<(C, Const<H>, Const<W>), E, D, T>
-        where
-            Const<H>: ConvAlgebra<K, S, P>,
-            Const<W>: ConvAlgebra<K, S, P>,
+            > $ConstTrait<K, S, P> for Tensor<(C, H, W), E, D, T>
         {
             type Output = Tensor<
                 (
                     C,
-                    <Const<H> as ConvAlgebra<K, S, P>>::Convolved,
-                    <Const<W> as ConvAlgebra<K, S, P>>::Convolved,
+                    H::Convolved,
+                    W::Convolved,
                 ),
                 E,
                 D,
@@ -110,12 +107,15 @@ macro_rules! pool2d {
             >;
 
             fn try_pool2d(self) -> Result<Self::Output, Self::Err> {
+                let h = self.shape.1;
+                let w = self.shape.2;
+
                 let &(chan, _, _) = self.shape();
-                let op = Pool2DOp::new(K, S, P, [1, chan.size(), H, W]);
+                let op = Pool2DOp::new(K, S, P, [1, chan.size(), h.size(), w.size()]);
                 let (inp, mut tape) = self.split_tape();
                 let mut out =
                     inp.device
-                        .try_zeros_like(&(chan, Default::default(), Default::default()))?;
+                        .try_zeros_like(&(chan, h.convolve_dim(), w.convolve_dim()))?;
                 inp.device.forward(op, &inp, &mut out)?;
                 let phantom_out = out.clone();
                 tape.try_alloc_grad(&inp)?;
@@ -132,25 +132,22 @@ macro_rules! pool2d {
         impl<
                 B: Dim,
                 C: Dim,
-                const H: usize,
-                const W: usize,
+                H: Dim + ConvAlgebra<K, S, P>,
+                W: Dim + ConvAlgebra<K, S, P>,
                 E: Dtype,
                 D: $Kernel<E> + ZerosTensor<E>,
                 T: 'static + Tape<E, D>,
                 const K: usize,
                 const S: usize,
                 const P: usize,
-            > $ConstTrait<K, S, P> for Tensor<(B, C, Const<H>, Const<W>), E, D, T>
-        where
-            Const<H>: ConvAlgebra<K, S, P>,
-            Const<W>: ConvAlgebra<K, S, P>,
+            > $ConstTrait<K, S, P> for Tensor<(B, C, H, W), E, D, T>
         {
             type Output = Tensor<
                 (
                     B,
                     C,
-                    <Const<H> as ConvAlgebra<K, S, P>>::Convolved,
-                    <Const<W> as ConvAlgebra<K, S, P>>::Convolved,
+                    H::Convolved,
+                    W::Convolved,
                 ),
                 E,
                 D,
@@ -158,14 +155,17 @@ macro_rules! pool2d {
             >;
 
             fn try_pool2d(self) -> Result<Self::Output, Self::Err> {
+                let h = self.shape.2;
+                let w = self.shape.3;
+
                 let &(batch, chan, _, _) = self.shape();
-                let op = Pool2DOp::new(K, S, P, [batch.size(), chan.size(), H, W]);
+                let op = Pool2DOp::new(K, S, P, [batch.size(), chan.size(), h.size(), w.size()]);
                 let (inp, mut tape) = self.split_tape();
                 let mut out = inp.device.try_zeros_like(&(
                     batch,
                     chan,
-                    Default::default(),
-                    Default::default(),
+                    h.convolve_dim(),
+                    w.convolve_dim(),
                 ))?;
                 inp.device.forward(op, &inp, &mut out)?;
                 let phantom_out = out.clone();

--- a/src/tensor_ops/pool2d/mod.rs
+++ b/src/tensor_ops/pool2d/mod.rs
@@ -95,16 +95,7 @@ macro_rules! pool2d {
                 const P: usize,
             > $ConstTrait<K, S, P> for Tensor<(C, H, W), E, D, T>
         {
-            type Output = Tensor<
-                (
-                    C,
-                    H::Convolved,
-                    W::Convolved,
-                ),
-                E,
-                D,
-                T,
-            >;
+            type Output = Tensor<(C, H::Convolved, W::Convolved), E, D, T>;
 
             fn try_pool2d(self) -> Result<Self::Output, Self::Err> {
                 let h = self.shape.1;
@@ -142,17 +133,7 @@ macro_rules! pool2d {
                 const P: usize,
             > $ConstTrait<K, S, P> for Tensor<(B, C, H, W), E, D, T>
         {
-            type Output = Tensor<
-                (
-                    B,
-                    C,
-                    H::Convolved,
-                    W::Convolved,
-                ),
-                E,
-                D,
-                T,
-            >;
+            type Output = Tensor<(B, C, H::Convolved, W::Convolved), E, D, T>;
 
             fn try_pool2d(self) -> Result<Self::Output, Self::Err> {
                 let h = self.shape.2;


### PR DESCRIPTION
Adds the `convolve_dim` method to ConvAlgebra and uses it to implement ConvAlgebra for usize. Conv2d and Pool2d still require nightly, as making them work on stable would require making `Const<N>::Convolved` be `usize`, which I don't think is a desirable outcome of changing toolchains.