### PR TITLE
Removing rerun build.rs for output destination

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -89,7 +89,6 @@ mod cuda {
             println!("cargo:rerun-if-changed={}", path.display());
             let destination =
                 std::format!("{out_dir}/{}", path.file_name().unwrap().to_str().unwrap());
-            println!("cargo:rerun-if-changed={}", destination);
             std::fs::copy(path.clone(), destination).unwrap();
             // remove the filename from the path so it's just the directory
             path.pop();


### PR DESCRIPTION
This was causing dfdx to be recompiled each time the output directory changed.