### PR TITLE
Adds rust 1.65 as the minimum rust compiler version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "dfdx"
 version = "0.11.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
+rust-version = "1.65"
 
 description = "Ergonomic auto differentiation in Rust, with pytorch like apis."
 homepage = "https://github.com/coreylowman/dfdx"


### PR DESCRIPTION
Related to #734 