### PR TITLE
Refactors TryMatmuls for better error messages when dimensions don't match

### DIFF
--- a/examples/02-ops.rs
+++ b/examples/02-ops.rs
@@ -3,7 +3,7 @@
 use dfdx::{
     shapes::{Rank0, Rank1, Rank2},
     tensor::{AsArray, AutoDevice, SampleTensor, Tensor},
-    tensor_ops::{MeanTo, TryMatMul},
+    tensor_ops::{MeanTo, TryStaticMatMul},
 };
 
 fn main() {

--- a/examples/03-nn.rs
+++ b/examples/03-nn.rs
@@ -33,7 +33,7 @@ fn main() {
 
     // Even dynamic size is supported;
     let batch_size = 3;
-    let _: Tensor<(usize, Const<2>), f32, _> = m.forward(dev.zeros_like(&(batch_size, Const)));
+    let _: Tensor<(usize, Const<2>), f32, _> = m.forward(dev.zeros_like(&(batch_size, Const::<2>)));
 
     // you can also combine multiple modules with tuples
     type Mlp = (Linear<4, 2>, ReLU, Linear<2, 1>);

--- a/examples/04-gradients.rs
+++ b/examples/04-gradients.rs
@@ -4,7 +4,7 @@ use dfdx::{
     nn::ZeroGrads,
     shapes::{Rank0, Rank2},
     tensor::{AsArray, AutoDevice, Gradients, NoneTape, OwnedTape, SampleTensor, Tensor, Trace},
-    tensor_ops::{Backward, MeanTo, TryMatMul},
+    tensor_ops::{Backward, MeanTo, TryStaticMatMul},
 };
 
 fn main() {

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -127,11 +127,11 @@ where
 
         // Get weights
         let scalar: E = E::ONE / E::from_usize(K / H).unwrap().sqrt();
-        let weights = q.try_matmul(k)?.try_mul(scalar)?;
+        let weights = q.try_dynamic_matmul(k)?.try_mul(scalar)?;
         let weights = weights.try_softmax::<Axis<2>>()?;
 
         // Get new tokens
-        let tokens = weights.try_matmul(v)?;
+        let tokens = weights.try_dynamic_matmul(v)?;
         let tokens = tokens.try_permute::<_, Axes3<1, 0, 2>>()?;
         let tokens = tokens.try_reshape_like(&(s1, Const::<V>)).unwrap()?;
 
@@ -187,11 +187,11 @@ where
 
         // Get weights
         let scalar: E = E::ONE / E::from_usize(K / H).unwrap().sqrt();
-        let weights = q.try_matmul(k)?.try_mul(scalar)?;
+        let weights = q.try_dynamic_matmul(k)?.try_mul(scalar)?;
         let weights = weights.try_softmax::<Axis<3>>()?;
 
         // Get new tokens
-        let tokens = weights.try_matmul(v)?;
+        let tokens = weights.try_dynamic_matmul(v)?;
         let tokens = tokens.try_permute::<_, Axes4<0, 2, 1, 3>>()?;
         let tokens = tokens.try_reshape_like(&(b, s1, Const::<V>)).unwrap()?;
 

--- a/src/nn/unbiased_linear.rs
+++ b/src/nn/unbiased_linear.rs
@@ -79,7 +79,7 @@ impl<const I: usize, const O: usize, E: Dtype + Float + SampleUniform, D: Device
 impl<const I: usize, const O: usize, E: Dtype, D: Device<E>, T> Module<T>
     for UnbiasedLinear<I, O, E, D>
 where
-    T: SplitTape + TryMatMul<Tensor<Rank2<I, O>, E, D, T::Tape>> + HasErr<Err = D::Err>,
+    T: SplitTape + TryStaticMatMul<Tensor<Rank2<I, O>, E, D, T::Tape>> + HasErr<Err = D::Err>,
     T::Tape: Tape<E, D>,
 {
     type Output = T::Output;

--- a/src/tensor_ops/mod.rs
+++ b/src/tensor_ops/mod.rs
@@ -221,7 +221,7 @@ pub use huber_error::huber_error;
 pub use ln::ln;
 pub use log_softmax::log_softmax;
 pub use logsumexp_to::LogSumExpTo;
-pub use matmul::{matmul, TryMatMul};
+pub use matmul::{matmul, TryDynamicMatMul, TryDynamicMatMul1, TryStaticMatMul};
 pub use max_to::MaxTo;
 pub use maximum::maximum;
 pub use mean_to::MeanTo;

--- a/src/tensor_ops/utilities/device.rs
+++ b/src/tensor_ops/utilities/device.rs
@@ -42,11 +42,14 @@ pub trait Device<E: Dtype>:
 
     // matmuls
     + super::super::matmul::VecMatKernel<E>
-    + super::super::matmul::MatMatKernel<E>
+    + super::super::matmul::StaticMatMatKernel<E>
     + super::super::matmul::VecVecKernel<E>
     + super::super::matmul::MatMatBrKernel<E>
-    + super::super::matmul::MatMatBatch3Kernel<E>
-    + super::super::matmul::MatMatBatch4Kernel<E>
+    + super::super::matmul::StaticMatMatBatch3Kernel<E>
+    + super::super::matmul::DynamicMatMatBatch3Kernel<E>
+    + super::super::matmul::StaticMatMatBatch4Kernel<E>
+    + super::super::matmul::DynamicMatMatBatch4Kernel<E>
+    + super::super::matmul::DynamicMatMatBatch4Kernel1<E>
 
     // scalar arithmetic
     + UnaryKernel<super::super::add::ScalarAddKernelOp<E>, E>


### PR DESCRIPTION
I haven't synced the branch yet with all the recent commits, but will of course do if this works out in the end.

So, I tried to move more of the dynamic dim checks into the respective traits before pushing, and now I need to split the traits and ops even more for stuff to work inside `mha.rs`. So, unless I "turn off" the dynamic checks as in e.g. `where
        (B, S1, usize): MulDynamicDimCheck<(B, usize, S2)>;`  (and apart from tests inside mod.rs needing to be fixed in any case), multiheaded attentions still spits out errors.
        
Just so that you don't get completely lost in the mess that I have pushed, a quick summary of what I am doing:

1. Replacing all the trymatmuls `TryMatMul<M,K,N>` from assuming that the crucial dim `K` is always common between the two tensors, into `TryMatMul<M, LeftK, RightK, N>`, so that we can make the dim checks with the respective trait. This would already work quite good, but with dynamic dims we need to split into static or dynamic traits, depending on whether K is static or dynamic (the dynamic part mostly because of transformers).
2. Splitting all kernels and ops into more variations so that we are able to implement the checks for different combinations of shapes, e.g when trying to check different combinations within the same trait:

```
impl<B: Dim, S1: Dim, S2: Dim> MulDynamicDimCheck<(B, usize, usize, S2)> for (B, usize, S1, usize) {
    fn assert_dim_eq(&self, rhs: &(B, usize, usize, S2)) {
        assert_eq!(self.1, rhs.1);
        assert_eq!(self.3, rhs.2);
    }
}

impl<B: Dim, S1: Dim, S2: Dim> MulDynamicDimCheck<(B, usize, S2, usize)> for (B, usize, S1, S2) {
    fn assert_dim_eq(&self, rhs: &(B, usize, S1, S2)) {
        assert_eq!(self.1, rhs.1);
    }
}
```

we get conflict errors:

```
--> src\tensor_ops\matmul\mod.rs:277:1
    |
270 | impl<B: Dim, S1: Dim, S2: Dim> MulDynamicDimCheck<(B, usize, usize, S2)> for (B, usize, S1, usize) {
    | -------------------------------------------------------------------------------------------------- first implementation here
...
277 | impl<B: Dim, S1: Dim, S2: Dim> MulDynamicDimCheck<(B, usize, S2, usize)> for (B, usize, S1, S2) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(_, usize, _, usize)`
```

I have also probably forgotten to implement some stuff while lost in the splitting of traits. All the implementations that I have commented out more or less need new variations of the traits for them to work.

It would be great if we could find a nicer (and more maintainable way) to get over this, because the errors now look quite good and informative (already tested for the static cases and some dynamic cases).