### PR TITLE
Run CI for all kind of pushes - not only pull request related ones

### DIFF
--- a/.github/workflows/cargo-check-features.yml
+++ b/.github/workflows/cargo-check-features.yml
@@ -1,5 +1,6 @@
 on:
   - push
+  - pull_request
 
 jobs:
   cargo-check-features:

--- a/.github/workflows/cargo-check-features.yml
+++ b/.github/workflows/cargo-check-features.yml
@@ -1,4 +1,5 @@
-on: [pull_request]
+on:
+  - push
 
 jobs:
   cargo-check-features:

--- a/.github/workflows/cargo-fmt-check-doc.yml
+++ b/.github/workflows/cargo-fmt-check-doc.yml
@@ -1,5 +1,6 @@
 on:
   - push
+  - pull_request
 
 jobs:
   cargo-check:

--- a/.github/workflows/cargo-fmt-check-doc.yml
+++ b/.github/workflows/cargo-fmt-check-doc.yml
@@ -1,4 +1,5 @@
-on: [pull_request]
+on:
+  - push
 
 jobs:
   cargo-check:

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -1,5 +1,6 @@
 on:
   - push
+  - pull_request
 
 jobs:
   cargo-test:

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -1,4 +1,5 @@
-on: [pull_request]
+on:
+  - push
 
 jobs:
   cargo-test:


### PR DESCRIPTION
Before this PR the GitHub actions where only run for pull requests related pushes.

Therefore there was the possibility for maintainers to sneak in code to the code base which was not tested / checked for code style and checked for cargo features (only if they wouldn't do a pull request and merge branches directly).

It is as well not a very nice developer experience when you need to open a pull request every time you wanna test a change and maybe need to force-push some changes (which get displayed as such in the pull request itself but not in normal branches (before a pull request was created)).

This PR runs the GitHub actions for every kind of push (commits to single branches w/o a pull request as well as commits to pull request related branches (which could also be outside of this repository since GitHub supports this feature of "crossover pull-requests")).

Keep in mind that only the last commit in each push will be tested with GitHub actions as its the default behavior which cannot be changed.