### PR TITLE
Deprecates `try_scalar_*`. Moves scalar comparison to use the same method as tensor comparison

### DIFF
--- a/src/tensor_ops/cmp/mod.rs
+++ b/src/tensor_ops/cmp/mod.rs
@@ -197,7 +197,7 @@ pub fn le<S: Shape, E: Unit, D: CmpKernel<LeKernelOp, E>, T: Tape<E, D>>(
 
 // Macro to reduce boilerplate of implementing comparison methods on Tensor.
 macro_rules! impl_cmp_kernel_op {
-    ($TraitName:tt, $FnName:tt, $TryFnName:tt, $KernelOp:tt, $doc:expr) => {
+    ($TraitName:tt, $FnName:tt, $TryFnName:tt, $KernelOp:tt, $doc:expr, $ScalarFnName:tt, $TryScalarFnName:tt) => {
         pub trait $TraitName<Rhs>: HasErr {
             type Output;
             #[doc = $doc]
@@ -227,15 +227,82 @@ macro_rules! impl_cmp_kernel_op {
                 try_scalar_cmp_op(self, other)
             }
         }
+
+        impl<S: Shape, E: Unit, D: ScalarCmpKernel<$KernelOp, E>, T: Tape<E, D>>
+            Tensor<S, E, D, T>
+        {
+            #[doc = $doc]
+            #[deprecated = "You can now use the non-scalar method for both tensors & scalars."]
+            pub fn $ScalarFnName(&self, other: E) -> Tensor<S, bool, D, NoneTape> {
+                self.$TryScalarFnName(other).unwrap()
+            }
+
+            #[doc = $doc]
+            #[deprecated = "You can now use the non-scalar method for both tensors & scalars."]
+            pub fn $TryScalarFnName(
+                &self,
+                other: E,
+            ) -> Result<Tensor<S, bool, D, NoneTape>, D::Err> {
+                try_scalar_cmp_op(self, other)
+            }
+        }
     };
 }
 
-impl_cmp_kernel_op!(TryEq, eq, try_eq, EqKernelOp, "See [eq]");
-impl_cmp_kernel_op!(TryNe, ne, try_ne, NeKernelOp, "See [ne]");
-impl_cmp_kernel_op!(TryGt, gt, try_gt, GtKernelOp, "See [gt]");
-impl_cmp_kernel_op!(TryGe, ge, try_ge, GeKernelOp, "See [ge]");
-impl_cmp_kernel_op!(TryLt, lt, try_lt, LtKernelOp, "See [lt]");
-impl_cmp_kernel_op!(TryLe, le, try_le, LeKernelOp, "See [le]");
+impl_cmp_kernel_op!(
+    TryEq,
+    eq,
+    try_eq,
+    EqKernelOp,
+    "See [eq]",
+    scalar_eq,
+    try_scalar_eq
+);
+impl_cmp_kernel_op!(
+    TryNe,
+    ne,
+    try_ne,
+    NeKernelOp,
+    "See [ne]",
+    scalar_ne,
+    try_scalar_ne
+);
+impl_cmp_kernel_op!(
+    TryGt,
+    gt,
+    try_gt,
+    GtKernelOp,
+    "See [gt]",
+    scalar_gt,
+    try_scalar_gt
+);
+impl_cmp_kernel_op!(
+    TryGe,
+    ge,
+    try_ge,
+    GeKernelOp,
+    "See [ge]",
+    scalar_ge,
+    try_scalar_ge
+);
+impl_cmp_kernel_op!(
+    TryLt,
+    lt,
+    try_lt,
+    LtKernelOp,
+    "See [lt]",
+    scalar_lt,
+    try_scalar_lt
+);
+impl_cmp_kernel_op!(
+    TryLe,
+    le,
+    try_le,
+    LeKernelOp,
+    "See [le]",
+    scalar_le,
+    try_scalar_le
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/tensor_ops/cmp/mod.rs
+++ b/src/tensor_ops/cmp/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::{HasShape, Shape, Unit},
-    tensor::{DeviceStorage, NoneTape, Tape, Tensor},
+    tensor::{DeviceStorage, HasErr, NoneTape, Tape, Tensor},
 };
 
 mod cpu_kernels;
@@ -60,7 +60,7 @@ pub enum LeKernelOp {}
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
 /// let a = dev.tensor([-2, -1, 0, 1, 2]);
-/// let r = a.scalar_eq(1);
+/// let r = a.eq(1);
 /// assert_eq!(r.array(), [false, false, false, true, false]);
 /// ```
 pub fn eq<S: Shape, E: Unit, D: CmpKernel<EqKernelOp, E>, T: Tape<E, D>>(
@@ -85,7 +85,7 @@ pub fn eq<S: Shape, E: Unit, D: CmpKernel<EqKernelOp, E>, T: Tape<E, D>>(
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
 /// let a = dev.tensor([-2, -1, 0, 1, 2]);
-/// let r = a.scalar_ne(1);
+/// let r = a.ne(1);
 /// assert_eq!(r.array(), [true, true, true, false, true]);
 /// ```
 pub fn ne<S: Shape, E: Unit, D: CmpKernel<NeKernelOp, E>, T: Tape<E, D>>(
@@ -110,7 +110,7 @@ pub fn ne<S: Shape, E: Unit, D: CmpKernel<NeKernelOp, E>, T: Tape<E, D>>(
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
 /// let a = dev.tensor([-2, -1, 0, 1, 2]);
-/// let r = a.scalar_gt(-1);
+/// let r = a.gt(-1);
 /// assert_eq!(r.array(), [false, false, true, true, true]);
 /// ```
 pub fn gt<S: Shape, E: Unit, D: CmpKernel<GtKernelOp, E>, T: Tape<E, D>>(
@@ -135,7 +135,7 @@ pub fn gt<S: Shape, E: Unit, D: CmpKernel<GtKernelOp, E>, T: Tape<E, D>>(
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
 /// let a = dev.tensor([-2, -1, 0, 1, 2]);
-/// let r = a.scalar_ge(-1);
+/// let r = a.ge(-1);
 /// assert_eq!(r.array(), [false, true, true, true, true]);
 /// ```
 pub fn ge<S: Shape, E: Unit, D: CmpKernel<GeKernelOp, E>, T: Tape<E, D>>(
@@ -160,7 +160,7 @@ pub fn ge<S: Shape, E: Unit, D: CmpKernel<GeKernelOp, E>, T: Tape<E, D>>(
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
 /// let a = dev.tensor([-2, -1, 0, 1, 2]);
-/// let r = a.scalar_lt(1);
+/// let r = a.lt(1);
 /// assert_eq!(r.array(), [true, true, true, false, false]);
 /// ```
 pub fn lt<S: Shape, E: Unit, D: CmpKernel<LtKernelOp, E>, T: Tape<E, D>>(
@@ -185,7 +185,7 @@ pub fn lt<S: Shape, E: Unit, D: CmpKernel<LtKernelOp, E>, T: Tape<E, D>>(
 /// # use dfdx::prelude::*;
 /// # let dev: Cpu = Default::default();
 /// let a = dev.tensor([-2, -1, 0, 1, 2]);
-/// let r = a.scalar_le(1);
+/// let r = a.le(1);
 /// assert_eq!(r.array(), [true, true, true, true, false]);
 /// ```
 pub fn le<S: Shape, E: Unit, D: CmpKernel<LeKernelOp, E>, T: Tape<E, D>>(
@@ -197,47 +197,49 @@ pub fn le<S: Shape, E: Unit, D: CmpKernel<LeKernelOp, E>, T: Tape<E, D>>(
 
 // Macro to reduce boilerplate of implementing comparison methods on Tensor.
 macro_rules! impl_cmp_kernel_op {
-    ($kernel_op:ty, $try_op:ident, $op:ident, $try_scalar_op:ident, $scalar_op:ident, $doc:expr) => {
-        impl<S: Shape, E: Unit, D: CmpKernel<$kernel_op, E>, T: Tape<E, D>> Tensor<S, E, D, T> {
+    ($TraitName:tt, $FnName:tt, $TryFnName:tt, $KernelOp:tt, $doc:expr) => {
+        pub trait $TraitName<Rhs>: HasErr {
+            type Output;
             #[doc = $doc]
-            pub fn $try_op(&self, other: &Self) -> Result<Tensor<S, bool, D, NoneTape>, D::Err> {
-                try_cmp_op(self, other)
+            fn $FnName(&self, rhs: Rhs) -> Self::Output {
+                self.$TryFnName(rhs).unwrap()
             }
-
             #[doc = $doc]
-            pub fn $op(&self, other: &Self) -> Tensor<S, bool, D, NoneTape> {
-                self.$try_op(other).unwrap()
+            fn $TryFnName(&self, rhs: Rhs) -> Result<Self::Output, Self::Err>;
+        }
+
+        impl<S: Shape, E: Unit, D: CmpKernel<$KernelOp, E>, T: Tape<E, D>> $TraitName<&Self>
+            for Tensor<S, E, D, T>
+        {
+            type Output = Tensor<S, bool, D, NoneTape>;
+            #[doc = $doc]
+            fn $TryFnName(&self, other: &Self) -> Result<Self::Output, D::Err> {
+                try_cmp_op(self, other)
             }
         }
 
-        impl<S: Shape, E: Unit, D: ScalarCmpKernel<$kernel_op, E>, T: Tape<E, D>>
-            Tensor<S, E, D, T>
+        impl<S: Shape, E: Unit, D: ScalarCmpKernel<$KernelOp, E>, T: Tape<E, D>> $TraitName<E>
+            for Tensor<S, E, D, T>
         {
+            type Output = Tensor<S, bool, D, NoneTape>;
             #[doc = $doc]
-            pub fn $try_scalar_op(
-                &self,
-                scalar: impl Into<E>,
-            ) -> Result<Tensor<S, bool, D, NoneTape>, D::Err> {
-                try_scalar_cmp_op(self, scalar.into())
-            }
-
-            #[doc = $doc]
-            pub fn $scalar_op(&self, scalar: impl Into<E>) -> Tensor<S, bool, D, NoneTape> {
-                self.$try_scalar_op(scalar).unwrap()
+            fn $TryFnName(&self, other: E) -> Result<Self::Output, D::Err> {
+                try_scalar_cmp_op(self, other)
             }
         }
     };
 }
 
-impl_cmp_kernel_op!(EqKernelOp, try_eq, eq, try_scalar_eq, scalar_eq, "See [eq]");
-impl_cmp_kernel_op!(NeKernelOp, try_ne, ne, try_scalar_ne, scalar_ne, "See [ne]");
-impl_cmp_kernel_op!(GtKernelOp, try_gt, gt, try_scalar_gt, scalar_gt, "See [gt]");
-impl_cmp_kernel_op!(GeKernelOp, try_ge, ge, try_scalar_ge, scalar_ge, "See [ge]");
-impl_cmp_kernel_op!(LtKernelOp, try_lt, lt, try_scalar_lt, scalar_lt, "See [lt]");
-impl_cmp_kernel_op!(LeKernelOp, try_le, le, try_scalar_le, scalar_le, "See [le]");
+impl_cmp_kernel_op!(TryEq, eq, try_eq, EqKernelOp, "See [eq]");
+impl_cmp_kernel_op!(TryNe, ne, try_ne, NeKernelOp, "See [ne]");
+impl_cmp_kernel_op!(TryGt, gt, try_gt, GtKernelOp, "See [gt]");
+impl_cmp_kernel_op!(TryGe, ge, try_ge, GeKernelOp, "See [ge]");
+impl_cmp_kernel_op!(TryLt, lt, try_lt, LtKernelOp, "See [lt]");
+impl_cmp_kernel_op!(TryLe, le, try_le, LeKernelOp, "See [le]");
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{shapes::*, tensor::*, tests::*};
 
     type TestTensor<const R: usize, const C: usize, E> =
@@ -272,33 +274,23 @@ mod tests {
 
     #[test]
     fn test_eq() {
-        test_cmp::<TestDtype, 2, 3, _>(
-            [[1.0, 2.0, 3.0], [4.0, 5.0, 0.0]],
-            [[0.0, 2.0, -3.0], [4.0, 0.5, -0.0]],
-            |a, b| a.eq(b).array(),
-            [[false, true, false], [true, false, true]],
-        );
-    }
+        let dev: TestDevice = Default::default();
+        let a = dev
+            .tensor([[1.0, 2.0, 0.0], [4.0, 5.0, 0.0]])
+            .to_dtype::<TestDtype>();
 
-    // TODO Remove this attribute once Cuda supports integers
-    #[cfg(not(feature = "cuda"))]
-    #[test]
-    fn test_eq_not_dtype() {
-        test_cmp(
-            [[1, 2, 3], [0, 123, 5]],
-            [[0, 2, -3], [-4, 123, 6]],
-            |a, b| a.eq(b).array(),
-            [[false, true, false], [false, true, false]],
-        );
-    }
+        {
+            let b = dev
+                .tensor([[0.0, 2.0, -3.0], [4.0, 0.5, -0.0]])
+                .to_dtype::<TestDtype>();
+            let r = a.eq(&b);
+            assert_eq!(r.array(), [[false, true, false], [true, false, true]]);
+        }
 
-    #[test]
-    fn test_scalar_eq() {
-        test_scalar_cmp::<TestDtype, 2, 2, _>(
-            [[0.0, 1.2], [3.4, -5.6]],
-            |a| a.scalar_eq(1.2).array(),
-            [[false, true], [false, false]],
-        );
+        {
+            let r = a.eq(0.0);
+            assert_eq!(r.array(), [[false, false, true], [false, false, true]]);
+        }
     }
 
     #[test]
@@ -327,7 +319,7 @@ mod tests {
     fn test_scalar_ne() {
         test_scalar_cmp::<TestDtype, 2, 2, _>(
             [[0.0, 1.2], [3.4, -5.6]],
-            |a| a.scalar_ne(1.2).array(),
+            |a| a.ne(1.2).array(),
             [[true, false], [true, true]],
         );
     }
@@ -358,7 +350,7 @@ mod tests {
     fn test_scalar_gt() {
         test_scalar_cmp::<TestDtype, 2, 2, _>(
             [[0.0, 1.2], [3.4, -5.6]],
-            |a| a.scalar_gt(1.2).array(),
+            |a| a.gt(1.2).array(),
             [[false, false], [true, false]],
         );
     }
@@ -389,7 +381,7 @@ mod tests {
     fn test_scalar_ge() {
         test_scalar_cmp::<TestDtype, 2, 2, _>(
             [[0.0, 1.2], [3.4, -5.6]],
-            |a| a.scalar_ge(1.2).array(),
+            |a| a.ge(1.2).array(),
             [[false, true], [true, false]],
         );
     }
@@ -420,7 +412,7 @@ mod tests {
     fn test_scalar_lt() {
         test_scalar_cmp::<TestDtype, 2, 2, _>(
             [[0.0, 1.2], [3.4, -5.6]],
-            |a| a.scalar_lt(1.2).array(),
+            |a| a.lt(1.2).array(),
             [[true, false], [false, true]],
         );
     }
@@ -451,7 +443,7 @@ mod tests {
     fn test_scalar_le() {
         test_scalar_cmp::<TestDtype, 2, 2, _>(
             [[0.0, 1.2], [3.4, -5.6]],
-            |a| a.scalar_le(1.2).array(),
+            |a| a.le(1.2).array(),
             [[true, true], [false, true]],
         );
     }

--- a/src/tensor_ops/mod.rs
+++ b/src/tensor_ops/mod.rs
@@ -212,7 +212,7 @@ pub use boolean::{bool_and, bool_not, bool_or, bool_xor};
 pub use broadcast_to::BroadcastTo;
 pub use choose::ChooseFrom;
 pub use clamp::clamp;
-pub use cmp::{eq, ge, gt, le, lt, ne};
+pub use cmp::{eq, ge, gt, le, lt, ne, TryEq, TryGe, TryGt, TryLe, TryLt, TryNe};
 pub use concat::TryConcat;
 pub use cos::cos;
 pub use div::{div, TryDiv};

--- a/src/tensor_ops/prelu.rs
+++ b/src/tensor_ops/prelu.rs
@@ -1,6 +1,6 @@
 use crate::{shapes::*, tensor::*};
 
-use super::{BroadcastTo, ChooseFrom, Device, TryMul};
+use super::{cmp::*, BroadcastTo, ChooseFrom, Device, TryMul};
 
 /// [Parametric Rectified Linear Unit (PReLU)](https://pytorch.org/docs/stable/generated/torch.nn.PReLU.html). `max(0, lhs) + rhs*min(0, lhs)`
 ///
@@ -66,7 +66,7 @@ where
     /// See [prelu]
     fn try_prelu(self, rhs: Tensor<S, E, D, R>) -> Result<Self, Self::Err> {
         let scaled = self.with_empty_tape().try_mul(rhs)?;
-        self.try_scalar_lt(E::default())?.try_choose(scaled, self)
+        self.try_lt(E::default())?.try_choose(scaled, self)
     }
 }
 
@@ -76,7 +76,7 @@ impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> TryPReLU<E> for Tensor<S, 
         let dev = self.device.clone();
         let scale = dev.tensor(rhs).retaped::<T>().broadcast_like(self.shape());
         let scaled = self.with_empty_tape().try_mul(scale)?;
-        self.try_scalar_lt(E::default())?.try_choose(scaled, self)
+        self.try_lt(E::default())?.try_choose(scaled, self)
     }
 }
 


### PR DESCRIPTION
Now instead of calling `a.scalar_eq(1.0)` you can call `a.eq(1.0)`.