### PR TITLE
(feat) add device access method

### DIFF
--- a/src/tensor/tensor_impls.rs
+++ b/src/tensor/tensor_impls.rs
@@ -111,6 +111,11 @@ impl<S: Shape, E: Unit, D: DeviceStorage, T> Tensor<S, E, D, T> {
             tape: Default::default(),
         }
     }
+
+    /// Get a reference to the tensor's `DeviceStorage`
+    pub fn device(&self) -> &D {
+        return &self.device;
+    }
 }
 
 /// Put a tape of type `T` into the tensor

--- a/src/tensor/tensor_impls.rs
+++ b/src/tensor/tensor_impls.rs
@@ -114,7 +114,7 @@ impl<S: Shape, E: Unit, D: DeviceStorage, T> Tensor<S, E, D, T> {
 
     /// Get a reference to the tensor's `DeviceStorage`
     pub fn device(&self) -> &D {
-        return &self.device;
+        &self.device
     }
 }
 


### PR DESCRIPTION
Returns a reference to the tensor's DeviceStorage

Motivation: create new tensors in forward pass

Example:
```rs
fn try_forward(&self, input: ...) {
    let new_tensor: Tensor<Rank2<10, 5>, E, D> = input.device().zeros();
    ....
}
```

