### PR TITLE
[RFC] Adding `thread_cpu()` and functions to create tensors on cpu

### DIFF
--- a/src/tensor/global.rs
+++ b/src/tensor/global.rs
@@ -1,0 +1,52 @@
+use super::*;
+use crate::shapes::*;
+
+thread_local! {
+    static GLOBAL_CPU: Cpu = Cpu::default();
+}
+
+pub fn thread_cpu() -> Cpu {
+    GLOBAL_CPU.with(|cpu| cpu.clone())
+}
+
+pub fn tensor<S: ConstShape, E: Dtype, Array>(array: Array) -> Tensor<S, E, Cpu>
+where
+    Cpu: TensorFrom<Array, S, E>,
+{
+    thread_cpu().tensor(array)
+}
+
+pub fn zeros<S: ConstShape, E: Dtype>() -> Tensor<S, E, Cpu> {
+    thread_cpu().zeros()
+}
+
+pub fn ones<S: ConstShape, E: Dtype>() -> Tensor<S, E, Cpu> {
+    thread_cpu().ones()
+}
+
+pub fn sample_uniform<S: ConstShape, E: Dtype>() -> Tensor<S, E, Cpu>
+where
+    Cpu: SampleTensor<E>,
+    rand_distr::Standard: rand_distr::Distribution<E>,
+{
+    thread_cpu().sample_uniform()
+}
+
+pub fn sample_normal<S: ConstShape, E: Dtype>() -> Tensor<S, E, Cpu>
+where
+    Cpu: SampleTensor<E>,
+    rand_distr::StandardNormal: rand_distr::Distribution<E>,
+{
+    thread_cpu().sample_normal()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tensor_new() {
+        let q = tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        let r = sample_normal::<Rank2<4, 5>, f32>();
+    }
+}

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -141,6 +141,8 @@ pub(crate) mod cpu;
 #[cfg(feature = "cuda")]
 pub(crate) mod cuda;
 mod ghost;
+#[cfg(feature = "std")]
+mod global;
 mod gradients;
 mod masks;
 #[cfg(feature = "numpy")]


### PR DESCRIPTION
This adds a `thread_cpu()` function akin to rand's `thread_rng()` function. This let's you get access to a global copy of a Cpu device, meaning you don't have to keep constructing cpu's in whatever method you are using one in.

Additionally, this let's us add functions for all the standard ways to create tensors, instead of relying on device methods:

```rust
use dfdx::tensor::*;
let _ = zeros::<Rank2<2, 3>, f32>();
let _ = ones::<Rank3<1, 2, 3>, f64>();
let _ = tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
```

TODOS
- [ ] Can we do something similar for Cuda?
- [ ] Add docstrings
- [ ] Add more tests