### PR TITLE
Work on compatibility

### DIFF
--- a/src/optim/adam/adam.cu
+++ b/src/optim/adam/adam.cu
@@ -75,7 +75,7 @@ __device__ void adam_update(
 
     const float t_f32 = t;
 
-    const AdamConfig<float> cfg_f32 = {
+    const AdamConfig<float> cfg_f32 = AdamConfig<float> {
         cfg.lr,
         cfg.beta1,
         cfg.beta2,

--- a/src/optim/adam/adam.cu
+++ b/src/optim/adam/adam.cu
@@ -75,13 +75,13 @@ __device__ void adam_update(
 
     const float t_f32 = t;
 
-    const AdamConfig<float> cfg_f32 = AdamConfig<float> {
-        .lr = cfg.lr,
-        .beta1 = cfg.beta1,
-        .beta2 = cfg.beta2,
-        .eps = cfg.eps,
-        .weight_decay_type = cfg.weight_decay_type,
-        .weight_decay = cfg.weight_decay,
+    const AdamConfig<float> cfg_f32 = {
+        cfg.lr,
+        cfg.beta1,
+        cfg.beta2,
+        cfg.eps,
+        cfg.weight_decay_type,
+        cfg.weight_decay,
     };
 
     float p = param[i];

--- a/src/optim/rmsprop/rmsprop.cu
+++ b/src/optim/rmsprop/rmsprop.cu
@@ -91,14 +91,14 @@ __device__ void rmsprop_update(
     }
 
     RMSpropConfig<float> cfg_f32 = RMSpropConfig<float> {
-        .lr = cfg.lr,
-        .alpha = cfg.alpha,
-        .eps = cfg.eps,
-        .centered = cfg.centered,
-        .has_momentum = cfg.has_momentum,
-        .momentum = cfg.momentum,
-        .weight_decay_type = cfg.weight_decay_type,
-        .weight_decay = cfg.weight_decay,
+        cfg.lr,
+        cfg.alpha,
+        cfg.eps,
+        cfg.centered,
+        cfg.has_momentum,
+        cfg.momentum,
+        cfg.weight_decay_type,
+        cfg.weight_decay,
     };
 
     float p = param[i];

--- a/src/tensor_ops/concat/cuda_kernel.rs
+++ b/src/tensor_ops/concat/cuda_kernel.rs
@@ -39,7 +39,11 @@ impl<E: Dtype + CudaTypeName> super::ConcatKernel<E> for Cuda {
             let src = BWD_KERNEL.replace("$Ty", E::NAME);
             let opts = CompileOptions {
                 arch: Some(env!("CUDA_COMPUTE_CAP")),
-                include_paths: vec!["/usr/include".to_string()],
+                include_paths: vec![
+                    "/usr/include".to_string(),
+                    "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.0\\include"
+                        .to_string(),
+                ],
                 ..Default::default()
             };
             let ptx = compile_ptx_with_opts(src, opts).unwrap();

--- a/src/tensor_ops/max_to/max_to.cu
+++ b/src/tensor_ops/max_to/max_to.cu
@@ -7,7 +7,7 @@ __device__ __forceinline__ __half atomicMaxf(__half* address, __half val) {
     unsigned short int assumed;
     do {
         assumed = old;
-        old = atomicCAS(casted_address, assumed, __half_as_ushort(__hmax(val, __ushort_as_half(assumed)))); // __hmax_nan
+        old = atomicCAS(casted_address, assumed, __half_as_ushort(__hmax_nan(val, __ushort_as_half(assumed))));
     // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
     } while (assumed != old);
     return __ushort_as_half(old);

--- a/src/tensor_ops/min_to/min_to.cu
+++ b/src/tensor_ops/min_to/min_to.cu
@@ -7,7 +7,7 @@ __device__ __forceinline__ __half atomicMinf(__half* address, __half val) {
     unsigned short int assumed;
     do {
         assumed = old;
-        old = atomicCAS(casted_address, assumed, __half_as_ushort(__hmin(val, __ushort_as_half(assumed)))); // __hmin_nan
+        old = atomicCAS(casted_address, assumed, __half_as_ushort(__hmin_nan(val, __ushort_as_half(assumed))));
     // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
     } while (assumed != old);
     return __ushort_as_half(old);

--- a/src/tensor_ops/reshape_to/cuda_kernel.rs
+++ b/src/tensor_ops/reshape_to/cuda_kernel.rs
@@ -21,7 +21,11 @@ impl<E: Dtype + CudaTypeName> super::ReshapeKernel<E> for Cuda {
             let src = FWD_KERNEL.replace("$T", E::NAME);
             let opts = CompileOptions {
                 arch: Some(env!("CUDA_COMPUTE_CAP")),
-                include_paths: vec!["/usr/include".to_string()],
+                include_paths: vec![
+                    "/usr/include".to_string(),
+                    "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.0\\include"
+                        .to_string(),
+                ],
                 ..Default::default()
             };
             let ptx = compile_ptx_with_opts(src, opts).unwrap();
@@ -65,7 +69,11 @@ impl<E: Dtype + CudaTypeName> super::ReshapeKernel<E> for Cuda {
             let src = BWD_KERNEL.replace("$T", E::NAME);
             let opts = CompileOptions {
                 arch: Some(env!("CUDA_COMPUTE_CAP")),
-                include_paths: vec!["/usr/include".to_string()],
+                include_paths: vec![
+                    "/usr/include".to_string(),
+                    "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.0\\include"
+                        .to_string(),
+                ],
                 ..Default::default()
             };
             let ptx = compile_ptx_with_opts(src, opts).unwrap();

--- a/src/tensor_ops/stack/cuda_kernel.rs
+++ b/src/tensor_ops/stack/cuda_kernel.rs
@@ -60,7 +60,11 @@ impl<E: Dtype + CudaTypeName> super::StackKernel<E> for Cuda {
             let src = BWD_KERNEL.replace("$Ty", E::NAME);
             let opts = CompileOptions {
                 arch: Some(env!("CUDA_COMPUTE_CAP")),
-                include_paths: vec!["/usr/include".to_string()],
+                include_paths: vec![
+                    "/usr/include".to_string(),
+                    "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.0\\include"
+                        .to_string(),
+                ],
                 ..Default::default()
             };
             let ptx = compile_ptx_with_opts(src, opts).unwrap();

--- a/src/tensor_ops/to_dtype/cuda_kernel.rs
+++ b/src/tensor_ops/to_dtype/cuda_kernel.rs
@@ -29,7 +29,11 @@ impl<E1: Unit + CudaTypeName, E2: Unit + CudaTypeName> super::ToDtypeKernel<E1, 
             let src = KERNEL.replace("$Src", E1::NAME).replace("$Dst", E2::NAME);
             let opts = CompileOptions {
                 arch: Some(env!("CUDA_COMPUTE_CAP")),
-                include_paths: vec!["/usr/include".to_string()],
+                include_paths: vec![
+                    "/usr/include".to_string(),
+                    "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.0\\include"
+                        .to_string(),
+                ],
                 ..Default::default()
             };
             let ptx = compile_ptx_with_opts(src, opts).unwrap();

--- a/src/tensor_ops/utilities/compatibility.cuh
+++ b/src/tensor_ops/utilities/compatibility.cuh
@@ -29,15 +29,15 @@ __device__ unsigned short int atomicCAS(
 ) {
     // Read the two shorts that make up the 32 bit int at the aligned memory location.
     unsigned int* aligned_address = (unsigned int*) ((size_t) address & ~2);
-    unsigned int my_short = *address;
+    // unsigned int my_short = *address;
     unsigned int other_short = *(unsigned short int*) ((size_t) address ^ 2);
     // Replace my_short with value in the integer.
     const unsigned int value = val;
     const bool aligned = ((size_t) address & 2) == 0;
-    unsigned int new_whole = aligned ? (value << 16) | other_short : (other_short << 16) | value;
+    unsigned int new_whole = aligned ? (other_short << 16) | value : (value << 16) | other_short;
     
     unsigned int old = atomicCAS(aligned_address, (unsigned int) compare, new_whole);
-    return aligned ? old >> 16 : old & (0xffff);
+    return aligned ? old & (0xffff) : old >> 16;
 }
 
 __device__ __half atomicAdd(__half* address, __half val) {

--- a/src/tensor_ops/utilities/compatibility.cuh
+++ b/src/tensor_ops/utilities/compatibility.cuh
@@ -1,0 +1,54 @@
+#include "cuda_fp16.h"
+
+// Table showing which features are supported on which compute capability
+// https://docs.nvidia.com/cuda/cuda-c-programming-guide/#features-and-technical-specifications
+
+// FIXME: the minimum compute capabilities are just guesses since the table is not specific enough
+
+#if __CUDA_ARCH__ < 700
+__device__ __forceinline__ __half __hmax_nan(__half a, __half b) {
+    return __hisnan(a) ? a : (__hisnan(b) ? b : __hmax(a, b));
+}
+__device__ __forceinline__ __half __hmin_nan(__half a, __half b) {
+    return __hisnan(a) ? a : (__hisnan(b) ? b : __hmin(a, b));
+}
+#endif
+
+
+// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicadd
+// > The 16-bit __half floating-point version of atomicAdd() is only supported by devices of compute capability 7.x and higher.
+// We assume that atomicCAS for shorts has the same compute capability restrictions.
+#if __CUDA_ARCH__ < 700
+
+// Inspired by https://github.com/torch/cutorch/blob/master/lib/THC/THCAtomics.cuh#L96-L119
+// Lots of bit and pointer magic, very unsafe!
+__device__ unsigned short int atomicCAS(
+    unsigned short int *address,
+    unsigned short int compare,
+    unsigned short int val
+) {
+    // Read the two shorts that make up the 32 bit int at the aligned memory location.
+    unsigned int* aligned_address = (unsigned int*) ((size_t) address & ~2);
+    unsigned int my_short = *address;
+    unsigned int other_short = *(unsigned short int*) ((size_t) address ^ 2);
+    // Replace my_short with value in the integer.
+    const unsigned int value = val;
+    const bool aligned = ((size_t) address & 2) == 0;
+    unsigned int new_whole = aligned ? (value << 16) | other_short : (other_short << 16) | value;
+    
+    unsigned int old = atomicCAS(aligned_address, (unsigned int) compare, new_whole);
+    return aligned ? old >> 16 : old & (0xffff);
+}
+
+__device__ __half atomicAdd(__half* address, __half val) {
+    unsigned short int* casted_address = (unsigned short int*)address;
+    unsigned short int old = *casted_address;
+    unsigned short int assumed;
+    do {
+        assumed = old;
+        old = atomicCAS(casted_address, assumed, __half_as_ushort(val + __ushort_as_half(assumed)));
+    } while (assumed != old);
+    return __ushort_as_half(old);
+}
+
+#endif

--- a/src/tensor_ops/utilities/cuda_utils.cuh
+++ b/src/tensor_ops/utilities/cuda_utils.cuh
@@ -1,4 +1,5 @@
 #include "cuda_fp16.h"
+#include "compatibility.cuh"
 
 __device__ unsigned int get_strided_index(
     unsigned int idx,
@@ -141,10 +142,10 @@ __device__ __forceinline__ double tanhg(double a) { return tanh(a); }
 __device__ __forceinline__ __half tanhg(__half a) { return __float2half(tanhf(__half2float(a))); }
 __device__ __forceinline__ float maxg(float a, float b) { return fmaxf(a, b); }
 __device__ __forceinline__ double maxg(double a, double b) { return fmax(a, b); }
-__device__ __forceinline__ __half maxg(__half a, __half b) { return __hmax(a, b); } // __hmax_nan
+__device__ __forceinline__ __half maxg(__half a, __half b) { return __hmax_nan(a, b); }
 __device__ __forceinline__ float ming(float a, float b) { return fminf(a, b); }
 __device__ __forceinline__ double ming(double a, double b) { return fmin(a, b); }
-__device__ __forceinline__ __half ming(__half a, __half b) { return __hmin(a, b); } // __hmin_nan
+__device__ __forceinline__ __half ming(__half a, __half b) { return __hmin_nan(a, b); }
 __device__ __forceinline__ float logg(float a) { return logf(a); }
 __device__ __forceinline__ double logg(double a) { return log(a); }
 __device__ __forceinline__ __half logg(__half a) { return hlog(a); }


### PR DESCRIPTION
- A few unrelated fixes to optimizers that I needed to compile and run the code.
- Compatibility header with a few functions:
  - Pay special attention to `atomicCAS` since it's quite unsafe and complicated. It's almost 3 AM so I worry I might have messed it up.
  - I implemented `__hmax_nan` and `__hmin_nan` so that we can have the nice NaN propagation even on older GPUs
  - Someone should try where the compute capability boundaries for when functions are defined actually lie. For now I just guessed `700`.
- I added an example Windows include path so that you have some idea of what it looks like for me.

---

I still get runtime errors like this:
```rs
---- tensor_ops::reshape_to::tests::test_1d_reshape_non_contiguous stdout ----
thread 'tensor_ops::reshape_to::tests::test_1d_reshape_non_contiguous' panicked at 'called `Result::unwrap()` on an `Err` value: CompileError { nvrtc: NvrtcError(NVRTC_ERROR_COMPILATION), options: ["--include-path=/usr/include", "--include-path=C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.0\\include", "--gpu-architecture=sm_61"], log: "default_program(46): error: no instance of overloaded function \"atomicAdd\" matches the argument list\n            argument types are: (__half *, const __half)\n\n1 error detected in the compilation of \"default_program\".\n" }', src\tensor_ops\reshape_to\cuda_kernel.rs:79:56
```
which are very strange.

---

To be honest I think this PR breaks more things than it fixes. 🥴
For reference, running `cargo test --features cuda,test-f16` I get: `245 passed; 112 failed;`

