### PR TITLE
Fixes most of the failing tests for f16 on older GPUs

### DIFF
--- a/src/tensor_ops/min_to/min_to.cu
+++ b/src/tensor_ops/min_to/min_to.cu
@@ -1,7 +1,26 @@
 #include "cuda_utils.cuh"
 
-// Based on https://docs.nvidia.com/cuda/cuda-c-programming-guide/#atomic-functions
 __device__ __forceinline__ __half atomicMinf(__half* address, __half val) {
+#if __CUDA_ARCH__ < 700
+    // On older GPUs we do not have access to atomicCAS for shorts, so we have to do some trickery.
+    // Solution adapted from https://github.com/torch/cutorch/blob/master/lib/THC/THCAtomics.cuh#L96-L119
+    unsigned int *address_as_ui = (unsigned int *) ((char *)address - ((size_t)address & 2));
+    unsigned int old = *address_as_ui;
+    unsigned int assumed;
+    bool unaligned = (size_t) address & 2;
+    do {
+        assumed = old;
+        unsigned int hmin;
+        hmin = unaligned ? (old >> 16) : (old & 0xffff);
+        hmin = __half_as_ushort(__hmin_nan(val, __ushort_as_half(hmin))); 
+        old = atomicCAS(address_as_ui, assumed,
+            unaligned ? (old & 0xffff) | (hmin << 16) : (old & 0xffff0000) | hmin
+        );
+
+   } while (assumed != old);
+   return __ushort_as_half(unaligned ? (old >> 16) : (old & 0xffff));
+#else
+    // Based on https://docs.nvidia.com/cuda/cuda-c-programming-guide/#atomic-functions
     unsigned short int* casted_address = (unsigned short int*)address;
     unsigned short int old = *casted_address;
     unsigned short int assumed;
@@ -11,6 +30,7 @@ __device__ __forceinline__ __half atomicMinf(__half* address, __half val) {
     // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
     } while (assumed != old);
     return __ushort_as_half(old);
+#endif
 }
 
 // atomicMin is not implemented for floats,

--- a/src/tensor_ops/utilities/compatibility.cuh
+++ b/src/tensor_ops/utilities/compatibility.cuh
@@ -5,13 +5,16 @@
 
 // FIXME: the minimum compute capabilities are just guesses since the table is not specific enough
 
-#if __CUDA_ARCH__ <= 800
+#if __CUDA_ARCH__ < 600
 __device__ __forceinline__ __half __hmax(__half a, __half b) {
     return __float2half(fmaxf(__half2float(a), __half2float(b)));
 }
 __device__ __forceinline__ __half __hmin(__half a, __half b) {
     return __float2half(fminf(__half2float(a), __half2float(b)));
 }
+#endif
+
+#if __CUDA_ARCH__ < 700
 __device__ __forceinline__ __half __hmax_nan(__half a, __half b) {
     return __hisnan(a) ? a : (__hisnan(b) ? b : __hmax(a, b));
 }
