### PR TITLE
Typos in feature_flags.rs

### DIFF
--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -9,12 +9,12 @@
 //!
 //! Cuda:
 //! ```toml
-//! dfdx = { version = "...", default-features = False, features = ["std", "cuda"]}
+//! dfdx = { version = "...", default-features = false, features = ["std", "cuda"]}
 //! ```
 //!
 //! Cpu:
 //! ```toml
-//! dfdx = { version = "...", default-features = False, features = ["std", "cpu-par-matmul"]}
+//! dfdx = { version = "...", default-features = false, features = ["std", "cpu-par-matmul"]}
 //! ```
 //!
 //! # "std"


### PR DESCRIPTION
Hello, I noticed two small typos in the documentation,

For some context, I am learning rust so I copy pasted the cpu line (17) and got a mistake when running `cargo build` so I corrected the mistake.