### PR TITLE
[Breaking] Optimizer config values are now all f64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ indicatif = "0.17.3"
 glob = { version = "0.3.1", optional = true }
 
 [features]
-default = ["std", "fast-alloc", "cpu-par-matmul", "test-f16"]
+default = ["std", "fast-alloc", "cpu-par-matmul"]
 nightly = ["half?/use-intrinsics"]
 
 std = ["cudarc?/std", "matrixmultiply?/std", "rand_distr/std_math"]

--- a/src/nn/impl_module_for_tuples.rs
+++ b/src/nn/impl_module_for_tuples.rs
@@ -108,7 +108,7 @@ mod tests {
     fn test_2_tuple_update() {
         let dev: TestDevice = Default::default();
         type Model = (Linear<2, 3>, Linear<3, 4>);
-        let mut model = Model::build_on_device(&dev);
+        let mut model = dev.build_module::<Model, f32>();
         assert_ne!(model.0.weight.array(), [[0.0; 2]; 3]);
         assert_ne!(model.0.bias.array(), [0.0; 3]);
         assert_ne!(model.1.weight.array(), [[0.0; 3]; 4]);

--- a/src/optim/adam/adam.cu
+++ b/src/optim/adam/adam.cu
@@ -6,14 +6,13 @@ enum WeightDecayType {
     Decoupled
 };
 
-template<typename T>
 struct AdamConfig {
-    T lr;
-    T beta1;
-    T beta2;
-    T eps;
+    double lr;
+    double beta1;
+    double beta2;
+    double eps;
     WeightDecayType weight_decay_type;
-    T weight_decay;
+    double weight_decay;
 };
 
 template<typename T>
@@ -58,60 +57,9 @@ __device__ void adam_update(
     param[i] -= g;
 }
 
-__device__ void adam_update(
-    const AdamConfig<__half> cfg,
-    const size_t numel,
-    const int t,
-    __half* param,
-    __half* moment1,
-    __half* moment2,
-    const __half* grad
-) {
-    unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-
-    if (i >= numel) {
-        return;
-    }
-
-    const float t_f32 = t;
-
-    const AdamConfig<float> cfg_f32 = AdamConfig<float> {
-        cfg.lr,
-        cfg.beta1,
-        cfg.beta2,
-        cfg.eps,
-        cfg.weight_decay_type,
-        cfg.weight_decay,
-    };
-
-    float p = param[i];
-    float g = grad[i];
-    float m = moment1[i];
-    float v = moment2[i];
-    float one = 1.0;
-
-    if (cfg_f32.weight_decay_type == L2) {
-        g += cfg_f32.weight_decay * p;
-    }
-
-    m = m * cfg_f32.beta1 + g * (one - cfg_f32.beta1);
-    v = v * cfg_f32.beta2 + g * g * (one - cfg_f32.beta2);
-    float m_hat = m * one / (one - powg(cfg_f32.beta1, t_f32));
-    float v_hat = v * one / (one - powg(cfg_f32.beta2, t_f32));
-    g = cfg_f32.lr * m_hat / (sqrtg(v_hat) + cfg_f32.eps);
-
-    if (cfg_f32.weight_decay_type == Decoupled) {
-        g += cfg_f32.weight_decay * cfg_f32.lr * p;
-    }
-
-    moment1[i] = __float2half(m);
-    moment2[i] = __float2half(v);
-    param[i] -= __float2half(g);
-}
-
 #define ADAM(TYPENAME, FN) \
 extern "C" __global__ void FN( \
-    const AdamConfig<TYPENAME> cfg, \
+    const AdamConfig cfg, \
     const size_t numel, \
     const int t, \
     TYPENAME* param, \

--- a/src/optim/adam/cpu_kernel.rs
+++ b/src/optim/adam/cpu_kernel.rs
@@ -5,29 +5,33 @@ impl<E: num_traits::Float + Dtype> AdamKernel<E> for Cpu {
     fn update(
         &self,
         t: i32,
-        cfg: &AdamConfig<E>,
+        cfg: &AdamConfig,
         param: &mut Self::Vec<E>,
         moment1: &mut Self::Vec<E>,
         moment2: &mut Self::Vec<E>,
         grad: &Self::Vec<E>,
     ) -> Result<(), Self::Err> {
+        let betas = cfg.betas.map(E::from_f64).map(Option::unwrap);
+        let eps = E::from_f64(cfg.eps).unwrap();
+        let lr = E::from_f64(cfg.lr).unwrap();
+
         for ((p, mut g), (m, v)) in param
             .iter_mut()
             .zip(grad.iter().cloned())
             .zip(moment1.iter_mut().zip(moment2.iter_mut()))
         {
             if let Some(WeightDecay::L2(wd)) = cfg.weight_decay {
-                g += wd * *p;
+                g += E::from_f64(wd).unwrap() * *p;
             }
 
-            *m = *m * cfg.betas[0] + g * (E::one() - cfg.betas[0]);
-            *v = *v * cfg.betas[1] + g.powi(2) * (E::one() - cfg.betas[1]);
-            let m_hat = *m * (E::one() - cfg.betas[0].powi(t)).recip();
-            let v_hat = *v * (E::one() - cfg.betas[1].powi(t)).recip();
-            g = cfg.lr * m_hat / (v_hat.sqrt() + cfg.eps);
+            *m = *m * betas[0] + g * (E::one() - betas[0]);
+            *v = *v * betas[1] + g.powi(2) * (E::one() - betas[1]);
+            let m_hat = *m * (E::one() - betas[0].powi(t)).recip();
+            let v_hat = *v * (E::one() - betas[1].powi(t)).recip();
+            g = lr * m_hat / (v_hat.sqrt() + eps);
 
             if let Some(WeightDecay::Decoupled(wd)) = cfg.weight_decay {
-                g += wd * cfg.lr * *p;
+                g += E::from_f64(wd * cfg.lr).unwrap() * *p;
             }
 
             *p -= g;

--- a/src/optim/adam/cuda_kernel.rs
+++ b/src/optim/adam/cuda_kernel.rs
@@ -7,18 +7,18 @@ use crate::{
 use cudarc::driver::{DeviceRepr, DeviceSlice, LaunchAsync};
 
 #[repr(C)]
-struct CudaAdamConfig<E> {
-    lr: E,
-    beta1: E,
-    beta2: E,
-    eps: E,
+struct CudaAdamConfig {
+    lr: f64,
+    beta1: f64,
+    beta2: f64,
+    eps: f64,
     weight_decay_type: WeightDecayType,
-    weight_decay: E,
+    weight_decay: f64,
 }
 
-unsafe impl<E: DeviceRepr> DeviceRepr for CudaAdamConfig<E> {}
+unsafe impl DeviceRepr for CudaAdamConfig {}
 
-fn adam_config_to_cuda<E: Default + Copy>(config: &super::AdamConfig<E>) -> CudaAdamConfig<E> {
+fn adam_config_to_cuda(config: &super::AdamConfig) -> CudaAdamConfig {
     let (weight_decay_type, weight_decay) = weight_decay_to_cuda(config.weight_decay);
 
     CudaAdamConfig {
@@ -61,7 +61,7 @@ where
     fn update(
         &self,
         t: i32,
-        cfg: &super::AdamConfig<E>,
+        cfg: &super::AdamConfig,
         param: &mut Self::Vec<E>,
         moment1: &mut Self::Vec<E>,
         moment2: &mut Self::Vec<E>,

--- a/src/optim/adam/mod.rs
+++ b/src/optim/adam/mod.rs
@@ -27,26 +27,26 @@ use super::{Optimizer, OptimizerUpdateError, UnusedTensors, WeightDecay};
 /// };
 /// ```
 #[derive(Debug, Clone, Copy)]
-pub struct AdamConfig<E> {
+pub struct AdamConfig {
     /// Learning rate. Defaults to `1e-3`.
-    pub lr: E,
+    pub lr: f64,
 
     /// Betas from Adam paper. Defaults to `[0.9, 0.999]`.
-    pub betas: [E; 2],
+    pub betas: [f64; 2],
 
     /// Epsilon for numerical stability. Defaults to `1e-8`.
-    pub eps: E,
+    pub eps: f64,
 
     /// Optional weight decay. Defaults to `None`.
-    pub weight_decay: Option<WeightDecay<E>>,
+    pub weight_decay: Option<WeightDecay>,
 }
 
-impl<E: Dtype> Default for AdamConfig<E> {
+impl Default for AdamConfig {
     fn default() -> Self {
         Self {
-            lr: E::from_f32(1e-3).unwrap(),
-            betas: [E::from_f32(0.9).unwrap(), E::from_f32(0.999).unwrap()],
-            eps: E::from_f32(1e-8).unwrap(),
+            lr: 1e-3,
+            betas: [0.9, 0.999],
+            eps: 1e-8,
             weight_decay: None,
         }
     }
@@ -73,7 +73,7 @@ impl<E: Dtype> Default for AdamConfig<E> {
 #[derive(Debug)]
 pub struct Adam<M, E: Dtype, D: DeviceStorage> {
     /// Hyperparameter configuration
-    pub cfg: AdamConfig<E>,
+    pub cfg: AdamConfig,
 
     t: i32,
     moment1: Gradients<E, D>,
@@ -84,7 +84,7 @@ pub struct Adam<M, E: Dtype, D: DeviceStorage> {
 
 impl<M, E: Dtype, D: DeviceStorage> Adam<M, E, D> {
     /// Constructs using hyperparameters from `cfg`.
-    pub fn new(_model: &M, cfg: AdamConfig<E>) -> Self {
+    pub fn new(_model: &M, cfg: AdamConfig) -> Self {
         Self {
             cfg,
             t: 0,
@@ -99,7 +99,7 @@ pub trait AdamKernel<E: Dtype>: DeviceStorage {
     fn update(
         &self,
         t: i32,
-        cfg: &AdamConfig<E>,
+        cfg: &AdamConfig,
         param: &mut Self::Vec<E>,
         moment1: &mut Self::Vec<E>,
         moment2: &mut Self::Vec<E>,

--- a/src/optim/optimizer.rs
+++ b/src/optim/optimizer.rs
@@ -4,14 +4,14 @@ use crate::{
 };
 
 /// L2 and decoupled regularization methods
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum WeightDecay<E> {
+#[derive(Debug, Clone, Copy)]
+pub enum WeightDecay {
     /// Weight decay applied to the gradients before any momentum updates. Equivalent to L2 regularization.
-    L2(E),
+    L2(f64),
 
     /// Weight decay applied after any momentum updates, without modifying the gradients.
     /// See [Decoupled Weight Decay Regularization](https://arxiv.org/abs/1711.05101)
-    Decoupled(E),
+    Decoupled(f64),
 }
 
 /// Used to communicate the "WeightDecay" enum to cuda kernels
@@ -25,7 +25,7 @@ pub(super) enum WeightDecayType {
 }
 
 #[cfg(feature = "cuda")]
-pub(super) fn weight_decay_to_cuda<E: Default>(wd: Option<WeightDecay<E>>) -> (WeightDecayType, E) {
+pub(super) fn weight_decay_to_cuda(wd: Option<WeightDecay>) -> (WeightDecayType, f64) {
     match wd {
         None => (WeightDecayType::None, Default::default()),
         Some(WeightDecay::L2(x)) => (WeightDecayType::L2, x),
@@ -34,13 +34,13 @@ pub(super) fn weight_decay_to_cuda<E: Default>(wd: Option<WeightDecay<E>>) -> (W
 }
 
 /// Momentum used for [super::Sgd] and others
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Momentum<E> {
+#[derive(Debug, Clone, Copy)]
+pub enum Momentum {
     /// Momentum that is applied to the velocity of a parameter directly.
-    Classic(E),
+    Classic(f64),
 
     /// Momentum that is applied to both velocity and gradients. See [super::Sgd] nesterov paper for more.
-    Nesterov(E),
+    Nesterov(f64),
 }
 
 /// Used to communicate the "Momentum" enum to cuda kernels
@@ -54,7 +54,7 @@ pub(super) enum MomentumType {
 }
 
 #[cfg(feature = "cuda")]
-pub(super) fn momentum_to_cuda<E: Default>(wd: Option<Momentum<E>>) -> (MomentumType, E) {
+pub(super) fn momentum_to_cuda(wd: Option<Momentum>) -> (MomentumType, f64) {
     match wd {
         None => (MomentumType::None, Default::default()),
         Some(Momentum::Classic(x)) => (MomentumType::Classic, x),

--- a/src/optim/rmsprop/cpu_kernel.rs
+++ b/src/optim/rmsprop/cpu_kernel.rs
@@ -5,47 +5,50 @@ use super::{RMSpropConfig, RMSpropKernel};
 impl<E: num_traits::Float + Dtype> RMSpropKernel<E> for Cpu {
     fn update(
         &self,
-        cfg: &RMSpropConfig<E>,
+        cfg: &RMSpropConfig,
         param: &mut Self::Vec<E>,
         momentum: &mut Self::Vec<E>,
         square_avg: &mut Self::Vec<E>,
         grad_avg: &mut Self::Vec<E>,
         grad: &Self::Vec<E>,
     ) -> Result<(), Self::Err> {
+        let alpha = E::from_f64(cfg.alpha).unwrap();
+        let eps = E::from_f64(cfg.eps).unwrap();
+        let lr = E::from_f64(cfg.lr).unwrap();
         for ((p, mut g), (s_avg, (g_avg, m))) in param.iter_mut().zip(grad.iter().cloned()).zip(
             square_avg
                 .iter_mut()
                 .zip(grad_avg.iter_mut().zip(momentum.iter_mut())),
         ) {
             if let Some(WeightDecay::L2(wd)) = cfg.weight_decay {
-                g += wd * *p;
+                g += E::from_f64(wd).unwrap() * *p;
             }
 
             // sa = a * sa + (1 - a) * g^2
-            *s_avg += (E::one() - cfg.alpha) * (g * g - *s_avg);
+            *s_avg += (E::one() - alpha) * (g * g - *s_avg);
 
             let avg = if cfg.centered {
                 // ga = a * ga + (1 - a) * g
-                *g_avg += (E::one() - cfg.alpha) * (g - *g_avg);
-                // NOTE: cfg.eps in sqrt
-                (*s_avg - g_avg.powi(2) + cfg.eps).sqrt()
+                *g_avg += (E::one() - alpha) * (g - *g_avg);
+                // NOTE: eps in sqrt
+                (*s_avg - g_avg.powi(2) + eps).sqrt()
             } else {
-                // NOTE: cfg.eps in sqrt
-                (*s_avg + cfg.eps).sqrt()
+                // NOTE: eps in sqrt
+                (*s_avg + eps).sqrt()
             };
 
             g /= avg;
 
             match cfg.momentum {
                 Some(u) => {
-                    *m = *m * u + g;
-                    g = *m * cfg.lr;
+                    *m = *m * E::from_f64(u).unwrap() + g;
+                    g = *m * lr;
                 }
-                None => g *= cfg.lr,
+                None => g *= lr,
             }
 
             if let Some(WeightDecay::Decoupled(wd)) = cfg.weight_decay {
-                g += wd * cfg.lr * *p;
+                g += E::from_f64(wd * cfg.lr).unwrap() * *p;
             }
 
             *p -= g;

--- a/src/optim/rmsprop/cuda_kernel.rs
+++ b/src/optim/rmsprop/cuda_kernel.rs
@@ -8,20 +8,20 @@ use crate::{
 use cudarc::driver::{DeviceRepr, DeviceSlice, LaunchAsync};
 
 #[repr(C)]
-struct CudaRMSpropConfig<E> {
-    lr: E,
-    alpha: E,
-    eps: E,
+struct CudaRMSpropConfig {
+    lr: f64,
+    alpha: f64,
+    eps: f64,
     centered: bool,
     has_momentum: bool,
-    momentum: E,
+    momentum: f64,
     weight_decay_type: WeightDecayType,
-    weight_decay: E,
+    weight_decay: f64,
 }
 
-unsafe impl<E: DeviceRepr> DeviceRepr for CudaRMSpropConfig<E> {}
+unsafe impl DeviceRepr for CudaRMSpropConfig {}
 
-fn rmsprop_config_to_cuda<E: Default + Copy>(config: &RMSpropConfig<E>) -> CudaRMSpropConfig<E> {
+fn rmsprop_config_to_cuda(config: &RMSpropConfig) -> CudaRMSpropConfig {
     let (weight_decay_type, weight_decay) = weight_decay_to_cuda(config.weight_decay);
     let (has_momentum, momentum) = if let Some(m) = config.momentum {
         (true, m)
@@ -70,7 +70,7 @@ where
 {
     fn update(
         &self,
-        cfg: &RMSpropConfig<E>,
+        cfg: &RMSpropConfig,
         param: &mut Self::Vec<E>,
         momentum: &mut Self::Vec<E>,
         square_avg: &mut Self::Vec<E>,

--- a/src/optim/rmsprop/mod.rs
+++ b/src/optim/rmsprop/mod.rs
@@ -16,33 +16,33 @@ use super::{Optimizer, OptimizerUpdateError, UnusedTensors, WeightDecay};
 
 /// Configuration of hyperparameters for [RMSprop].
 #[derive(Debug, Clone, Copy)]
-pub struct RMSpropConfig<E> {
+pub struct RMSpropConfig {
     /// Learning rate. Defaults to `1e-2`.
-    pub lr: E,
+    pub lr: f64,
 
     /// Value for exponential moving average. Defaults to `0.9`.
-    pub alpha: E,
+    pub alpha: f64,
 
     /// Epsilon for stability. Defaults to `1e-8`.
-    pub eps: E,
+    pub eps: f64,
 
     /// Optional momentum. Defaults to `None`.
-    pub momentum: Option<E>,
+    pub momentum: Option<f64>,
 
     /// Whether the avg should be centered by the grad's avg value.
     /// Defaults to `false`.
     pub centered: bool,
 
     /// Optional weight decay. Defaults to `None`.
-    pub weight_decay: Option<WeightDecay<E>>,
+    pub weight_decay: Option<WeightDecay>,
 }
 
-impl<E: Dtype> Default for RMSpropConfig<E> {
+impl Default for RMSpropConfig {
     fn default() -> Self {
         Self {
-            lr: E::from_f32(1e-2).unwrap(),
-            alpha: E::from_f32(0.9).unwrap(),
-            eps: E::from_f32(1e-8).unwrap(),
+            lr: 1e-2,
+            alpha: 0.9,
+            eps: 1e-8,
             momentum: None,
             centered: false,
             weight_decay: None,
@@ -80,7 +80,7 @@ impl<E: Dtype> Default for RMSpropConfig<E> {
 #[derive(Debug)]
 pub struct RMSprop<M, E: Dtype, D: DeviceStorage> {
     /// Hyperparameter configuration
-    pub cfg: RMSpropConfig<E>,
+    pub cfg: RMSpropConfig,
 
     step: usize,
     momentums: Gradients<E, D>,
@@ -92,7 +92,7 @@ pub struct RMSprop<M, E: Dtype, D: DeviceStorage> {
 
 impl<M, E: Dtype, D: DeviceStorage> RMSprop<M, E, D> {
     /// Constructs using hyperparameters from `cfg`.
-    pub fn new(_model: &M, cfg: RMSpropConfig<E>) -> Self {
+    pub fn new(_model: &M, cfg: RMSpropConfig) -> Self {
         Self {
             cfg,
             step: 0,
@@ -107,7 +107,7 @@ impl<M, E: Dtype, D: DeviceStorage> RMSprop<M, E, D> {
 pub trait RMSpropKernel<E: Dtype>: DeviceStorage {
     fn update(
         &self,
-        cfg: &RMSpropConfig<E>,
+        cfg: &RMSpropConfig,
         param: &mut Self::Vec<E>,
         momentum: &mut Self::Vec<E>,
         square_avg: &mut Self::Vec<E>,
@@ -186,7 +186,7 @@ mod tests {
     use super::*;
     use crate::{shapes::*, tensor_ops::*, tests::*};
 
-    fn test_matches_expected(cfg: RMSpropConfig<TestDtype>, expected: [[f64; 5]; 5]) {
+    fn test_matches_expected(cfg: RMSpropConfig, expected: [[f64; 5]; 5]) {
         let dev: TestDevice = Default::default();
         let rate = dev
             .tensor([0.1, 1.0, 2.0, 10.0, 100.0])

--- a/src/optim/rmsprop/rmsprop.cu
+++ b/src/optim/rmsprop/rmsprop.cu
@@ -6,21 +6,20 @@ enum WeightDecayType {
     Decoupled
 };
 
-template<typename T>
 struct RMSpropConfig {
-    T lr;
-    T alpha;
-    T eps;
+    double lr;
+    double alpha;
+    double eps;
     bool centered;
     bool has_momentum;
-    T momentum;
+    double momentum;
     WeightDecayType weight_decay_type;
-    T weight_decay;
+    double weight_decay;
 };
 
 template<typename T>
 __device__ void rmsprop_update(
-    const RMSpropConfig<T> cfg,
+    const RMSpropConfig cfg,
     const size_t numel,
     T* param,
     T* momentum,
@@ -76,76 +75,9 @@ __device__ void rmsprop_update(
     param[i] -= g;
 }
 
-__device__ void rmsprop_update(
-    const RMSpropConfig<__half> cfg,
-    const size_t numel,
-    __half* param,
-    __half* momentum,
-    __half* square_avg,
-    __half* grad_avg,
-    const __half* grad
-) {
-    unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i >= numel) {
-        return;
-    }
-
-    RMSpropConfig<float> cfg_f32 = RMSpropConfig<float> {
-        cfg.lr,
-        cfg.alpha,
-        cfg.eps,
-        cfg.centered,
-        cfg.has_momentum,
-        cfg.momentum,
-        cfg.weight_decay_type,
-        cfg.weight_decay,
-    };
-
-    float p = param[i];
-    float g = grad[i];
-    float s_avg = square_avg[i];
-    float g_avg = grad_avg[i];
-    float m = momentum[i];
-    float one = 1.0;
-
-    if (cfg_f32.weight_decay_type == L2) {
-        g += cfg_f32.weight_decay * p;
-    }
-
-    s_avg += (one - cfg_f32.alpha) * (g * g - s_avg);
-
-    float avg;
-
-    if (cfg_f32.centered) {
-        // ga = a * ga + (1 - a) * g
-        g_avg += (one - cfg_f32.alpha) * (g - g_avg);
-        avg = sqrtg(s_avg - g_avg * g_avg + cfg_f32.eps);
-    } else {
-        avg = sqrtg(s_avg + cfg_f32.eps);
-    };
-
-    g /= avg;
-
-    if (cfg_f32.has_momentum) {
-        m = m * cfg_f32.momentum + g;
-        g = m * cfg_f32.lr;
-    } else {
-        g *= cfg_f32.lr;
-    }
-
-    if (cfg_f32.weight_decay_type == Decoupled) {
-        g += cfg_f32.weight_decay * cfg_f32.lr * p;
-    }
-
-    square_avg[i] = __float2half(s_avg);
-    grad_avg[i] = __float2half(g_avg);
-    momentum[i] = __float2half(m);
-    param[i] -= __float2half(g);
-}
-
 #define RMSPROP(TYPENAME, FN) \
 extern "C" __global__ void FN( \
-    const RMSpropConfig<TYPENAME> cfg, \
+    const RMSpropConfig cfg, \
     const size_t numel, \
     TYPENAME* param, \
     TYPENAME* momentum, \

--- a/src/optim/sgd/cpu_kernel.rs
+++ b/src/optim/sgd/cpu_kernel.rs
@@ -9,34 +9,39 @@ use super::{SgdConfig, SgdKernel};
 impl<E: Dtype> SgdKernel<E> for Cpu {
     fn update(
         &self,
-        cfg: &SgdConfig<E>,
+        cfg: &SgdConfig,
         param: &mut Self::Vec<E>,
         velocity: &mut Self::Vec<E>,
         grad: &Self::Vec<E>,
     ) -> Result<(), Self::Err> {
+        let lr = E::from_f64(cfg.lr).unwrap();
+
         for ((p, mut g), v) in param
             .iter_mut()
             .zip(grad.iter().cloned())
             .zip(velocity.iter_mut())
         {
             if let Some(WeightDecay::L2(wd)) = cfg.weight_decay {
+                let wd = E::from_f64(wd).unwrap();
                 g += wd * *p;
             }
 
             match cfg.momentum {
                 Some(Momentum::Classic(u)) => {
+                    let u = E::from_f64(u).unwrap();
                     *v = g + u * *v;
-                    g = *v * cfg.lr;
+                    g = *v * lr;
                 }
                 Some(Momentum::Nesterov(u)) => {
+                    let u = E::from_f64(u).unwrap();
                     *v = g + u * *v;
-                    g = (g + u * *v) * cfg.lr;
+                    g = (g + u * *v) * lr;
                 }
-                None => g *= cfg.lr,
+                None => g *= lr,
             }
 
             if let Some(WeightDecay::Decoupled(wd)) = cfg.weight_decay {
-                g += wd * cfg.lr * *p;
+                g += E::from_f64(wd * cfg.lr).unwrap() * *p;
             }
 
             *p -= g;

--- a/src/optim/sgd/cuda_kernel.rs
+++ b/src/optim/sgd/cuda_kernel.rs
@@ -8,17 +8,17 @@ use crate::{
 use cudarc::driver::{DeviceRepr, DeviceSlice, LaunchAsync};
 
 #[repr(C)]
-struct CudaSgdConfig<E> {
-    lr: E,
+struct CudaSgdConfig {
+    lr: f64,
     momentum_type: MomentumType,
-    momentum: E,
+    momentum: f64,
     weight_decay_type: WeightDecayType,
-    weight_decay: E,
+    weight_decay: f64,
 }
 
-unsafe impl<E: DeviceRepr> DeviceRepr for CudaSgdConfig<E> {}
+unsafe impl DeviceRepr for CudaSgdConfig {}
 
-fn sgd_config_to_cuda<E: Default + Copy>(config: &SgdConfig<E>) -> CudaSgdConfig<E> {
+fn sgd_config_to_cuda(config: &SgdConfig) -> CudaSgdConfig {
     let (momentum_type, momentum) = momentum_to_cuda(config.momentum);
     let (weight_decay_type, weight_decay) = weight_decay_to_cuda(config.weight_decay);
 
@@ -60,7 +60,7 @@ where
 {
     fn update(
         &self,
-        cfg: &SgdConfig<E>,
+        cfg: &SgdConfig,
         param: &mut Self::Vec<E>,
         velocity: &mut Self::Vec<E>,
         grad: &Self::Vec<E>,

--- a/src/optim/sgd/sgd.cu
+++ b/src/optim/sgd/sgd.cu
@@ -12,18 +12,17 @@ enum WeightDecayType {
     Decoupled
 };
 
-template<typename T>
 struct SgdConfig {
-    T lr;
+    double lr;
     MomentumType momentum_type;
-    T momentum;
+    double momentum;
     WeightDecayType weight_decay_type;
-    T weight_decay;
+    double weight_decay;
 };
 
 template<typename T>
 __device__ void sgd_update(
-    const SgdConfig<T> cfg,
+    const SgdConfig cfg,
     const size_t numel,
     T* param,
     T* velocity,
@@ -63,7 +62,7 @@ __device__ void sgd_update(
 
 #define SGD(TYPENAME, FN) \
 extern "C" __global__ void FN( \
-    const SgdConfig<TYPENAME> cfg, \
+    const SgdConfig cfg, \
     const size_t numel, \
     TYPENAME* param, \
     TYPENAME* velocity, \


### PR DESCRIPTION
This is to make it easier to work with optimizers regardless of the dtype. Previously when using f16 you had to specify the configuration as half values. Since halfs aren't native types, it was difficult to write code that would work for a variety of dtypes.