### PR TITLE
feat: use `Cow` when appropriate

### DIFF
--- a/src/tensor_ops/pow/cuda_kernel.rs
+++ b/src/tensor_ops/pow/cuda_kernel.rs
@@ -24,7 +24,7 @@ where
     fn forward<S: Shape>(
         &self,
         op: super::PowiKernelOp,
-        inp: Result<&Tensor<S, E, Self>, Tensor<S, E, Self>>,
+        inp: Cow<Tensor<S, E, Self>>,
     ) -> Result<Tensor<S, E, Self>, Self::Err> {
         self.forward(super::PowfKernelOp(E::from_i32(op.0).unwrap()), inp)
     }

--- a/src/tensor_ops/pow/cuda_kernel.rs
+++ b/src/tensor_ops/pow/cuda_kernel.rs
@@ -4,6 +4,7 @@ use crate::{
     tensor::*,
     tensor_ops::{cuda_kernels::cuda_unary, ops::UnaryKernel},
 };
+use std::borrow::Cow;
 
 unsafe impl cudarc::driver::DeviceRepr for super::PowfKernelOp<f32> {}
 unsafe impl cudarc::driver::DeviceRepr for super::PowfKernelOp<f64> {}

--- a/src/tensor_ops/utilities/cuda_kernels.rs
+++ b/src/tensor_ops/utilities/cuda_kernels.rs
@@ -66,7 +66,7 @@ impl<E: Dtype, K: UnaryOpCudaKernel<E> + DeviceRepr> UnaryKernel<K, E> for Cuda 
     fn forward<S: Shape>(
         &self,
         op: K,
-        inp: Result<&Tensor<S, E, Self>, Tensor<S, E, Self>>,
+        inp: Cow<Tensor<S, E, Self>>,
     ) -> Result<Tensor<S, E, Self>, Self::Err> {
         if !self.dev.has_func(K::MODULE_NAME, K::FWD_FN_NAME) {
             self.dev
@@ -225,8 +225,8 @@ impl<E: Dtype, K: BinaryOpCudaKernel<E> + DeviceRepr + Clone> BinaryKernel<K, E>
     fn forward<S: Shape>(
         &self,
         op: K,
-        lhs: Result<&Tensor<S, E, Self>, Tensor<S, E, Self>>,
-        rhs: Result<&Tensor<S, E, Self>, Tensor<S, E, Self>>,
+        lhs: Cow<Tensor<S, E, Self>>,
+        rhs: Cow<Tensor<S, E, Self>>,
     ) -> Result<Tensor<S, E, Self>, Self::Err> {
         if !self.dev.has_func(K::MODULE_NAME, K::FWD_FN_NAME) {
             self.dev

--- a/src/tensor_ops/utilities/cuda_kernels.rs
+++ b/src/tensor_ops/utilities/cuda_kernels.rs
@@ -4,7 +4,7 @@ use crate::{
     tensor_ops::ops::{BinaryKernel, UnaryKernel},
 };
 use cudarc::driver::{DeviceRepr, DeviceSlice, LaunchAsync};
-use std::{sync::Arc, vec::Vec};
+use std::{borrow::Cow, sync::Arc, vec::Vec};
 
 pub trait UnaryOpCudaKernel<E> {
     const DF_USES_FX: bool;


### PR DESCRIPTION
# Description

Some tensor ops use `Result<Borrowed, Owned>` when a `Cow` would be more idiomatic. This fixes those instances.