### PR TITLE
Adds cudnn feature flag. Removes "test-cuda" feature flag. Using cuDNN for convolutions

### DIFF
--- a/.github/workflows/cargo-check-features.yml
+++ b/.github/workflows/cargo-check-features.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         config:
           - toolchain: stable
-            command: cargo hack check --feature-powerset --no-dev-deps --depth 2 --skip default,nightly,cpu-mkl-matmul,cuda,test-cuda
+            command: cargo hack check --feature-powerset --no-dev-deps --depth 2 --skip default,nightly,cpu-mkl-matmul,cuda,cudnn
           - toolchain: nightly
-            command: cargo hack check --each-feature --no-dev-deps --features nightly --skip default,cpu-mkl-matmul,cuda,test-cuda
+            command: cargo hack check --each-feature --no-dev-deps --features nightly --skip default,cpu-mkl-matmul,cuda,cudnn
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cargo-check.yml
+++ b/.github/workflows/cargo-check.yml
@@ -21,4 +21,9 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --features test-cuda,ci-check
+          args: --features cuda,ci-check
+      - name: Check CUDNN
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --features cudnn,ci-check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ indicatif = "0.17.3"
 glob = { version = "0.3.1", optional = true }
 
 [features]
-default = ["std", "fast-alloc", "test-cuda"]
+default = ["std", "fast-alloc", "cpu-par-matmul"]
 nightly = []
 
 std = ["cudarc?/std", "matrixmultiply?/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ matrixmultiply = { version = "0.3.2", default-features = false, optional = true 
 zip = { version = "0.6.2", default-features = false, optional = true }
 cblas-sys = { version = "0.1.4", default-features = false, optional = true }
 libc = { version = "0.2", default-features = false, optional = true }
-cudarc = { path = "../cudarc", default-features = false, optional = true, features = ["driver", "cublas", "nvrtc", "cudnn"] }
+cudarc = { version = "0.9.6", default-features = false, optional = true, features = ["driver", "cublas", "nvrtc"] }
 num-traits = { version = "0.2.15", default-features = false }
 safetensors = { version = "0.3", default-features = false, optional = true }
 memmap2 = { version = "0.5", default-features = false, optional = true }
@@ -46,7 +46,7 @@ indicatif = "0.17.3"
 glob = { version = "0.3.1", optional = true }
 
 [features]
-default = ["std", "fast-alloc", "test-cuda", "nightly"]
+default = ["std", "fast-alloc", "test-cuda"]
 nightly = []
 
 std = ["cudarc?/std", "matrixmultiply?/std"]
@@ -56,7 +56,9 @@ no-std = ["no-std-compat", "dep:spin", "cudarc?/no-std"]
 cpu-seq-matmul = ["dep:matrixmultiply"]
 cpu-par-matmul = ["std", "dep:matrixmultiply", "matrixmultiply?/threading"]
 cpu-mkl-matmul = ["dep:cblas-sys", "dep:libc"]
+
 cuda = ["dep:cudarc", "dep:glob"]
+cudnn = ["cuda", "cudarc?/cudnn"]
 
 numpy = ["dep:zip", "std"]
 safetensors = ["dep:safetensors", "std", "dep:memmap2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ matrixmultiply = { version = "0.3.2", default-features = false, optional = true 
 zip = { version = "0.6.2", default-features = false, optional = true }
 cblas-sys = { version = "0.1.4", default-features = false, optional = true }
 libc = { version = "0.2", default-features = false, optional = true }
-cudarc = { version = "0.9.5", default-features = false, optional = true, features = ["driver", "cublas", "nvrtc"] }
+cudarc = { path = "../cudarc", default-features = false, optional = true, features = ["driver", "cublas", "nvrtc", "cudnn"] }
 num-traits = { version = "0.2.15", default-features = false }
 safetensors = { version = "0.3", default-features = false, optional = true }
 memmap2 = { version = "0.5", default-features = false, optional = true }
@@ -46,7 +46,7 @@ indicatif = "0.17.3"
 glob = { version = "0.3.1", optional = true }
 
 [features]
-default = ["std", "fast-alloc", "cpu-par-matmul"]
+default = ["std", "fast-alloc", "test-cuda", "nightly"]
 nightly = []
 
 std = ["cudarc?/std", "matrixmultiply?/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ cudnn = ["cuda", "cudarc?/cudnn"]
 numpy = ["dep:zip", "std"]
 safetensors = ["dep:safetensors", "std", "dep:memmap2"]
 
-test-cuda = ["cuda"]
 test-f64 = []
 test-integrations = []
 ci-check = ["cudarc?/ci-check"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,10 +242,10 @@ pub fn keep_denormals() {
 #[cfg(test)]
 pub(crate) mod tests {
 
-    #[cfg(not(feature = "test-cuda"))]
+    #[cfg(not(feature = "cuda"))]
     pub type TestDevice = crate::tensor::Cpu;
 
-    #[cfg(feature = "test-cuda")]
+    #[cfg(feature = "cuda")]
     pub type TestDevice = crate::tensor::Cuda;
 
     #[cfg(not(feature = "test-f64"))]

--- a/src/tensor/cuda/device.rs
+++ b/src/tensor/cuda/device.rs
@@ -82,7 +82,7 @@ impl Cuda {
         let cpu = Cpu::seed_from_u64(seed);
         let dev = CudaDevice::new(ordinal)?;
         let blas = Arc::new(CudaBlas::new(dev.clone())?);
-        let cudnn = Arc::new(Cudnn::new(dev.clone())?);
+        let cudnn = Cudnn::new(dev.clone())?;
         let par_stream = Arc::new(dev.fork_default_stream()?);
         let workspace = Arc::new(Mutex::new(dev.alloc_zeros::<u8>(0)?));
         Ok(Self {

--- a/src/tensor_ops/conv2d/cuda_kernel.rs
+++ b/src/tensor_ops/conv2d/cuda_kernel.rs
@@ -1,16 +1,15 @@
 use cudarc::cublas::{CudaBlas, Gemm};
-use cudarc::driver::{DeviceRepr, LaunchAsync, ValidAsZeroBits};
+use cudarc::cudnn::{self, Conv2dBackwardData, Conv2dBackwardFilter, Conv2dForward, CudnnDataType};
+use cudarc::driver::{DeviceRepr, DeviceSlice};
 
 use crate::{
     shapes::*,
-    tensor::{launch_cfg, unique_id, Cuda, Tensor},
+    tensor::{unique_id, Cuda, Tensor},
 };
 
 use std::sync::Arc;
 
 unsafe impl DeviceRepr for super::Conv2DOp {}
-
-const PTX_SRC: &str = include_str!(concat!(env!("OUT_DIR"), "/conv2d.ptx"));
 
 trait HasCudaKernel<E> {
     const MOD: &'static str;
@@ -37,15 +36,15 @@ impl HasCudaKernel<f64> for Cuda {
     ];
 }
 
-fn make_4d<S: Shape>(strides: S::Concrete) -> [usize; 4] {
+fn make_4d<S: Shape>(strides: S::Concrete, pad: usize) -> [usize; 4] {
     match S::NUM_DIMS {
-        3 => [0, strides[0], strides[1], strides[2]],
+        3 => [pad, strides[0], strides[1], strides[2]],
         4 => [strides[0], strides[1], strides[2], strides[3]],
         _ => unreachable!("Only implemented for 3d & 4d arrays"),
     }
 }
 
-impl<E: Dtype + ValidAsZeroBits> super::Conv2DKernel<E> for Cuda
+impl<E: Dtype + CudnnDataType> super::Conv2DKernel<E> for Cuda
 where
     Self: HasCudaKernel<E>,
     CudaBlas: Gemm<E>,
@@ -68,38 +67,48 @@ where
         rhs: &Tensor<R, E, Self>,
         out: &mut Tensor<O, E, Self>,
     ) -> Result<(), Self::Err> {
-        if !self.dev.has_func(Self::MOD, Self::FNS[0]) {
-            self.dev.load_ptx(PTX_SRC.into(), Self::MOD, Self::FNS)?;
-        }
+        let conv = self.cudnn.create_conv2d::<E>(
+            [op.padding as i32, op.padding as i32],
+            [op.stride as i32, op.stride as i32],
+            [1, 1],
+            cudnn::sys::cudnnConvolutionMode_t::CUDNN_CROSS_CORRELATION,
+        )?;
+        let img = self.cudnn.create_tensor4d::<E>(
+            make_4d::<L>(lhs.shape.concrete(), 1).map(|x| x as i32),
+            make_4d::<L>(lhs.strides, 0).map(|x| x as i32),
+        )?;
+        let filter = self.cudnn.create_filter4d::<E>(
+            cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
+            make_4d::<R>(rhs.shape.concrete(), 1).map(|x| x as i32),
+        )?;
+        let y = self.cudnn.create_tensor4d::<E>(
+            make_4d::<O>(out.shape.concrete(), 1).map(|x| x as i32),
+            make_4d::<O>(out.strides, 0).map(|x| x as i32),
+        )?;
+        let op = Conv2dForward {
+            conv,
+            img,
+            filter,
+            y,
+        };
 
-        let patches_item_numel = op.chan_in * op.kernel * op.kernel * op.h_out * op.w_out;
-        let patches_numel = op.batch * patches_item_numel;
+        let algo = op.pick_algorithm()?;
+        let workspace_size_in_bytes = op.get_workspace_size(algo)?;
 
-        let mut patches = unsafe { self.get_workspace::<E>(patches_numel) }?;
-        let mut patches = unsafe { patches.transmute_mut::<E>(patches_numel).unwrap() };
-
-        let img_strides = self.dev.htod_copy(make_4d::<L>(lhs.strides).into())?;
-        let unfold_fn = self.dev.get_func(Self::MOD, Self::FNS[0]).unwrap();
-        let cfg = launch_cfg((op.batch * op.chan_in * op.h_out * op.w_out) as u32);
-        let params = (op, lhs.data.as_ref(), &img_strides, &mut patches);
-        unsafe { unfold_fn.launch(cfg, params) }?;
-
-        // (O, C * K * K) * (B, C * K * K, OH * OW) = (B, O, OH * OW)
-        let m = op.chan_out;
-        let k = op.chan_in * op.kernel * op.kernel;
-        let n = op.h_out * op.w_out;
         unsafe {
-            self.gemm_batch(
-                (op.batch, m, k, n),
+            let mut workspace = self.get_workspace::<u8>(workspace_size_in_bytes)?;
+            let mut workspace = workspace
+                .transmute_mut::<u8>(workspace_size_in_bytes)
+                .unwrap();
+            assert_eq!(workspace.len(), workspace_size_in_bytes);
+            op.launch(
+                algo,
+                Some(&mut workspace),
+                (E::ONE, Default::default()),
+                lhs.data.as_ref(),
                 rhs.data.as_ref(),
-                [0, k, 1],
-                &patches,
-                [k * n, n, 1],
-                Default::default(),
                 Arc::get_mut(&mut out.data).unwrap(),
-                [m * n, n, 1],
-            )
-            .unwrap();
+            )?;
         }
 
         Ok(())
@@ -112,95 +121,82 @@ where
         grad_lhs: &mut Self::Vec<E>,
         rhs: &Tensor<R, E, Self>,
         grad_rhs: &mut Self::Vec<E>,
-        _: &Tensor<O, E, Self>,
+        out: &Tensor<O, E, Self>,
         grad_out: &Self::Vec<E>,
     ) -> Result<(), Self::Err> {
-        let patches_item_numel = op.chan_out * op.kernel * op.kernel * op.h_in * op.w_in;
-        let patches_numel = op.batch * patches_item_numel;
-        let filters_numel = op.chan_in * op.chan_out * op.kernel * op.kernel;
-
-        let mut patches = unsafe { self.get_workspace::<E>(patches_numel) }?;
-        let mut patches = unsafe { patches.transmute_mut::<E>(patches_numel).unwrap() };
-
-        let mut f_b1023 = unsafe { self.dev.alloc::<E>(filters_numel) }?;
-        let mut grad_f_b1023 = unsafe { self.dev.alloc::<E>(op.batch * filters_numel) }?;
-        let f_strides = self.dev.htod_copy(rhs.strides.into())?;
-
-        self.par_stream.wait_for_default()?;
+        let conv = self.cudnn.create_conv2d::<E>(
+            [op.padding as i32, op.padding as i32],
+            [op.stride as i32, op.stride as i32],
+            [1, 1],
+            cudnn::sys::cudnnConvolutionMode_t::CUDNN_CROSS_CORRELATION,
+        )?;
+        let img = self.cudnn.create_tensor4d::<E>(
+            make_4d::<L>(lhs.shape.concrete(), 1).map(|x| x as i32),
+            make_4d::<L>(lhs.strides, 0).map(|x| x as i32),
+        )?;
+        let filter = self.cudnn.create_filter4d::<E>(
+            cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
+            make_4d::<R>(rhs.shape.concrete(), 1).map(|x| x as i32),
+        )?;
+        let out = self.cudnn.create_tensor4d::<E>(
+            make_4d::<O>(out.shape.concrete(), 1).map(|x| x as i32),
+            make_4d::<O>(out.strides, 0).map(|x| x as i32),
+        )?;
 
         {
-            // unfold grad_out into patches
-            let unfold_fn = self.dev.get_func(Self::MOD, Self::FNS[1]).unwrap();
-            let cfg = launch_cfg((op.batch * op.chan_out * op.h_in * op.w_in) as u32);
-            unsafe { unfold_fn.launch(cfg, (op, grad_out, &mut patches)) }?;
-        }
+            let op = Conv2dBackwardData {
+                conv: &conv,
+                dx: &img,
+                filter: &filter,
+                dy: &out,
+            };
+            let algo = op.pick_algorithm()?;
+            let workspace_size_in_bytes = op.get_workspace_size(algo)?;
 
-        {
-            // prepare filters for backward operations by
-            // swapping dims 0 and 1
-            let tr_fn = self.dev.get_func(Self::MOD, Self::FNS[2]).unwrap();
-            let cfg = launch_cfg(rhs.shape.num_elements() as u32);
             unsafe {
-                tr_fn.launch_on_stream(
-                    self.par_stream.as_ref(),
-                    cfg,
-                    (op, rhs.data.as_ref(), &f_strides, &mut f_b1023),
+                let mut workspace = self.get_workspace::<u8>(workspace_size_in_bytes)?;
+                let mut workspace = workspace
+                    .transmute_mut::<u8>(workspace_size_in_bytes)
+                    .unwrap();
+                assert_eq!(workspace.len(), workspace_size_in_bytes);
+                op.launch(
+                    algo,
+                    Some(&mut workspace),
+                    (E::ONE, Default::default()),
+                    grad_lhs,
+                    rhs.data.as_ref(),
+                    grad_out,
                 )
             }?;
-
-            self.par_stream.wait_for_default()?;
-
-            // img_g += filters * patches
-            // (B, C, H * W) += (B, C, O * K * K) * (B, O * K * K, H * W)
-            let m = op.chan_in;
-            let k = op.chan_out * op.kernel * op.kernel;
-            let n = op.h_in * op.w_in;
-            unsafe {
-                self.blas.set_stream(Some(self.par_stream.as_ref()))?;
-                self.gemm_batch(
-                    (op.batch, m, k, n),
-                    &f_b1023,
-                    [0, k, 1],
-                    &patches,
-                    [k * n, n, 1],
-                    <E>::ONE,
-                    grad_lhs,
-                    [m * n, n, 1],
-                )
-                .unwrap();
-                self.blas.set_stream(None)?;
-            }
         }
 
         {
-            // weight_g += img * patches^T
-            // (B, C, O * K * K) += (B, C, H * W) * (B, H * W, O * K * K)
-            let m = op.chan_in;
-            let k = op.h_in * op.w_in;
-            let n = op.chan_out * op.kernel * op.kernel;
+            let op = Conv2dBackwardFilter {
+                conv: &conv,
+                x: &img,
+                dfilter: &filter,
+                dy: &out,
+            };
+
+            let algo = op.pick_algorithm()?;
+            let workspace_size_in_bytes = op.get_workspace_size(algo)?;
+
             unsafe {
-                self.gemm_batch(
-                    (op.batch, m, k, n),
+                let mut workspace = self.get_workspace::<u8>(workspace_size_in_bytes)?;
+                let mut workspace = workspace
+                    .transmute_mut::<u8>(workspace_size_in_bytes)
+                    .unwrap();
+                assert_eq!(workspace.len(), workspace_size_in_bytes);
+                op.launch(
+                    algo,
+                    Some(&mut workspace),
+                    (E::ONE, Default::default()),
                     lhs.data.as_ref(),
-                    [m * k, k, 1],
-                    &patches,
-                    [k * n, 1, k],
-                    Default::default(),
-                    &mut grad_f_b1023,
-                    [m * n, n, 1],
+                    grad_rhs,
+                    grad_out,
                 )
-                .unwrap();
-            }
-
-            // sum all the gradients collected in our broadcasted grad_f
-            // into grad_rhs
-            let sum_fn = self.dev.get_func(Self::MOD, Self::FNS[3]).unwrap();
-            let cfg = launch_cfg(rhs.shape.num_elements() as u32);
-            unsafe { sum_fn.launch(cfg, (op, &grad_f_b1023, grad_rhs, &f_strides)) }?;
+            }?;
         }
-
-        self.dev.wait_for(self.par_stream.as_ref())?;
-
         Ok(())
     }
 }

--- a/src/tensor_ops/conv2d/cuda_kernel.rs
+++ b/src/tensor_ops/conv2d/cuda_kernel.rs
@@ -73,23 +73,23 @@ where
             [1, 1],
             cudnn::sys::cudnnConvolutionMode_t::CUDNN_CROSS_CORRELATION,
         )?;
-        let img = self.cudnn.create_tensor4d::<E>(
+        let img = self.cudnn.create_4d_tensor_ex::<E>(
             make_4d::<L>(lhs.shape.concrete(), 1).map(|x| x as i32),
             make_4d::<L>(lhs.strides, 0).map(|x| x as i32),
         )?;
-        let filter = self.cudnn.create_filter4d::<E>(
+        let filter = self.cudnn.create_4d_filter::<E>(
             cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
             make_4d::<R>(rhs.shape.concrete(), 1).map(|x| x as i32),
         )?;
-        let y = self.cudnn.create_tensor4d::<E>(
+        let y = self.cudnn.create_4d_tensor_ex::<E>(
             make_4d::<O>(out.shape.concrete(), 1).map(|x| x as i32),
             make_4d::<O>(out.strides, 0).map(|x| x as i32),
         )?;
         let op = Conv2dForward {
-            conv,
-            img,
-            filter,
-            y,
+            conv: &conv,
+            x: &img,
+            w: &filter,
+            y: &y,
         };
 
         let algo = op.pick_algorithm()?;
@@ -130,15 +130,15 @@ where
             [1, 1],
             cudnn::sys::cudnnConvolutionMode_t::CUDNN_CROSS_CORRELATION,
         )?;
-        let img = self.cudnn.create_tensor4d::<E>(
+        let img = self.cudnn.create_4d_tensor_ex::<E>(
             make_4d::<L>(lhs.shape.concrete(), 1).map(|x| x as i32),
             make_4d::<L>(lhs.strides, 0).map(|x| x as i32),
         )?;
-        let filter = self.cudnn.create_filter4d::<E>(
+        let filter = self.cudnn.create_4d_filter::<E>(
             cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
             make_4d::<R>(rhs.shape.concrete(), 1).map(|x| x as i32),
         )?;
-        let out = self.cudnn.create_tensor4d::<E>(
+        let out = self.cudnn.create_4d_tensor_ex::<E>(
             make_4d::<O>(out.shape.concrete(), 1).map(|x| x as i32),
             make_4d::<O>(out.strides, 0).map(|x| x as i32),
         )?;
@@ -147,7 +147,7 @@ where
             let op = Conv2dBackwardData {
                 conv: &conv,
                 dx: &img,
-                filter: &filter,
+                w: &filter,
                 dy: &out,
             };
             let algo = op.pick_algorithm()?;
@@ -174,7 +174,7 @@ where
             let op = Conv2dBackwardFilter {
                 conv: &conv,
                 x: &img,
-                dfilter: &filter,
+                dw: &filter,
                 dy: &out,
             };
 

--- a/src/tensor_ops/conv2d/cudnn_kernel.rs
+++ b/src/tensor_ops/conv2d/cudnn_kernel.rs
@@ -1,0 +1,177 @@
+use cudarc::cudnn::{self, Conv2dBackwardData, Conv2dBackwardFilter, Conv2dForward, CudnnDataType};
+use cudarc::driver::DeviceSlice;
+
+use crate::{
+    shapes::*,
+    tensor::{unique_id, Cuda, GhostTensor, Tensor},
+};
+
+use std::sync::Arc;
+
+trait HasCudnnKernel<E> {}
+impl HasCudnnKernel<f32> for Cuda {}
+impl HasCudnnKernel<f64> for Cuda {}
+
+fn make_4d<S: Shape>(strides: S::Concrete, pad: usize) -> [usize; 4] {
+    match S::NUM_DIMS {
+        3 => [pad, strides[0], strides[1], strides[2]],
+        4 => [strides[0], strides[1], strides[2], strides[3]],
+        _ => unreachable!("Only implemented for 3d & 4d arrays"),
+    }
+}
+
+impl<E: Dtype + CudnnDataType> super::Conv2DKernel<E> for Cuda
+where
+    Self: HasCudnnKernel<E>,
+{
+    fn alloc<S: Shape>(&self, shape: S) -> Result<Tensor<S, E, Self>, Self::Err> {
+        let data = Arc::new(unsafe { self.dev.alloc::<E>(shape.num_elements()) }?);
+        Ok(Tensor {
+            id: unique_id(),
+            data,
+            shape,
+            strides: shape.strides(),
+            device: self.clone(),
+            tape: Default::default(),
+        })
+    }
+    fn forward<L: Shape, R: Shape, O: Shape>(
+        &self,
+        op: super::Conv2DOp,
+        lhs: &Tensor<L, E, Self>,
+        rhs: &Tensor<R, E, Self>,
+        out: &mut Tensor<O, E, Self>,
+    ) -> Result<(), Self::Err> {
+        let conv = self.cudnn.create_conv2d::<E>(
+            [op.padding as i32, op.padding as i32],
+            [op.stride as i32, op.stride as i32],
+            [1, 1],
+            cudnn::sys::cudnnConvolutionMode_t::CUDNN_CROSS_CORRELATION,
+        )?;
+        let img = self.cudnn.create_4d_tensor_ex::<E>(
+            make_4d::<L>(lhs.shape.concrete(), 1).map(|x| x as i32),
+            make_4d::<L>(lhs.strides, 0).map(|x| x as i32),
+        )?;
+        let filter = self.cudnn.create_4d_filter::<E>(
+            cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
+            make_4d::<R>(rhs.shape.concrete(), 1).map(|x| x as i32),
+        )?;
+        let y = self.cudnn.create_4d_tensor_ex::<E>(
+            make_4d::<O>(out.shape.concrete(), 1).map(|x| x as i32),
+            make_4d::<O>(out.strides, 0).map(|x| x as i32),
+        )?;
+        let op = Conv2dForward {
+            conv: &conv,
+            x: &img,
+            w: &filter,
+            y: &y,
+        };
+
+        let algo = op.pick_algorithm()?;
+        let workspace_size_in_bytes = op.get_workspace_size(algo)?;
+
+        unsafe {
+            let mut workspace = self.get_workspace::<u8>(workspace_size_in_bytes)?;
+            let mut workspace = workspace
+                .transmute_mut::<u8>(workspace_size_in_bytes)
+                .unwrap();
+            assert_eq!(workspace.len(), workspace_size_in_bytes);
+            op.launch(
+                algo,
+                Some(&mut workspace),
+                (E::ONE, Default::default()),
+                lhs.data.as_ref(),
+                rhs.data.as_ref(),
+                Arc::get_mut(&mut out.data).unwrap(),
+            )?;
+        }
+
+        Ok(())
+    }
+
+    fn backward<L: Shape, R: Shape, O: Shape>(
+        &self,
+        op: super::Conv2DOp,
+        lhs: &Tensor<L, E, Self>,
+        grad_lhs: &mut Self::Vec<E>,
+        rhs: &Tensor<R, E, Self>,
+        grad_rhs: &mut Self::Vec<E>,
+        out: &GhostTensor<O, E, Self>,
+        grad_out: &Self::Vec<E>,
+    ) -> Result<(), Self::Err> {
+        let conv = self.cudnn.create_conv2d::<E>(
+            [op.padding as i32, op.padding as i32],
+            [op.stride as i32, op.stride as i32],
+            [1, 1],
+            cudnn::sys::cudnnConvolutionMode_t::CUDNN_CROSS_CORRELATION,
+        )?;
+        let img = self.cudnn.create_4d_tensor_ex::<E>(
+            make_4d::<L>(lhs.shape.concrete(), 1).map(|x| x as i32),
+            make_4d::<L>(lhs.strides, 0).map(|x| x as i32),
+        )?;
+        let filter = self.cudnn.create_4d_filter::<E>(
+            cudnn::sys::cudnnTensorFormat_t::CUDNN_TENSOR_NCHW,
+            make_4d::<R>(rhs.shape.concrete(), 1).map(|x| x as i32),
+        )?;
+        let out = self.cudnn.create_4d_tensor_ex::<E>(
+            make_4d::<O>(out.shape.concrete(), 1).map(|x| x as i32),
+            make_4d::<O>(out.strides, 0).map(|x| x as i32),
+        )?;
+
+        {
+            let op = Conv2dBackwardData {
+                conv: &conv,
+                dx: &img,
+                w: &filter,
+                dy: &out,
+            };
+            let algo = op.pick_algorithm()?;
+            let workspace_size_in_bytes = op.get_workspace_size(algo)?;
+
+            unsafe {
+                let mut workspace = self.get_workspace::<u8>(workspace_size_in_bytes)?;
+                let mut workspace = workspace
+                    .transmute_mut::<u8>(workspace_size_in_bytes)
+                    .unwrap();
+                assert_eq!(workspace.len(), workspace_size_in_bytes);
+                op.launch(
+                    algo,
+                    Some(&mut workspace),
+                    (E::ONE, Default::default()),
+                    grad_lhs,
+                    rhs.data.as_ref(),
+                    grad_out,
+                )
+            }?;
+        }
+
+        {
+            let op = Conv2dBackwardFilter {
+                conv: &conv,
+                x: &img,
+                dw: &filter,
+                dy: &out,
+            };
+
+            let algo = op.pick_algorithm()?;
+            let workspace_size_in_bytes = op.get_workspace_size(algo)?;
+
+            unsafe {
+                let mut workspace = self.get_workspace::<u8>(workspace_size_in_bytes)?;
+                let mut workspace = workspace
+                    .transmute_mut::<u8>(workspace_size_in_bytes)
+                    .unwrap();
+                assert_eq!(workspace.len(), workspace_size_in_bytes);
+                op.launch(
+                    algo,
+                    Some(&mut workspace),
+                    (E::ONE, Default::default()),
+                    lhs.data.as_ref(),
+                    grad_rhs,
+                    grad_out,
+                )
+            }?;
+        }
+        Ok(())
+    }
+}

--- a/src/tensor_ops/conv2d/mod.rs
+++ b/src/tensor_ops/conv2d/mod.rs
@@ -229,6 +229,7 @@ impl<
 mod tests {
     use super::*;
     use crate::{tensor_ops::*, tests::*};
+    use num_traits::FromPrimitive;
 
     #[test]
     /// Produced by
@@ -437,6 +438,7 @@ mod tests {
         let x = x
             .broadcast::<Rank4<10, 3, 28, 28>, _>()
             .reshape::<Rank4<10, 3, 28, 28>>();
+        assert_eq!(x.strides, x.shape.strides());
 
         let y: Tensor<Rank4<10, 5, 9, 9>, _, _, _> = x.leaky_trace().conv2d::<3, 2>(w.clone());
         for i in 0..10 {
@@ -445,7 +447,7 @@ mod tests {
 
         let grads = y.square().mean().backward();
 
-        assert_close(&w0, &(grads.get(&w)).array());
+        w0.assert_close(&(grads.get(&w)).array(), TestDtype::from_f32(1e-3).unwrap());
 
         let x_grad = grads.get(&x) * 10.0;
         for i in 0..10 {

--- a/src/tensor_ops/conv2d/mod.rs
+++ b/src/tensor_ops/conv2d/mod.rs
@@ -1,7 +1,10 @@
 mod cpu_kernel;
 
-#[cfg(feature = "cuda")]
+#[cfg(all(not(feature = "cudnn"), feature = "cuda"))]
 mod cuda_kernel;
+
+#[cfg(feature = "cudnn")]
+mod cudnn_kernel;
 
 use crate::{shapes::*, tensor::*};
 

--- a/src/tensor_ops/select_and_gather/mod.rs
+++ b/src/tensor_ops/select_and_gather/mod.rs
@@ -214,7 +214,7 @@ mod tests {
         let _ = t.leaky_trace().select(dev.zeros_like(&(7, 4)));
     }
 
-    #[cfg(not(feature = "test-cuda"))]
+    #[cfg(not(feature = "cuda"))]
     #[test]
     #[should_panic = "Index out of bounds: index=[7]"]
     fn test_select_index_out_of_bounds() {
@@ -241,7 +241,7 @@ mod tests {
         let _ = t.leaky_trace().gather(dev.zeros_like(&(5, 4, 2)));
     }
 
-    #[cfg(not(feature = "test-cuda"))]
+    #[cfg(not(feature = "cuda"))]
     #[test]
     #[should_panic = "Index out of bounds: index=[7]"]
     fn test_gather_index_out_of_bounds() {
@@ -250,7 +250,7 @@ mod tests {
         let _ = t.leaky_trace().gather(dev.tensor([7, 6, 1, 2]));
     }
 
-    #[cfg(not(feature = "test-cuda"))]
+    #[cfg(not(feature = "cuda"))]
     #[test]
     #[should_panic = "Index out of bounds: index=[5, 0]"]
     fn test_gather_batch_out_of_bounds() {


### PR DESCRIPTION
Resolves #638
Resolves #527 

TODOS
- Should we optionally enable cudnn?

Timings of `cargo +nightly bench --bench conv2d -F cuda` on an A10

| branch | fwd | bwd |
| --- | --- | --- |
| main | 4.73ms | 20ms |
| this | 2.6ms | 8ms |
