### PR TITLE
Fix bug in reshape on cuda

### DIFF
--- a/examples/02-ops.rs
+++ b/examples/02-ops.rs
@@ -57,7 +57,7 @@ fn main() {
     // these operations are equal across devices
     #[cfg(feature = "cuda")]
     {
-        use dfdx::nn::ToDevice;
+        use dfdx::{nn::ToDevice, tensor::Cpu};
 
         let cpu = Cpu::default();
 

--- a/src/tensor_ops/reshape_to/cuda_kernel.rs
+++ b/src/tensor_ops/reshape_to/cuda_kernel.rs
@@ -47,7 +47,7 @@ where
             self.dev.load_ptx(PTX_SRC.into(), Self::MOD, Self::FNS)?;
         }
 
-        let numel = inp.data.len();
+        let numel = inp.shape.num_elements();
         let mut storage = unsafe { self.dev.alloc::<E>(numel) }?;
 
         let inp_dims = self.dev.htod_copy(inp.shape.concrete().into())?;

--- a/src/tensor_ops/reshape_to/mod.rs
+++ b/src/tensor_ops/reshape_to/mod.rs
@@ -187,4 +187,18 @@ mod tests {
             ],
         )
     }
+
+    #[test]
+    fn test_reshape_broadcasted() {
+        let dev: TestDevice = Default::default();
+        let a: Tensor<Rank2<2, 3>, TestDtype, _> = dev.tensor([1., 2., 3.]).broadcast();
+        let b: Tensor<Rank2<3, 2>, TestDtype, _> = a.clone().reshape();
+
+        #[cfg(feature = "cuda")]
+        use cudarc::driver::DeviceSlice;
+
+        assert_eq!(b.data.len(), 6);
+        assert_eq!(a.as_vec(), b.as_vec());
+        assert_eq!(b.array(), [[1., 2.], [3., 1.], [2., 3.]]);
+    }
 }


### PR DESCRIPTION
Fixes cuda implementation of reshape not allocating enough memory for broadcasted tensors and adds test to verify the new behavior. Also fixes 02-ops not compiling on cuda, although I don't know when/how this bug was introduced.