### PR TITLE
Adds `Tensor::to_device` to support sending tensors of any shape to any device

### DIFF
--- a/examples/02-ops.rs
+++ b/examples/02-ops.rs
@@ -67,7 +67,7 @@ fn main() {
     // these operations are equal across devices
     #[cfg(feature = "cuda")]
     {
-        use dfdx::{nn::ToDevice, tensor::Cpu};
+        use dfdx::tensor::Cpu;
 
         let cpu = Cpu::default();
 

--- a/src/tensor/storage_traits.rs
+++ b/src/tensor/storage_traits.rs
@@ -459,6 +459,22 @@ pub trait TensorFromVec<E: Unit>: DeviceStorage {
     ) -> Result<Tensor<S, E, Self>, Self::Err>;
 }
 
+impl<S: Shape, E: Unit, D: DeviceStorage, T> Tensor<S, E, D, T> {
+    /// Clones the tensor onto a different device.
+    pub fn to_device<Dst: TensorFromVec<E>>(&self, device: &Dst) -> Tensor<S, E, Dst> {
+        self.try_to_device(device).unwrap()
+    }
+
+    /// Fallibly clones the tensor onto a different device.
+    pub fn try_to_device<Dst: TensorFromVec<E>>(
+        &self,
+        device: &Dst,
+    ) -> Result<Tensor<S, E, Dst>, Dst::Err> {
+        let buf = self.as_vec();
+        device.try_tensor_from_vec(buf, self.shape)
+    }
+}
+
 /// Construct tensors from rust data
 pub trait TensorFrom<Src, S: Shape, E: Unit>: DeviceStorage {
     /// Create a tensor from rust data


### PR DESCRIPTION
Currently there is `nn::ToDevice`, however it is only implemented for tensors of `ConstShape`. Additionally, the to_device functionality should be implemented at the Tensor level, so that other libraries implementing their own nn layer can still use the functionality.

