### PR TITLE
Optimize chunk reduction algorithms

### DIFF
--- a/src/tensor_ops/max_to/max_to.cu
+++ b/src/tensor_ops/max_to/max_to.cu
@@ -40,13 +40,12 @@ __device__ void chunk_max(
     unsigned int chunk_start = max((int)(warp_i - chunk_i), 0);
     unsigned int chunk_end = min((unsigned int)(warp_i + chunk_len - chunk_i), warpSize);
 
-    unsigned int mask = (1 << chunk_end) - (1 << chunk_start);
     unsigned int tail = chunk_end - warp_i;
     T tmp;
 
     for (unsigned int j = 16; j > 0; j /= 2) {
         // get data from thread (warp_i + j)
-        tmp = __shfl_down_sync(mask, data, j);
+        tmp = __shfl_down_sync(SHFL_MASK, data, j);
         // optimized version of (warp_i + j < chunk_end) 
         if (j < tail) {
             data = max(data, tmp);

--- a/src/tensor_ops/max_to/max_to.cu
+++ b/src/tensor_ops/max_to/max_to.cu
@@ -22,44 +22,39 @@ __device__ __forceinline__ double atomicMaxf(double * addr, double value) {
 // stores the maximums in out[i / chunk_len]
 template<typename T>
 __device__ void chunk_max(
-    const size_t numel,
     const size_t chunk_len,
-    const T data,
+    T data,
     T* out
 ) {
-    __shared__ T buf[1024];
     // assumes that threads where i >= numel have already exited
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-    unsigned int block_i = threadIdx.x;
-    buf[block_i] = data;
+    unsigned int warp_i = i % warpSize;
 
-    unsigned int chunk_i = i % chunk_len;
-    unsigned int chunk_start = max((int)(block_i - chunk_i), 0);
-    unsigned int chunk_end = min((unsigned int)(block_i + chunk_len - chunk_i), blockDim.x);
-
-    chunk_i = block_i - chunk_start;
-
-    size_t max_chunk_len = min(chunk_end - chunk_start, blockDim.x);
-    size_t incr = next_power_of_two(max_chunk_len) >> 1;
-
-    __syncthreads();
-
-    // Uses sequential addressing as discussed in
-    // https://developer.download.nvidia.com/assets/cuda/files/reduction.pdf
-    for (; incr > 0; incr >>= 1) {
-        unsigned int block_i_2 = block_i + incr;
-
-        if (block_i_2 < chunk_end && chunk_i < incr) {
-            // This is sound because __syncthreads and the conditions above
-            // ensure that no data races occur
-            buf[block_i] = maxg(buf[block_i], buf[block_i_2]);
-        }
-
-        __syncthreads();
+    // Fall back to atomicMaxf if chunk_len is small to reduce overhead
+    if (chunk_len <= 4) {
+        atomicMaxf(out + i / chunk_len, data);
+        return;
     }
 
-    if (block_i == chunk_start) {
-        atomicMaxf(out + i / chunk_len, buf[block_i]);
+    unsigned int chunk_i = i % chunk_len;
+    unsigned int chunk_start = max((int)(warp_i - chunk_i), 0);
+    unsigned int chunk_end = min((unsigned int)(warp_i + chunk_len - chunk_i), warpSize);
+
+    unsigned int mask = (1 << chunk_end) - (1 << chunk_start);
+    unsigned int tail = chunk_end - warp_i;
+    T tmp;
+
+    for (unsigned int j = 16; j > 0; j /= 2) {
+        // get data from thread (warp_i + j)
+        tmp = __shfl_down_sync(mask, data, j);
+        // optimized version of (warp_i + j < chunk_end) 
+        if (j < tail) {
+            data = max(data, tmp);
+        }
+    }
+
+    if (warp_i == chunk_start) {
+        atomicMaxf(out + i / chunk_len, data);
     }
 }
 
@@ -84,7 +79,7 @@ __device__ void max_to_fwd(
     const size_t *strides = info + num_dims;
 
     unsigned int inp_i = get_strided_index(i, num_dims, dims, strides);
-    chunk_max(numel, chunk_len, inp[inp_i], out);
+    chunk_max(chunk_len, inp[inp_i], out);
 }
 
 // Accepts pre-broadcasted strides for both input & output.

--- a/src/tensor_ops/min_to/min_to.cu
+++ b/src/tensor_ops/min_to/min_to.cu
@@ -40,13 +40,12 @@ __device__ void chunk_min(
     unsigned int chunk_start = max((int)(warp_i - chunk_i), 0);
     unsigned int chunk_end = min((unsigned int)(warp_i + chunk_len - chunk_i), warpSize);
 
-    unsigned int mask = (1 << chunk_end) - (1 << chunk_start);
     unsigned int tail = chunk_end - warp_i;
     T tmp;
 
     for (unsigned int j = 16; j > 0; j /= 2) {
         // get data from thread (warp_i + j)
-        tmp = __shfl_down_sync(mask, data, j);
+        tmp = __shfl_down_sync(SHFL_MASK, data, j);
         // optimized version of (warp_i + j < chunk_end) 
         if (j < tail) {
             data = min(data, tmp);

--- a/src/tensor_ops/utilities/cuda_utils.cuh
+++ b/src/tensor_ops/utilities/cuda_utils.cuh
@@ -44,52 +44,96 @@ __device__ __forceinline__ unsigned int next_power_of_two(unsigned int v) {
 
 // Efficiently computes the sum of each chunk in "data" of size chunk_len, and
 // stores the sums in out[i / chunk_len]
+// template<typename T>
+// __device__ void chunk_sum(
+    // const size_t chunk_len,
+    // const T data,
+    // T* out
+// ) {
+    // __shared__ T buf[1024];
+
+    // // assumes that threads where i >= numel have already exited
+    // unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
+    // unsigned int block_i = threadIdx.x;
+
+    // // Fall back to atomicAdd if chunk_len is small to reduce overhead
+    // if (chunk_len <= 3) {
+        // atomicAdd(out + i / chunk_len, data);
+        // return;
+    // }
+    // buf[block_i] = data;
+
+    // unsigned int chunk_i = i % chunk_len;
+    // unsigned int chunk_start = max((int)(block_i - chunk_i), 0);
+    // unsigned int chunk_end = min((unsigned int)(block_i + chunk_len - chunk_i), blockDim.x);
+
+    // chunk_i = block_i - chunk_start;
+
+    // size_t max_chunk_len = min(chunk_end - chunk_start, blockDim.x);
+    // size_t incr = next_power_of_two(max_chunk_len) >> 1;
+
+    // __syncthreads();
+
+    // // Uses sequential addressing as discussed in
+    // // https://developer.download.nvidia.com/assets/cuda/files/reduction.pdf
+    // for (; incr > 0; incr >>= 1) {
+        // unsigned int block_i_2 = block_i + incr;
+
+        // if (block_i_2 < chunk_end && chunk_i < incr) {
+            // // This is sound because __syncthreads and the conditions above
+            // // ensure that no data races occur
+            // buf[block_i] += buf[block_i_2];
+        // }
+
+        // __syncthreads();
+    // }
+
+    // if (block_i == chunk_start) {
+        // atomicAdd(out + i / chunk_len, buf[block_i]);
+    // }
+// }
+
 template<typename T>
 __device__ void chunk_sum(
     const size_t chunk_len,
-    const T data,
+    T data,
     T* out
 ) {
-    __shared__ T buf[1024];
+    __shared__ T buf[16];
 
     // assumes that threads where i >= numel have already exited
     unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-    unsigned int block_i = threadIdx.x;
+    unsigned int warp_i = i % warpSize;
 
     // Fall back to atomicAdd if chunk_len is small to reduce overhead
-    if (chunk_len <= 2) {
+    if (chunk_len <= 4) {
         atomicAdd(out + i / chunk_len, data);
         return;
     }
-    buf[block_i] = data;
 
     unsigned int chunk_i = i % chunk_len;
-    unsigned int chunk_start = max((int)(block_i - chunk_i), 0);
-    unsigned int chunk_end = min((unsigned int)(block_i + chunk_len - chunk_i), blockDim.x);
+    unsigned int chunk_start = max((int)(warp_i - chunk_i), 0);
+    unsigned int chunk_end = min((unsigned int)(warp_i + chunk_len - chunk_i), warpSize);
 
-    chunk_i = block_i - chunk_start;
+    chunk_i = warp_i - chunk_start;
 
-    size_t max_chunk_len = min(chunk_end - chunk_start, blockDim.x);
-    size_t incr = next_power_of_two(max_chunk_len) >> 1;
+    unsigned mask = (1 << chunk_end) - (1 << chunk_start);
+    T tmp;
 
-    __syncthreads();
+    // tmp is required because otherwise, the compiler will make a breaking optimization
+    tmp = __shfl_down_sync(mask, data, 16);
+    data += warp_i + 16 < chunk_end ? tmp : 0.0;
+    tmp = __shfl_down_sync(mask, data, 8);
+    data += warp_i +  8 < chunk_end ? tmp : 0.0;
+    tmp = __shfl_down_sync(mask, data, 4);
+    data += warp_i +  4 < chunk_end ? tmp : 0.0;
+    tmp = __shfl_down_sync(mask, data, 2);
+    data += warp_i +  2 < chunk_end ? tmp : 0.0;
+    tmp = __shfl_down_sync(mask, data, 1);
+    data += warp_i +  1 < chunk_end ? tmp : 0.0;
 
-    // Uses sequential addressing as discussed in
-    // https://developer.download.nvidia.com/assets/cuda/files/reduction.pdf
-    for (; incr > 0; incr >>= 1) {
-        unsigned int block_i_2 = block_i + incr;
-
-        if (block_i_2 < chunk_end && chunk_i < incr) {
-            // This is sound because __syncthreads and the conditions above
-            // ensure that no data races occur
-            buf[block_i] += buf[block_i_2];
-        }
-
-        __syncthreads();
-    }
-
-    if (block_i == chunk_start) {
-        atomicAdd(out + i / chunk_len, buf[block_i]);
+    if (chunk_i == 0) {
+        atomicAdd(out + i / chunk_len, data);
     }
 }
 

--- a/src/tensor_ops/utilities/cuda_utils.cuh
+++ b/src/tensor_ops/utilities/cuda_utils.cuh
@@ -29,6 +29,8 @@ __device__ unsigned int restrided(
     return idx;
 }
 
+const unsigned int SHFL_MASK = 0xffffffff;
+
 // Efficiently computes the sum of each chunk in "data" of size chunk_len, and
 // stores the sums in out[i / chunk_len]
 template<typename T>
@@ -51,13 +53,12 @@ __device__ void chunk_sum(
     unsigned int chunk_start = max((int)(warp_i - chunk_i), 0);
     unsigned int chunk_end = min((unsigned int)(warp_i + chunk_len - chunk_i), warpSize);
 
-    unsigned int mask = (1 << chunk_end) - (1 << chunk_start);
     unsigned int tail = chunk_end - warp_i;
     T tmp;
 
     for (unsigned int j = 16; j > 0; j /= 2) {
         // get data from thread (warp_i + j)
-        tmp = __shfl_down_sync(mask, data, j);
+        tmp = __shfl_down_sync(SHFL_MASK, data, j);
         // optimized version of (warp_i + j < chunk_end) 
         if (j < tail) {
             data += tmp;


### PR DESCRIPTION
Optimizes chunk_sum, chunk_min, and chunk_max by using the [__shfl_down_sync](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#warp-shuffle-functions) intrinsic to transfer memory between threads instead of shared memory. Despite causing more contention in the output buffer, this implementation measures ~25% faster on the `sum` benchmark, and I was unable to reduce contention in a way that measurably improves performance.