### PR TITLE
Have SplitInto keep tapes of each head seperate

### DIFF
--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -85,7 +85,7 @@ macro_rules! tuple_impls {
     }
 }
 
-tuple_impls!(A [B]);
+tuple_impls!(A[B]);
 tuple_impls!(A [B, C]);
 tuple_impls!(A [B, C, D]);
 tuple_impls!(A [B, C, D, E]);
@@ -109,7 +109,7 @@ mod tests {
         let gr = right.mean().backward();
         let l = left.retaped::<NoneTape>();
         let gl = left.mean().backward();
-        assert_eq!(gl.get(&l).array(), [1.0; 1]);
+        assert_ne!(gl.get(&l).array(), [0.0; 1]);
         assert_ne!(gr.get(&r).array(), [0.0; 1]);
     }
 

--- a/src/nn/split_into.rs
+++ b/src/nn/split_into.rs
@@ -8,6 +8,9 @@ use super::*;
 /// This provides a utility for multi headed structures where
 /// the tape needs to be moved around a number of times.
 ///
+/// Each head's operations will be stored in its output's tape, while the operations stored in the
+/// input tape will be saved in the first output's tape.
+///
 /// # Generics
 /// - `T` the module to split the input into.
 ///
@@ -37,62 +40,56 @@ impl<E: Dtype, D: Device<E>, T: TensorCollection<E, D>> TensorCollection<E, D> f
 }
 
 macro_rules! tuple_impls {
-    ([$($heads:ident),+] $tail:ident) => {
-impl<
-    Input: SplitTape,
-    $($heads : Module<Input, Error = $tail::Error>,)+
-    $tail: Module<Input>
-> Module<Input> for SplitInto<($($heads,)+ $tail)>
-where
-    $($heads::Output: SplitTape<Tape = Input::Tape>,)+
-{
-    type Output = (
-        $(<$heads::Output as SplitTape>::NoTape, )+
-        $tail::Output
-    );
-    type Error = $tail::Error;
+    ($head:ident [$($tails:ident),+]) => {
+        impl<
+            Input: WithEmptyTape,
+            $head: Module<Input>,
+            $($tails : Module<Input, Error = $head::Error>,)+
+        > Module<Input> for SplitInto<($head, $($tails,)+)> {
+            type Output = (
+                $head::Output,
+                $($tails::Output),+
+            );
+            type Error = $head::Error;
 
-    #[allow(non_snake_case)]
-    fn try_forward(&self, x: Input) -> Result<Self::Output, $tail::Error> {
-        let (x, tape) = x.split_tape();
-        let ($($heads, )+ $tail) = &self.0;
-        $(let ($heads, tape) = $heads.try_forward(x.clone().put_tape(tape))?.split_tape();)+
-        let $tail = $tail.try_forward(x.put_tape(tape))?;
-        Ok(($($heads,)+ $tail))
+            #[allow(non_snake_case)]
+            fn try_forward(&self, x: Input) -> Result<Self::Output, $head::Error> {
+                let ($head, $($tails,)+) = &self.0;
+                let ($($tails,)+) = ($($tails.try_forward(x.with_empty_tape())?,)+);
+                let $head = $head.try_forward(x)?;
+
+                Ok(($head, $($tails,)+))
+            }
+        }
+
+        impl<
+            Input: WithEmptyTape,
+            $head: ModuleMut<Input>,
+            $($tails : ModuleMut<Input, Error = $head::Error>,)+
+        > ModuleMut<Input> for SplitInto<($head, $($tails,)+)> {
+            type Output = (
+                $head::Output,
+                $($tails::Output),+
+            );
+            type Error = $head::Error;
+
+            #[allow(non_snake_case)]
+            fn try_forward_mut(&mut self, x: Input) -> Result<Self::Output, $head::Error> {
+                let ($head, $($tails,)+) = &mut self.0;
+                let ($($tails,)+) = ($($tails.try_forward_mut(x.with_empty_tape())?,)+);
+                let $head = $head.try_forward_mut(x)?;
+
+                Ok(($head, $($tails,)+))
+            }
+        }
     }
 }
 
-impl<
-    Input: SplitTape,
-    $($heads : ModuleMut<Input, Error = $tail::Error>,)+
-    $tail: ModuleMut<Input>
-> ModuleMut<Input> for SplitInto<($($heads,)+ $tail)>
-where
-    $($heads::Output: SplitTape<Tape = Input::Tape>,)+
-{
-    type Output = (
-        $(<$heads::Output as SplitTape>::NoTape, )+
-        $tail::Output
-    );
-    type Error = $tail::Error;
-
-    #[allow(non_snake_case)]
-    fn try_forward_mut(&mut self, x: Input) -> Result<Self::Output, $tail::Error> {
-        let (x, tape) = x.split_tape();
-        let ($($heads, )+ $tail) = &mut self.0;
-        $(let ($heads, tape) = $heads.try_forward_mut(x.clone().put_tape(tape))?.split_tape();)+
-        let $tail = $tail.try_forward_mut(x.put_tape(tape))?;
-        Ok(($($heads,)+ $tail))
-    }
-}
-}
-}
-
-tuple_impls!([A] B);
-tuple_impls!([A, B] C);
-tuple_impls!([A, B, C] D);
-tuple_impls!([A, B, C, D] E);
-tuple_impls!([A, B, C, D, E] F);
+tuple_impls!(A [B]);
+tuple_impls!(A [B, C]);
+tuple_impls!(A [B, C, D]);
+tuple_impls!(A [B, C, D, E]);
+tuple_impls!(A [B, C, D, E, F]);
 
 #[cfg(test)]
 mod tests {
@@ -109,9 +106,11 @@ mod tests {
         let m = dev.build_module::<Model, TestDtype>();
         let (left, right) = m.forward(dev.sample_normal::<Rank1<1>>().leaky_trace());
         let r = right.retaped::<NoneTape>();
-        let g = right.mean().backward();
-        assert_eq!(g.get(&left).array(), [0.0; 1]);
-        assert_ne!(g.get(&r).array(), [0.0; 1]);
+        let gr = right.mean().backward();
+        let l = left.retaped::<NoneTape>();
+        let gl = left.mean().backward();
+        assert_eq!(gl.get(&l).array(), [1.0; 1]);
+        assert_ne!(gr.get(&r).array(), [0.0; 1]);
     }
 
     #[test]
@@ -120,11 +119,11 @@ mod tests {
         type Model = SplitInto<(Linear<5, 1>, Linear<5, 2>)>;
         let m = dev.build_module::<Model, TestDtype>();
         let _: (
-            Tensor<Rank1<1>, _, _>,
+            Tensor<Rank1<1>, _, _, OwnedTape<_, _>>,
             Tensor<Rank1<2>, _, _, OwnedTape<_, _>>,
         ) = m.forward(dev.zeros::<Rank1<5>>().leaky_traced());
         let _: (
-            Tensor<Rank2<3, 1>, _, _>,
+            Tensor<Rank2<3, 1>, _, _, OwnedTape<_, _>>,
             Tensor<Rank2<3, 2>, _, _, OwnedTape<_, _>>,
         ) = m.forward(dev.zeros::<Rank2<3, 5>>().leaky_traced());
     }
@@ -135,13 +134,13 @@ mod tests {
         type Model = SplitInto<(Linear<5, 1>, Linear<5, 2>, Linear<5, 3>)>;
         let m = dev.build_module::<Model, TestDtype>();
         let _: (
-            Tensor<Rank1<1>, _, _>,
-            Tensor<Rank1<2>, _, _>,
+            Tensor<Rank1<1>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank1<2>, _, _, OwnedTape<_, _>>,
             Tensor<Rank1<3>, _, _, OwnedTape<_, _>>,
         ) = m.forward(dev.zeros::<Rank1<5>>().leaky_traced());
         let _: (
-            Tensor<Rank2<3, 1>, _, _>,
-            Tensor<Rank2<3, 2>, _, _>,
+            Tensor<Rank2<3, 1>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank2<3, 2>, _, _, OwnedTape<_, _>>,
             Tensor<Rank2<3, 3>, _, _, OwnedTape<_, _>>,
         ) = m.forward(dev.zeros::<Rank2<3, 5>>().leaky_traced());
     }
@@ -152,15 +151,15 @@ mod tests {
         type Model = SplitInto<(Linear<5, 1>, Linear<5, 2>, Linear<5, 3>, Linear<5, 4>)>;
         let m = dev.build_module::<Model, TestDtype>();
         let _: (
-            Tensor<Rank1<1>, _, _>,
-            Tensor<Rank1<2>, _, _>,
-            Tensor<Rank1<3>, _, _>,
+            Tensor<Rank1<1>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank1<2>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank1<3>, _, _, OwnedTape<_, _>>,
             Tensor<Rank1<4>, _, _, OwnedTape<_, _>>,
         ) = m.forward(dev.zeros::<Rank1<5>>().leaky_traced());
         let _: (
-            Tensor<Rank2<3, 1>, _, _>,
-            Tensor<Rank2<3, 2>, _, _>,
-            Tensor<Rank2<3, 3>, _, _>,
+            Tensor<Rank2<3, 1>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank2<3, 2>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank2<3, 3>, _, _, OwnedTape<_, _>>,
             Tensor<Rank2<3, 4>, _, _, OwnedTape<_, _>>,
         ) = m.forward(dev.zeros::<Rank2<3, 5>>().leaky_traced());
     }
@@ -177,17 +176,17 @@ mod tests {
         )>;
         let m = dev.build_module::<Model, TestDtype>();
         let _: (
-            Tensor<Rank1<1>, _, _>,
-            Tensor<Rank1<2>, _, _>,
-            Tensor<Rank1<3>, _, _>,
-            Tensor<Rank1<4>, _, _>,
+            Tensor<Rank1<1>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank1<2>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank1<3>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank1<4>, _, _, OwnedTape<_, _>>,
             Tensor<Rank1<5>, _, _, OwnedTape<_, _>>,
         ) = m.forward(dev.zeros::<Rank1<5>>().leaky_traced());
         let _: (
-            Tensor<Rank2<3, 1>, _, _>,
-            Tensor<Rank2<3, 2>, _, _>,
-            Tensor<Rank2<3, 3>, _, _>,
-            Tensor<Rank2<3, 4>, _, _>,
+            Tensor<Rank2<3, 1>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank2<3, 2>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank2<3, 3>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank2<3, 4>, _, _, OwnedTape<_, _>>,
             Tensor<Rank2<3, 5>, _, _, OwnedTape<_, _>>,
         ) = m.forward(dev.zeros::<Rank2<3, 5>>().leaky_traced());
     }
@@ -205,19 +204,19 @@ mod tests {
         )>;
         let m = dev.build_module::<Model, TestDtype>();
         let _: (
-            Tensor<Rank1<1>, _, _>,
-            Tensor<Rank1<2>, _, _>,
-            Tensor<Rank1<3>, _, _>,
-            Tensor<Rank1<4>, _, _>,
-            Tensor<Rank1<5>, _, _>,
+            Tensor<Rank1<1>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank1<2>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank1<3>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank1<4>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank1<5>, _, _, OwnedTape<_, _>>,
             Tensor<Rank1<6>, _, _, OwnedTape<_, _>>,
         ) = m.forward(dev.zeros::<Rank1<5>>().leaky_traced());
         let _: (
-            Tensor<Rank2<3, 1>, _, _>,
-            Tensor<Rank2<3, 2>, _, _>,
-            Tensor<Rank2<3, 3>, _, _>,
-            Tensor<Rank2<3, 4>, _, _>,
-            Tensor<Rank2<3, 5>, _, _>,
+            Tensor<Rank2<3, 1>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank2<3, 2>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank2<3, 3>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank2<3, 4>, _, _, OwnedTape<_, _>>,
+            Tensor<Rank2<3, 5>, _, _, OwnedTape<_, _>>,
             Tensor<Rank2<3, 6>, _, _, OwnedTape<_, _>>,
         ) = m.forward(dev.zeros::<Rank2<3, 5>>().leaky_traced());
     }


### PR DESCRIPTION
Changes the behavior of SplitInto to propagate the tape of the input to the output of the first head, and to keep the operations of each head in its respective output.