### PR TITLE
Add examples of runtime dimensions to `examples/02-ops.rs`

### DIFF
--- a/examples/01-tensor.rs
+++ b/examples/01-tensor.rs
@@ -3,6 +3,7 @@
 use dfdx::{
     shapes::{Const, Rank1, Rank2, Rank3},
     tensor::{AsArray, OnesTensor, SampleTensor, Tensor, TensorFrom, ZerosTensor},
+    tensor_ops::RealizeTo,
 };
 
 #[cfg(not(feature = "cuda"))]
@@ -34,6 +35,11 @@ fn main() {
     let _: Tensor<(usize, usize), f32, _> = dev.zeros_like(&(2, 4));
     let _: Tensor<(usize, usize, usize), f32, _> = dev.ones_like(&(3, 4, 5));
     let _: Tensor<(usize, usize, Const<5>), f32, _> = dev.ones_like(&(3, 4, Const));
+
+    // `realize` method helps us move between dynamic and known size for the dimensions,
+    // if the conversion is incompatible, it may result in runtime error
+    let a: Tensor<(usize, usize), f32, _> = dev.zeros_like(&(2, 3));
+    let _: Tensor<(usize, Const<3>), f32, _> = a.realize().expect("`a` should have 3 columns");
 
     // each of the creation methods also supports specifying the shape on the function
     // note to change the dtype we specify the dtype as the 2nd generic parameter

--- a/examples/02-ops.rs
+++ b/examples/02-ops.rs
@@ -1,9 +1,9 @@
 //! Intro to dfdx::tensor_ops
 
 use dfdx::{
-    shapes::{Rank0, Rank1, Rank2},
+    shapes::{Const, Rank0, Rank1, Rank2},
     tensor::{AsArray, AutoDevice, SampleTensor, Tensor},
-    tensor_ops::{MeanTo, TryMatMul},
+    tensor_ops::{MeanTo, RealizeTo, TryMatMul},
 };
 
 fn main() {
@@ -42,11 +42,21 @@ fn main() {
         .powf(0.5)
         / 2.0;
 
+    // binary and unary operations can also be performed on dynamically sized tensors
+    let mut a: Tensor<(Const<3>, usize), f32, _> = dev.sample_uniform_like(&(Const, 5));
+    a = a + 0.5;
+    let b: Tensor<(usize, Const<5>), f32, _> = dev.sample_uniform_like(&(3, Const));
+    // note the use of `realize`
+    let _: Tensor<(Const<3>, usize), f32, _> = a + b.realize().expect("`b` should have 3 rows");
+
     // then we have things like matrix and vector multiplication:
-    let a: Tensor<Rank2<3, 5>, f32, _> = dev.sample_normal();
-    let b: Tensor<Rank2<5, 7>, f32, _> = dev.sample_normal();
-    let c = a.matmul(b);
-    dbg!(c.array());
+    let a: Tensor<(usize, Const<5>), f32, _> = dev.sample_normal_like(&(3, Const));
+    let b: Tensor<(usize, usize), f32, _> = dev.sample_normal_like(&(5, 7));
+    // if type inference is not possible, we explicitly provide the shape for `realize`
+    let _: Tensor<(usize, usize), f32, _> = a.matmul(
+        b.realize::<(Const<5>, usize)>()
+            .expect("`b` should have 5 rows"),
+    );
 
     // which even the outer product between two vectors!
     let a: Tensor<Rank1<3>, f32, _> = dev.sample_normal();


### PR DESCRIPTION
Resolves #593,

I have mostly followed the instructions in #593, the only deviation is introducing a `realize` example in `01-tensor.rs`, thought this will be a prerequisite to understand the new examples in `02-ops.rs`.