### PR TITLE
Improve buffer caching

### DIFF
--- a/src/tensor/cpu/allocate.rs
+++ b/src/tensor/cpu/allocate.rs
@@ -35,16 +35,7 @@ impl Cpu {
                 data.resize(numel, elem);
                 Ok(data)
             },
-            |allocation| {
-                // SAFETY:
-                // - ✅ "ptr must have been allocated using the global allocator, such as via the alloc::alloc function."
-                // - ✅ handled by tensor cache "T needs to have the same alignment as what ptr was allocated with."
-                // - ✅ handled by tensor cache "The size of T times the capacity needs to be the same size as the pointer was allocated with."
-                // - ✅ "length needs to be less than or equal to capacity."
-                // - ✅ all the dtypes for this are builtin numbers "The first length values must be properly initialized values of type T."
-                // - ✅ "capacity needs to be the capacity that the pointer was allocated with."
-                // - ✅ "The allocated size in bytes must be no larger than isize::MAX. See the safety documentation of pointer::offset."
-                let mut data = unsafe { Vec::from_raw_parts(allocation.0 as *mut E, numel, numel) };
+            |mut data| {
                 data.fill(elem);
                 Ok(data)
             },


### PR DESCRIPTION
So far, makes the TensorCache api cleaner using the CacheStorage trait to allow calling buffer conversion logic within the context of a TensorCache.

## Todo:
- [ ] More thoroughly document safety details
- [ ] Add buffer removal strategy (FIFO until total size of the cache is less than some number of bytes)
- [ ]  Set a reasonable default maximum cache size, and allow users to configure cache size.