@@ -22,10 +25,8 @@ __device__ __forceinline__ __half __hmin_nan(__half a, __half b) {
 
 #if __CUDA_ARCH__ < 600
 // Copied from https://docs.nvidia.com/cuda/cuda-c-programming-guide/#atomic-functions
-__device__ double atomicAdd(double* address, double val)
-{
-    unsigned long long int* address_as_ull =
-                              (unsigned long long int*)address;
+__device__ double atomicAdd(double* address, double val) {
+    unsigned long long int* address_as_ull = (unsigned long long int*)address;
     unsigned long long int old = *address_as_ull, assumed;
 
     do {
@@ -41,40 +42,26 @@ __device__ double atomicAdd(double* address, double val)
 }
 #endif
 
-// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicadd
-// > The 16-bit __half floating-point version of atomicAdd() is only supported by devices of compute capability 7.x and higher.
-// We assume that atomicCAS for shorts has the same compute capability restrictions.
+
 #if __CUDA_ARCH__ < 700
-
-// Inspired by https://github.com/torch/cutorch/blob/master/lib/THC/THCAtomics.cuh#L96-L119
-// Lots of bit and pointer magic, very unsafe!
-__device__ unsigned short int atomicCAS(
-    unsigned short int *address,
-    unsigned short int compare,
-    unsigned short int val
-) {
-    // Read the two shorts that make up the 32 bit int at the aligned memory location.
-    unsigned int* aligned_address = (unsigned int*) ((size_t) address & ~2);
-    // unsigned int my_short = *address;
-    unsigned int other_short = *(unsigned short int*) ((size_t) address ^ 2);
-    // Replace my_short with value in the integer.
-    const unsigned int value = val;
-    const bool aligned = ((size_t) address & 2) == 0;
-    unsigned int new_whole = aligned ? (other_short << 16) | value : (value << 16) | other_short;
-    
-    unsigned int old = atomicCAS(aligned_address, (unsigned int) compare, new_whole);
-    return aligned ? old & (0xffff) : old >> 16;
-}
-
-__device__ __half atomicAdd(__half* address, __half val) {
-    unsigned short int* casted_address = (unsigned short int*)address;
-    unsigned short int old = *casted_address;
-    unsigned short int assumed;
+// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicadd
+// The 16-bit __half floating-point version of atomicAdd() is only supported by devices of compute capability 7.x and higher.
+// Solution adapted from https://github.com/torch/cutorch/blob/master/lib/THC/THCAtomics.cuh#L96-L119
+__device__ __half atomicAdd(__half *address, __half val) {
+    unsigned int *address_as_ui = (unsigned int *) ((char *)address - ((size_t)address & 2));
+    unsigned int old = *address_as_ui;
+    unsigned int assumed;
+    bool unaligned = (size_t) address & 2;
     do {
         assumed = old;
-        old = atomicCAS(casted_address, assumed, __half_as_ushort(val + __ushort_as_half(assumed)));
-    } while (assumed != old);
-    return __ushort_as_half(old);
-}
+        unsigned int hsum;
+        hsum = unaligned ? (old >> 16) : (old & 0xffff);
+        hsum = __half_as_ushort(__ushort_as_half(hsum) + val); 
+        old = atomicCAS(address_as_ui, assumed,
+            unaligned ? (old & 0xffff) | (hsum << 16) : (old & 0xffff0000) | hsum
+        );
 
+   } while (assumed != old);
+   return __ushort_as_half(unaligned ? (old >> 16) : (old & 0xffff));
+}
 #endif


### PR DESCRIPTION
Removes my broken `atomicCAS` and instead implements `atomicAdd`, `atomicMinf`, and `atomicMaxf` directly. This does unfortunately mean that some compatibility code leaks into `max_to.cu` and `min_to.cu`.

```
test result: FAILED. 384 passed; 9 failed; 0 ignored; 0 measured; 0 filtered out; finished in 29.31s
```

Failing tests seem more related to accuracy:

```
---- losses::tests::test_bce_wide_range stdout ----
thread 'losses::tests::test_bce_wide_range' panicked at 'lhs != rhs | 33.5 != 33.46875', src\losses.rs:301:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- nn::linear::tests::test_linear_initialize stdout ----
thread 'nn::linear::tests::test_linear_initialize' panicked at 'assertion failed: -bound <= v && v <= bound', src\nn\linear.rs:181:13

---- optim::adam::tests::test_default_adam_params stdout ----
thread 'optim::adam::tests::test_default_adam_params' panicked at 'lhs != rhs | 0.97998047 != 0.99121094', src\optim\adam\mod.rs:195:13

---- tensor_ops::broadcast_to::tests::test_broadcast_backwards stdout ----
thread 'tensor_ops::broadcast_to::tests::test_broadcast_backwards' panicked at 'lhs != rhs | 0.91552734 != 0.9160156', src\tensor_ops\broadcast_to.rs:148:9

---- tensor_ops::conv2d::tests::test_conv2d_s4p3k2 stdout ----
thread 'tensor_ops::conv2d::tests::test_conv2d_s4p3k2' panicked at 'lhs != rhs | 4.2578125 != 4.2460938', src\tensor_ops\conv2d\mod.rs:435:9

---- tensor_ops::conv2d::tests::test_batched_conv2d stdout ----
thread 'tensor_ops::conv2d::tests::test_batched_conv2d' panicked at 'lhs != rhs | 0.4140625 != 0.4152832', src\tensor_ops\conv2d\mod.rs:466:9

---- tensor_ops::convtrans2d::tests::test_batched_convtrans2d stdout ----
thread 'tensor_ops::convtrans2d::tests::test_batched_convtrans2d' panicked at 'lhs != rhs | -0.039520264 != 0', src\tensor_ops\convtrans2d\mod.rs:371:9

---- tensor_ops::matmul::tests::test_small_matmul_mm stdout ----
thread 'tensor_ops::matmul::tests::test_small_matmul_mm' panicked at 'lhs != rhs | 8.1171875 != 8.109375', src\tensor_ops\matmul\mod.rs:674:13

---- tensor_ops::sum_to::tests::test_sum_broadcasted stdout ----
thread 'tensor_ops::sum_to::tests::test_sum_broadcasted' panicked at 'lhs != rhs | -4.3203125 != -4.3242188', src\tensor_ops\sum_to\mod.rs:143:9
```