### PR TITLE
[Breaking] Moving storage GAT to trait level generic. Split DeviceStorage into multiple traits

### DIFF
--- a/examples/07-custom-module.rs
+++ b/examples/07-custom-module.rs
@@ -22,7 +22,7 @@ struct Mlp<const IN: usize, const INNER: usize, const OUT: usize, E: Dtype, D: D
 impl<const IN: usize, const INNER: usize, const OUT: usize, E, D: Device<E>> TensorCollection<E, D>
     for Mlp<IN, INNER, OUT, E, D>
 where
-    E: Dtype + num_traits::Float,
+    E: Dtype + num_traits::Float + rand_distr::uniform::SampleUniform,
 {
     // Type alias that specifies the how Mlp's type changes when using a different dtype and/or
     // device.

--- a/src/data/arange.rs
+++ b/src/data/arange.rs
@@ -1,12 +1,12 @@
 use crate::{
     shapes::*,
-    tensor::{DeviceStorage, Tensor, TensorFromVec, ZerosTensor},
+    tensor::{Storage, Tensor, TensorFromVec, ZerosTensor},
 };
 
 use std::vec::Vec;
 
 /// Generates a tensor with ordered data from 0 to `N`.
-pub trait Arange<E: Dtype>: DeviceStorage + ZerosTensor<E> + TensorFromVec<E> {
+pub trait Arange<E: Dtype>: Storage<E> + ZerosTensor<E> + TensorFromVec<E> {
     /// Generates a tensor with ordered data from 0 to `N`.
     ///
     /// Const sized tensor:

--- a/src/data/one_hot_encode.rs
+++ b/src/data/one_hot_encode.rs
@@ -2,12 +2,12 @@ use std::vec::Vec;
 
 use crate::{
     shapes::*,
-    tensor::{DeviceStorage, Tensor, TensorFromVec, ZerosTensor},
+    tensor::{Storage, Tensor, TensorFromVec, ZerosTensor},
 };
 
 /// One hot encodes an array of class labels into a 2d tensor of probability
 /// vectors. This can be used in tandem with [crate::losses::cross_entropy_with_logits_loss()].
-pub trait OneHotEncode<E: Dtype>: DeviceStorage + ZerosTensor<E> + TensorFromVec<E> {
+pub trait OneHotEncode<E: Dtype>: Storage<E> + ZerosTensor<E> + TensorFromVec<E> {
     /// One hot encodes an array or vec into a tensor.
     ///
     /// Arguments:
@@ -92,4 +92,4 @@ pub trait OneHotEncode<E: Dtype>: DeviceStorage + ZerosTensor<E> + TensorFromVec
         self.tensor_from_vec(data, (l, n))
     }
 }
-impl<E: Dtype, D: DeviceStorage + ZerosTensor<E> + TensorFromVec<E>> OneHotEncode<E> for D {}
+impl<E: Dtype, D: Storage<E> + ZerosTensor<E> + TensorFromVec<E>> OneHotEncode<E> for D {}

--- a/src/nn/activations.rs
+++ b/src/nn/activations.rs
@@ -35,22 +35,8 @@ activation_impls!(Tanh, try_tanh, #[doc="Calls [tanh()]."]);
 activation_impls!(Square, try_square, #[doc="Calls [square()]."]);
 activation_impls!(Sqrt, try_sqrt, #[doc="Calls [sqrt()]."]);
 activation_impls!(Abs, try_abs, #[doc="Calls [abs()]."]);
-
-/// Calls [softmax()].
-#[derive(Default, Debug, Clone, Copy)]
-pub struct Softmax;
-
-impl ZeroSizedModule for Softmax {}
-impl NonMutableModule for Softmax {}
-
-impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for Softmax {
-    type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, input: Tensor<S, E, D, T>) -> Result<Self::Output, D::Err> {
-        input.try_softmax::<S::LastAxis>()
-    }
-}
+activation_impls!(Softmax, try_softmax, #[doc="Calls [softmax()]."]);
+activation_impls!(LogSoftmax, try_log_softmax, #[doc="Calls [log_softmax()]."]);
 
 /// Calls [prelu()] with constant value - defaults to 0.05
 #[derive(Debug, Clone, Copy)]
@@ -187,6 +173,21 @@ mod tests {
         let t = dev.tensor([[-2.0, -1.0, 0.0], [1.0, 2.0, 3.0]]);
         let r1 = Softmax.forward_mut(t.clone());
         let r2 = t.softmax::<crate::shapes::Axis<1>>();
+        assert_eq!(r1.array(), r2.array());
+    }
+
+    #[test]
+    fn test_nn_activations_log_softmax() {
+        let dev: TestDevice = Default::default();
+
+        let t = dev.tensor([-2.0, -1.0, 0.0, 1.0, 2.0]);
+        let r1 = LogSoftmax.forward_mut(t.clone());
+        let r2 = t.log_softmax();
+        assert_eq!(r1.array(), r2.array());
+
+        let t = dev.tensor([[-2.0, -1.0, 0.0], [1.0, 2.0, 3.0]]);
+        let r1 = LogSoftmax.forward_mut(t.clone());
+        let r2 = t.log_softmax::<crate::shapes::Axis<1>>();
         assert_eq!(r1.array(), r2.array());
     }
 

--- a/src/nn/batchnorm1d.rs
+++ b/src/nn/batchnorm1d.rs
@@ -55,7 +55,7 @@ where
 /// - Running statistics: **not** updated
 /// - Normalization: calculated using running stats
 #[derive(Clone, Debug)]
-pub struct BatchNorm1D<const C: usize, E: Dtype, D: DeviceStorage> {
+pub struct BatchNorm1D<const C: usize, E: Dtype, D: Storage<E>> {
     /// Scale for affine transform. Defaults to 1.0
     pub scale: Tensor<Rank1<C>, E, D>,
     /// Bias for affine transform. Defaults to 0.0

--- a/src/nn/batchnorm2d.rs
+++ b/src/nn/batchnorm2d.rs
@@ -129,7 +129,7 @@ where
 /// - Running statistics: **not** updated
 /// - Normalization: calculated using running stats
 #[derive(Clone, Debug)]
-pub struct BatchNorm2D<const C: usize, E: Dtype, D: DeviceStorage> {
+pub struct BatchNorm2D<const C: usize, E: Dtype, D: Storage<E>> {
     /// Scale for affine transform. Defaults to 1.0
     pub scale: Tensor<Rank1<C>, E, D>,
     /// Bias for affine transform. Defaults to 0.0

--- a/src/nn/bias2d.rs
+++ b/src/nn/bias2d.rs
@@ -37,11 +37,11 @@ where
 /// model.forward(x);
 /// ```
 #[derive(Clone, Debug)]
-pub struct Bias2D<const C: usize, E: Dtype, D: DeviceStorage> {
+pub struct Bias2D<const C: usize, E: Dtype, D: Storage<E>> {
     pub bias: Tensor<Rank1<C>, E, D>,
 }
 
-impl<const C: usize, E: Dtype, D: DeviceStorage> NonMutableModule for Bias2D<C, E, D> {}
+impl<const C: usize, E: Dtype, D: Storage<E>> NonMutableModule for Bias2D<C, E, D> {}
 
 impl<const C: usize, E: Dtype, D: Device<E>> TensorCollection<E, D> for Bias2D<C, E, D> {
     type To<E2: Dtype, D2: Device<E2>> = Bias2D<C, E2, D2>;

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -72,7 +72,7 @@ pub struct Conv2D<
     const DILATION: usize,
     const GROUPS: usize,
     E: Dtype,
-    D: DeviceStorage,
+    D: Storage<E>,
 > {
     pub weight: Tensor<Rank4<OUT_CHAN, IN_CHAN, KERNEL_SIZE, KERNEL_SIZE>, E, D>,
 }
@@ -156,12 +156,9 @@ impl<
         const P: usize,
         const L: usize,
         const G: usize,
-        E,
-        D,
+        E: Dtype,
+        D: Storage<E>,
     > NonMutableModule for Conv2D<I, O, K, S, P, L, G, E, D>
-where
-    E: Dtype,
-    D: DeviceStorage,
 {
 }
 

--- a/src/nn/convtrans.rs
+++ b/src/nn/convtrans.rs
@@ -53,7 +53,7 @@ pub struct ConvTrans2D<
     const STRIDE: usize,
     const PADDING: usize,
     E: Dtype,
-    D: DeviceStorage,
+    D: Storage<E>,
 > {
     pub weight: Tensor<Rank4<OUT_CHAN, IN_CHAN, KERNEL_SIZE, KERNEL_SIZE>, E, D>,
 }
@@ -104,7 +104,7 @@ impl<const I: usize, const O: usize, const K: usize, const S: usize, const P: us
     NonMutableModule for ConvTrans2D<I, O, K, S, P, E, D>
 where
     E: Dtype,
-    D: DeviceStorage,
+    D: Storage<E>,
 {
 }
 

--- a/src/nn/embedding.rs
+++ b/src/nn/embedding.rs
@@ -50,12 +50,12 @@ where
 /// let _: Tensor<(Const<10>, Const<5>, Const<2>), f32, _> = model.forward(inputs);
 /// ```
 #[derive(Debug, Clone)]
-pub struct Embedding<const VOCAB: usize, const DIM: usize, E: Dtype, D: DeviceStorage> {
+pub struct Embedding<const VOCAB: usize, const DIM: usize, E: Dtype, D: Storage<E>> {
     /// Transposed weight matrix, shape (I, O)
     pub weight: Tensor<Rank2<VOCAB, DIM>, E, D>,
 }
 
-impl<const V: usize, const M: usize, E: Dtype, D: DeviceStorage> NonMutableModule
+impl<const V: usize, const M: usize, E: Dtype, D: Storage<E>> NonMutableModule
     for Embedding<V, M, E, D>
 {
 }

--- a/src/nn/impl_module_for_tuples.rs
+++ b/src/nn/impl_module_for_tuples.rs
@@ -1,6 +1,36 @@
-use crate::{shapes::*, tensor_ops::*};
+use crate::{shapes::*, tensor::HasErr, tensor_ops::*};
 
 use super::*;
+
+impl<E: Dtype, D: Device<E>> TensorCollection<E, D> for () {
+    type To<E2: Dtype, D2: Device<E2>> = ();
+
+    fn iter_tensors<V: ModuleVisitor<Self, E, D>>(
+        _: &mut V,
+    ) -> Result<Option<Self::To<V::E2, V::D2>>, V::Err> {
+        Ok(None)
+    }
+}
+
+impl<D: Device<E>, E: Dtype> BuildOnDevice<D, E> for () {
+    type Built = ();
+}
+
+impl<X: HasErr> Module<X> for () {
+    type Output = X;
+    type Error = X::Err;
+    fn try_forward(&self, input: X) -> Result<Self::Output, Self::Error> {
+        Ok(input)
+    }
+}
+
+impl<X: HasErr> ModuleMut<X> for () {
+    type Output = X;
+    type Error = X::Err;
+    fn try_forward_mut(&mut self, input: X) -> Result<Self::Output, Self::Error> {
+        Ok(input)
+    }
+}
 
 macro_rules! tuple_impls {
     ([$($name:ident),+] [$($idx:tt),+], $last:ident, [$($rev_tail:ident),*]) => {

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -36,13 +36,13 @@ where
 /// ```
 
 #[derive(Debug, Clone)]
-pub struct LayerNorm1D<const M: usize, E: Dtype, D: DeviceStorage> {
+pub struct LayerNorm1D<const M: usize, E: Dtype, D: Storage<E>> {
     pub gamma: Tensor<Rank1<M>, E, D>,
     pub beta: Tensor<Rank1<M>, E, D>,
     pub epsilon: f64,
 }
 
-impl<const M: usize, E: Dtype, D: DeviceStorage> NonMutableModule for LayerNorm1D<M, E, D> {}
+impl<const M: usize, E: Dtype, D: Storage<E>> NonMutableModule for LayerNorm1D<M, E, D> {}
 
 impl<const M: usize, E: Dtype, D: Device<E>> TensorCollection<E, D> for LayerNorm1D<M, E, D> {
     type To<E2: Dtype, D2: Device<E2>> = LayerNorm1D<M, E2, D2>;

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -43,7 +43,7 @@ where
 /// let _: Tensor<Rank2<10, 2>, f32, _> = model.forward(dev.zeros::<Rank2<10, 5>>());
 /// ```
 #[derive(Debug, Clone)]
-pub struct Linear<const I: usize, const O: usize, E: Dtype, D: DeviceStorage> {
+pub struct Linear<const I: usize, const O: usize, E: Dtype, D: Storage<E>> {
     /// Transposed weight matrix, shape (I, O)
     pub weight: Tensor<Rank2<O, I>, E, D>,
 
@@ -51,7 +51,7 @@ pub struct Linear<const I: usize, const O: usize, E: Dtype, D: DeviceStorage> {
     pub bias: Tensor<Rank1<O>, E, D>,
 }
 
-impl<const I: usize, const O: usize, E: Dtype, D: DeviceStorage> NonMutableModule
+impl<const I: usize, const O: usize, E: Dtype, D: Storage<E>> NonMutableModule
     for Linear<I, O, E, D>
 {
 }
@@ -107,7 +107,7 @@ where
 }
 
 #[derive(Clone, Debug)]
-struct Bias1D<'a, const M: usize, E: Dtype, D: DeviceStorage> {
+struct Bias1D<'a, const M: usize, E: Dtype, D: Storage<E>> {
     beta: &'a Tensor<Rank1<M>, E, D>,
 }
 

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -56,8 +56,12 @@ impl<const I: usize, const O: usize, E: Dtype, D: Storage<E>> NonMutableModule
 {
 }
 
-impl<const I: usize, const O: usize, E: Dtype + num_traits::Float, D: Device<E>>
-    TensorCollection<E, D> for Linear<I, O, E, D>
+impl<
+        const I: usize,
+        const O: usize,
+        E: Dtype + num_traits::Float + rand_distr::uniform::SampleUniform,
+        D: Device<E>,
+    > TensorCollection<E, D> for Linear<I, O, E, D>
 {
     type To<E2: Dtype, D2: Device<E2>> = Linear<I, O, E2, D2>;
 

--- a/src/nn/module.rs
+++ b/src/nn/module.rs
@@ -1,7 +1,7 @@
 pub use super::build_module::BuildModule;
 pub use super::to_device::*;
 
-use crate::{shapes::Dtype, tensor::DeviceStorage, tensor_ops::Device};
+use crate::{shapes::Dtype, tensor_ops::Device};
 
 use super::tensor_collection::*;
 
@@ -55,7 +55,7 @@ pub trait BuildOnDevice<D: Device<E>, E: Dtype> {
 
 /// An extension trait that allows you to build a module with a device
 /// method. Also allows easy specification of Dtype.
-pub trait DeviceBuildExt: DeviceStorage {
+pub trait DeviceBuildExt {
     fn build_module<M: BuildOnDevice<Self, E>, E: Dtype>(&self) -> M::Built
     where
         Self: Device<E>,
@@ -69,7 +69,9 @@ pub trait DeviceBuildExt: DeviceStorage {
         M::try_build_on_device(self)
     }
 }
-impl<D: DeviceStorage> DeviceBuildExt for D {}
+impl DeviceBuildExt for crate::tensor::Cpu {}
+#[cfg(feature = "cuda")]
+impl DeviceBuildExt for crate::tensor::Cuda {}
 
 /// Marker trait for modules with no updatable parameters. These have
 /// blanket impls for, and [ModuleMut]

--- a/src/nn/tensor_collection/collection.rs
+++ b/src/nn/tensor_collection/collection.rs
@@ -23,7 +23,7 @@ use super::{ModuleField, ModuleFields, TensorField};
 ///     relu: ReLU,
 /// }
 ///
-/// impl<E: Dtype + num_traits::Float, D: Device<E>> TensorCollection<E, D> for Mlp<E, D> {
+/// impl<E: Dtype + num_traits::Float + rand_distr::uniform::SampleUniform, D: Device<E>> TensorCollection<E, D> for Mlp<E, D> {
 ///     type To<E2: Dtype, D2: Device<E2>> = Mlp<E2, D2>;
 ///
 ///     fn iter_tensors<V: ModuleVisitor<Self, E, D>>(

--- a/src/nn/transformer/decoder.rs
+++ b/src/nn/transformer/decoder.rs
@@ -4,7 +4,7 @@ use rand_distr::uniform::SampleUniform;
 use crate::{
     nn::modules::*,
     shapes::Dtype,
-    tensor::{DeviceStorage, HasErr, PutTape, SplitTape},
+    tensor::{HasErr, PutTape, SplitTape, Storage},
     tensor_ops::{Device, TryAdd},
 };
 
@@ -64,7 +64,7 @@ pub struct TransformerDecoder<
     const FF_DIM: usize,
     const NUM_LAYERS: usize,
     E: Dtype,
-    D: DeviceStorage,
+    D: Storage<E>,
 >(pub Repeated<TransformerDecoderBlock<MODEL_DIM, NUM_HEADS, FF_DIM, E, D>, NUM_LAYERS>);
 
 impl<const M: usize, const H: usize, const F: usize, const L: usize, E: Dtype, D: Device<E>>
@@ -127,7 +127,7 @@ pub struct TransformerDecoderBlock<
     const NUM_HEADS: usize,
     const FF_DIM: usize,
     E: Dtype,
-    D: DeviceStorage,
+    D: Storage<E>,
 > {
     pub self_attn: MultiHeadAttention<MODEL_DIM, NUM_HEADS, MODEL_DIM, MODEL_DIM, E, D>,
     pub norm1: LayerNorm1D<MODEL_DIM, E, D>,

--- a/src/nn/transformer/encoder.rs
+++ b/src/nn/transformer/encoder.rs
@@ -4,7 +4,7 @@ use rand_distr::uniform::SampleUniform;
 use crate::{
     nn::modules::*,
     shapes::Dtype,
-    tensor::{DeviceStorage, PutTape, SplitTape},
+    tensor::{PutTape, SplitTape, Storage},
     tensor_ops::Device,
 };
 
@@ -85,7 +85,7 @@ pub struct TransformerEncoderBlock<
     const NUM_HEADS: usize,
     const FF_DIM: usize,
     E: Dtype,
-    D: DeviceStorage,
+    D: Storage<E>,
 > {
     pub self_attn: MultiHeadAttention<MODEL_DIM, NUM_HEADS, MODEL_DIM, MODEL_DIM, E, D>,
     pub norm1: LayerNorm1D<MODEL_DIM, E, D>,

--- a/src/nn/transformer/mha.rs
+++ b/src/nn/transformer/mha.rs
@@ -55,7 +55,7 @@ pub struct MultiHeadAttention<
     const K_DIM: usize,
     const V_DIM: usize,
     E: Dtype,
-    D: DeviceStorage,
+    D: Storage<E>,
 > {
     pub w_q: Linear<EMBED_DIM, K_DIM, E, D>,
     pub w_k: Linear<EMBED_DIM, K_DIM, E, D>,

--- a/src/nn/transformer/mod.rs
+++ b/src/nn/transformer/mod.rs
@@ -72,7 +72,7 @@ pub struct Transformer<
     const NUM_DECODER_LAYERS: usize,
     const FF_DIM: usize,
     E: Dtype,
-    D: DeviceStorage,
+    D: Storage<E>,
 > {
     pub encoder: TransformerEncoder<MODEL_DIM, NUM_HEADS, FF_DIM, NUM_ENCODER_LAYERS, E, D>,
     pub decoder: TransformerDecoder<MODEL_DIM, NUM_HEADS, FF_DIM, NUM_DECODER_LAYERS, E, D>,

--- a/src/nn/unbiased_linear.rs
+++ b/src/nn/unbiased_linear.rs
@@ -43,12 +43,12 @@ where
 /// let _: Tensor<Rank2<10, 2>, f32, _> = model.forward(dev.zeros::<Rank2<10, 5>>());
 /// ```
 #[derive(Debug, Clone)]
-pub struct UnbiasedLinear<const I: usize, const O: usize, E: Dtype, D: DeviceStorage> {
+pub struct UnbiasedLinear<const I: usize, const O: usize, E: Dtype, D: Storage<E>> {
     /// Transposed weight matrix, shape (I, O)
     pub weight: Tensor<Rank2<O, I>, E, D>,
 }
 
-impl<const I: usize, const O: usize, E: Dtype, D: DeviceStorage> NonMutableModule
+impl<const I: usize, const O: usize, E: Dtype, D: Storage<E>> NonMutableModule
     for UnbiasedLinear<I, O, E, D>
 {
 }

--- a/src/nn/zero_grads.rs
+++ b/src/nn/zero_grads.rs
@@ -50,7 +50,7 @@ pub trait ZeroGrads<E: Dtype, D: Device<E>>: TensorCollection<E, D> {
 }
 impl<E: Dtype, D: Device<E>, M: TensorCollection<E, D>> ZeroGrads<E, D> for M {}
 
-struct ZeroGradOp<'a, E: Unit, D: DeviceStorage> {
+struct ZeroGradOp<'a, E: Unit, D: Storage<E>> {
     updated: Vec<UniqueId>,
     gradients: &'a mut Gradients<E, D>,
 }

--- a/src/optim/adam/cpu_kernel.rs
+++ b/src/optim/adam/cpu_kernel.rs
@@ -6,10 +6,10 @@ impl<E: num_traits::Float + Dtype> AdamKernel<E> for Cpu {
         &self,
         t: i32,
         cfg: &AdamConfig,
-        param: &mut Self::Vec<E>,
-        moment1: &mut Self::Vec<E>,
-        moment2: &mut Self::Vec<E>,
-        grad: &Self::Vec<E>,
+        param: &mut Self::Vec,
+        moment1: &mut Self::Vec,
+        moment2: &mut Self::Vec,
+        grad: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let betas = cfg.betas.map(E::from_f64).map(Option::unwrap);
         let eps = E::from_f64(cfg.eps).unwrap();

--- a/src/optim/adam/cuda_kernel.rs
+++ b/src/optim/adam/cuda_kernel.rs
@@ -62,10 +62,10 @@ where
         &self,
         t: i32,
         cfg: &super::AdamConfig,
-        param: &mut Self::Vec<E>,
-        moment1: &mut Self::Vec<E>,
-        moment2: &mut Self::Vec<E>,
-        grad: &Self::Vec<E>,
+        param: &mut Self::Vec,
+        moment1: &mut Self::Vec,
+        moment2: &mut Self::Vec,
+        grad: &Self::Vec,
     ) -> Result<(), Self::Err> {
         if !self.dev.has_func(Self::MOD, Self::FWD) {
             self.dev.load_ptx(PTX_SRC.into(), Self::MOD, &[Self::FWD])?;

--- a/src/optim/optimizer.rs
+++ b/src/optim/optimizer.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::{Dtype, Shape, Unit},
-    tensor::{DeviceStorage, Gradients, Tensor, UniqueId},
+    tensor::{Gradients, Storage, Tensor, UniqueId},
 };
 
 /// L2 and decoupled regularization methods
@@ -72,7 +72,7 @@ pub(super) fn momentum_to_cuda(wd: Option<Momentum>) -> (MomentumType, f64) {
 ///
 /// 3. Optimizer itself is generic over M, not the update method. This means a single optimizer object
 /// can only work on objects of type `M`. This also requires you to specify the model up front for the optimizer.
-pub trait Optimizer<M, D: DeviceStorage, E: Dtype> {
+pub trait Optimizer<M, D: Storage<E>, E: Dtype> {
     /// Updates all of `module`'s parameters using `gradients`.
     ///
     /// Requires a `&mut self` because the optimizer may change some internally
@@ -81,7 +81,7 @@ pub trait Optimizer<M, D: DeviceStorage, E: Dtype> {
         &mut self,
         module: &mut M,
         gradients: &Gradients<E, D>,
-    ) -> Result<(), OptimizerUpdateError<D>>;
+    ) -> Result<(), OptimizerUpdateError<D::Err>>;
 }
 
 /// Holds [UniqueId] of tensors that were missing gradients during
@@ -93,7 +93,7 @@ pub struct UnusedTensors {
 
 impl UnusedTensors {
     /// Adds a single unnammed parameter
-    pub fn add<S: Shape, E: Unit, D: DeviceStorage, T>(&mut self, t: &Tensor<S, E, D, T>) {
+    pub fn add<S: Shape, E: Unit, D: Storage<E>, T>(&mut self, t: &Tensor<S, E, D, T>) {
         self.ids.push(t.id);
     }
 
@@ -111,12 +111,12 @@ impl UnusedTensors {
 /// computation, and was therefore not present in [Gradients]
 /// during an update.
 #[derive(Debug)]
-pub enum OptimizerUpdateError<D: DeviceStorage> {
+pub enum OptimizerUpdateError<Err> {
     UnusedParams(UnusedTensors),
-    DeviceError(D::Err),
+    DeviceError(Err),
 }
 
-impl<D: DeviceStorage> std::fmt::Display for OptimizerUpdateError<D> {
+impl<Err: std::fmt::Display> std::fmt::Display for OptimizerUpdateError<Err> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::UnusedParams(unused) => write!(f, "Unused tensors: {unused:?}"),
@@ -126,11 +126,11 @@ impl<D: DeviceStorage> std::fmt::Display for OptimizerUpdateError<D> {
 }
 
 #[cfg(feature = "std")]
-impl<D: DeviceStorage + std::fmt::Debug> std::error::Error for OptimizerUpdateError<D> {}
+impl<Err: std::fmt::Debug + std::fmt::Display> std::error::Error for OptimizerUpdateError<Err> {}
 
 #[allow(clippy::from_over_into)]
-impl<D: DeviceStorage> Into<Result<(), OptimizerUpdateError<D>>> for UnusedTensors {
-    fn into(self) -> Result<(), OptimizerUpdateError<D>> {
+impl<Err> Into<Result<(), OptimizerUpdateError<Err>>> for UnusedTensors {
+    fn into(self) -> Result<(), OptimizerUpdateError<Err>> {
         if self.is_empty() {
             Ok(())
         } else {

--- a/src/optim/rmsprop/cpu_kernel.rs
+++ b/src/optim/rmsprop/cpu_kernel.rs
@@ -6,11 +6,11 @@ impl<E: num_traits::Float + Dtype> RMSpropKernel<E> for Cpu {
     fn update(
         &self,
         cfg: &RMSpropConfig,
-        param: &mut Self::Vec<E>,
-        momentum: &mut Self::Vec<E>,
-        square_avg: &mut Self::Vec<E>,
-        grad_avg: &mut Self::Vec<E>,
-        grad: &Self::Vec<E>,
+        param: &mut Self::Vec,
+        momentum: &mut Self::Vec,
+        square_avg: &mut Self::Vec,
+        grad_avg: &mut Self::Vec,
+        grad: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let alpha = E::from_f64(cfg.alpha).unwrap();
         let eps = E::from_f64(cfg.eps).unwrap();

--- a/src/optim/rmsprop/cuda_kernel.rs
+++ b/src/optim/rmsprop/cuda_kernel.rs
@@ -71,11 +71,11 @@ where
     fn update(
         &self,
         cfg: &RMSpropConfig,
-        param: &mut Self::Vec<E>,
-        momentum: &mut Self::Vec<E>,
-        square_avg: &mut Self::Vec<E>,
-        grad_avg: &mut Self::Vec<E>,
-        grad: &Self::Vec<E>,
+        param: &mut Self::Vec,
+        momentum: &mut Self::Vec,
+        square_avg: &mut Self::Vec,
+        grad_avg: &mut Self::Vec,
+        grad: &Self::Vec,
     ) -> Result<(), Self::Err> {
         if !self.dev.has_func(Self::MOD, Self::FWD) {
             self.dev.load_ptx(PTX_SRC.into(), Self::MOD, &[Self::FWD])?;

--- a/src/optim/sgd/cpu_kernel.rs
+++ b/src/optim/sgd/cpu_kernel.rs
@@ -10,9 +10,9 @@ impl<E: Dtype> SgdKernel<E> for Cpu {
     fn update(
         &self,
         cfg: &SgdConfig,
-        param: &mut Self::Vec<E>,
-        velocity: &mut Self::Vec<E>,
-        grad: &Self::Vec<E>,
+        param: &mut Self::Vec,
+        velocity: &mut Self::Vec,
+        grad: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let lr = E::from_f64(cfg.lr).unwrap();
 

--- a/src/optim/sgd/cuda_kernel.rs
+++ b/src/optim/sgd/cuda_kernel.rs
@@ -61,9 +61,9 @@ where
     fn update(
         &self,
         cfg: &SgdConfig,
-        param: &mut Self::Vec<E>,
-        velocity: &mut Self::Vec<E>,
-        grad: &Self::Vec<E>,
+        param: &mut Self::Vec,
+        velocity: &mut Self::Vec,
+        grad: &Self::Vec,
     ) -> Result<(), Self::Err> {
         if !self.dev.has_func(Self::MOD, Self::FWD) {
             self.dev.load_ptx(PTX_SRC.into(), Self::MOD, &[Self::FWD])?;

--- a/src/shapes/shape.rs
+++ b/src/shapes/shape.rs
@@ -70,7 +70,6 @@ pub trait Dtype:
     + std::ops::MulAssign
     + std::ops::DivAssign
     + num_traits::FromPrimitive
-    + rand_distr::uniform::SampleUniform
 {
 }
 impl Dtype for f32 {}

--- a/src/tensor/cpu/allocate.rs
+++ b/src/tensor/cpu/allocate.rs
@@ -75,7 +75,7 @@ impl<E: Unit> ZerosTensor<E> for Cpu {
 }
 
 impl<E: Unit> ZeroFillStorage<E> for Cpu {
-    fn try_fill_with_zeros(&self, storage: &mut Self::Vec<E>) -> Result<(), Self::Err> {
+    fn try_fill_with_zeros(&self, storage: &mut Self::Vec) -> Result<(), Self::Err> {
         storage.fill(Default::default());
         Ok(())
     }
@@ -145,7 +145,7 @@ impl<E: Unit> TriangleTensor<E> for Cpu {
 }
 
 impl<E: Unit> OneFillStorage<E> for Cpu {
-    fn try_fill_with_ones(&self, storage: &mut Self::Vec<E>) -> Result<(), Self::Err> {
+    fn try_fill_with_ones(&self, storage: &mut Self::Vec) -> Result<(), Self::Err> {
         storage.fill(E::ONE);
         Ok(())
     }
@@ -171,7 +171,7 @@ impl<E: Unit> SampleTensor<E> for Cpu {
     }
     fn try_fill_with_distr<D: Distribution<E>>(
         &self,
-        storage: &mut Self::Vec<E>,
+        storage: &mut Self::Vec,
         distr: D,
     ) -> Result<(), Self::Err> {
         {

--- a/src/tensor/cpu/device.rs
+++ b/src/tensor/cpu/device.rs
@@ -138,13 +138,7 @@ impl<E> std::ops::DerefMut for CachableVec<E> {
     }
 }
 
-impl DeviceStorage for Cpu {
-    type Vec<E: Unit> = CachableVec<E>;
-
-    fn try_alloc_len<E: Unit>(&self, len: usize) -> Result<Self::Vec<E>, Self::Err> {
-        self.try_alloc_zeros(len)
-    }
-
+impl RandomU64 for Cpu {
     fn random_u64(&self) -> u64 {
         #[cfg(not(feature = "no-std"))]
         {
@@ -155,12 +149,20 @@ impl DeviceStorage for Cpu {
             self.rng.lock().gen()
         }
     }
+}
 
-    fn len<E: Unit>(&self, v: &Self::Vec<E>) -> usize {
+impl<E: Unit> Storage<E> for Cpu {
+    type Vec = CachableVec<E>;
+
+    fn try_alloc_len(&self, len: usize) -> Result<Self::Vec, Self::Err> {
+        self.try_alloc_zeros(len)
+    }
+
+    fn len(&self, v: &Self::Vec) -> usize {
         v.len()
     }
 
-    fn tensor_to_vec<S: Shape, E: Unit, T>(&self, tensor: &Tensor<S, E, Self, T>) -> Vec<E> {
+    fn tensor_to_vec<S: Shape, T>(&self, tensor: &Tensor<S, E, Self, T>) -> Vec<E> {
         let mut buf = Vec::with_capacity(tensor.shape.num_elements());
         let mut iter = tensor.iter();
         while let Some(v) = iter.next() {
@@ -168,11 +170,15 @@ impl DeviceStorage for Cpu {
         }
         buf
     }
+}
 
+impl Synchronize for Cpu {
     fn try_synchronize(&self) -> Result<(), Self::Err> {
         Ok(())
     }
+}
 
+impl Cache for Cpu {
     fn try_enable_cache(&self) -> Result<(), Self::Err> {
         self.cache.enable();
         Ok(())

--- a/src/tensor/cuda/allocate.rs
+++ b/src/tensor/cuda/allocate.rs
@@ -54,7 +54,7 @@ impl<E: Unit> ZerosTensor<E> for Cuda {
 }
 
 impl<E: Unit> ZeroFillStorage<E> for Cuda {
-    fn try_fill_with_zeros(&self, storage: &mut Self::Vec<E>) -> Result<(), Self::Err> {
+    fn try_fill_with_zeros(&self, storage: &mut Self::Vec) -> Result<(), Self::Err> {
         self.dev.memset_zeros(&mut storage.data)?;
         Ok(())
     }
@@ -103,7 +103,7 @@ where
 }
 
 impl<E: Unit> OneFillStorage<E> for Cuda {
-    fn try_fill_with_ones(&self, storage: &mut Self::Vec<E>) -> Result<(), Self::Err> {
+    fn try_fill_with_ones(&self, storage: &mut Self::Vec) -> Result<(), Self::Err> {
         self.dev
             .htod_copy_into(std::vec![E::ONE; storage.len()], &mut storage.data)?;
         Ok(())
@@ -132,7 +132,7 @@ where
     }
     fn try_fill_with_distr<D: rand_distr::Distribution<E>>(
         &self,
-        storage: &mut Self::Vec<E>,
+        storage: &mut Self::Vec,
         distr: D,
     ) -> Result<(), Self::Err> {
         let mut buf = Vec::with_capacity(storage.len());
@@ -153,9 +153,9 @@ impl<E: Unit> CopySlice<E> for Cuda {
         assert_eq!(
             dst.data.len(),
             src.len(),
-            "Slices must have same number of elements as *physical* storage of tensors."
+            "Slices must have same number of elements as *physical* Storage<E> of tensors."
         );
-        let storage = Arc::make_mut(&mut dst.data);
+        let Storage<E> = Arc::make_mut(&mut dst.data);
         dst.device
             .dev
             .htod_sync_copy_into(src, &mut storage.data)
@@ -165,9 +165,9 @@ impl<E: Unit> CopySlice<E> for Cuda {
         assert_eq!(
             src.data.len(),
             dst.len(),
-            "Slices must have same number of elements as *physical* storage of tensors."
+            "Slices must have same number of elements as *physical* Storage<E> of tensors."
         );
-        let storage: &Self::Vec<E> = src.data.as_ref();
+        let storage: &Self::Vec = src.data.as_ref();
         src.device
             .dev
             .dtoh_sync_copy_into(&storage.data, dst)

--- a/src/tensor/cuda/allocate.rs
+++ b/src/tensor/cuda/allocate.rs
@@ -155,7 +155,7 @@ impl<E: Unit> CopySlice<E> for Cuda {
             src.len(),
             "Slices must have same number of elements as *physical* Storage<E> of tensors."
         );
-        let Storage<E> = Arc::make_mut(&mut dst.data);
+        let storage = Arc::make_mut(&mut dst.data);
         dst.device
             .dev
             .htod_sync_copy_into(src, &mut storage.data)
@@ -193,26 +193,12 @@ impl<E: Unit> TensorFromVec<E> for Cuda {
 
 impl<S: Shape, E: Unit> TensorToArray<S, E> for Cuda
 where
-    Cpu: TensorToArray<S, E>,
+    Cpu: TensorToArray<S, E> + Storage<E>,
 {
     type Array = <Cpu as TensorToArray<S, E>>::Array;
     fn tensor_to_array<T>(&self, tensor: &Tensor<S, E, Self, T>) -> Self::Array {
-        let buf = self
-            .cpu
-            .try_alloc_elem(tensor.data.data.len(), Default::default())
-            .unwrap();
-        let mut cpu_tensor = Tensor {
-            id: tensor.id,
-            data: Arc::new(buf),
-            shape: tensor.shape,
-            strides: tensor.strides,
-            device: self.cpu.clone(),
-            tape: Default::default(),
-        };
-        let buf = std::sync::Arc::make_mut(&mut cpu_tensor.data);
-        self.dev
-            .dtoh_sync_copy_into(&tensor.data.data, &mut buf.data)
-            .unwrap();
+        let buf = tensor.as_vec();
+        let cpu_tensor = self.cpu.tensor_from_vec(buf, tensor.shape);
         self.cpu.tensor_to_array::<NoneTape>(&cpu_tensor)
     }
 }

--- a/src/tensor/cuda/device.rs
+++ b/src/tensor/cuda/device.rs
@@ -1,6 +1,8 @@
 use crate::shapes::{Shape, Unit};
 use crate::tensor::cpu::{Cpu, CpuError};
-use crate::tensor::{cache::TensorCache, DeviceStorage, HasErr, NoneTape, Tensor};
+use crate::tensor::{
+    cache::TensorCache, Cache, HasErr, NoneTape, RandomU64, Storage, Synchronize, Tensor,
+};
 
 use cudarc::driver::{DevicePtr, DevicePtrMut, DeviceRepr};
 use cudarc::{
@@ -237,50 +239,13 @@ impl<E> Drop for CachableCudaSlice<E> {
     }
 }
 
-impl DeviceStorage<E> for Cuda {
-    type Vec<E: Unit> = CachableCudaSlice<E>;
-
-    fn try_alloc_len<E: Unit>(&self, len: usize) -> Result<Self::Vec, Self::Err> {
-        let mut data = unsafe { self.alloc_empty(len) }?;
-        self.dev.memset_zeros(&mut data)?;
-        Ok(CachableCudaSlice {
-            data,
-            cache: self.cache.clone(),
-        })
-    }
-
+impl RandomU64 for Cuda {
     fn random_u64(&self) -> u64 {
         self.cpu.random_u64()
     }
+}
 
-    fn len<E: Unit>(&self, v: &Self::Vec) -> usize {
-        v.len()
-    }
-
-    fn tensor_to_vec<S: Shape, E: Unit, T>(&self, tensor: &Tensor<S, E, Self, T>) -> Vec<E> {
-        let buf = self
-            .cpu
-            .try_alloc_elem(tensor.data.data.len(), Default::default())
-            .unwrap();
-        let mut cpu_tensor = Tensor {
-            id: tensor.id,
-            data: Arc::new(buf),
-            shape: tensor.shape,
-            strides: tensor.strides,
-            device: self.cpu.clone(),
-            tape: NoneTape,
-        };
-        let buf = std::sync::Arc::get_mut(&mut cpu_tensor.data).unwrap();
-        self.dev
-            .dtoh_sync_copy_into(&tensor.data.data, &mut buf.data)
-            .unwrap();
-        self.cpu.tensor_to_vec::<S, E, _>(&cpu_tensor)
-    }
-
-    fn try_synchronize(&self) -> Result<(), CudaError> {
-        self.dev.synchronize().map_err(CudaError::from)
-    }
-
+impl Cache for Cuda {
     fn try_enable_cache(&self) -> Result<(), Self::Err> {
         self.cache.enable();
         Ok(())
@@ -304,5 +269,48 @@ impl DeviceStorage<E> for Cuda {
         }
         cache.clear();
         Ok(())
+    }
+}
+
+impl Synchronize for Cuda {
+    fn try_synchronize(&self) -> Result<(), CudaError> {
+        self.dev.synchronize().map_err(CudaError::from)
+    }
+}
+
+impl<E: Unit> Storage<E> for Cuda {
+    type Vec = CachableCudaSlice<E>;
+
+    fn try_alloc_len(&self, len: usize) -> Result<Self::Vec, Self::Err> {
+        let mut data = unsafe { self.alloc_empty(len) }?;
+        self.dev.memset_zeros(&mut data)?;
+        Ok(CachableCudaSlice {
+            data,
+            cache: self.cache.clone(),
+        })
+    }
+
+    fn len(&self, v: &Self::Vec) -> usize {
+        v.len()
+    }
+
+    fn tensor_to_vec<S: Shape, T>(&self, tensor: &Tensor<S, E, Self, T>) -> Vec<E> {
+        let buf = self
+            .cpu
+            .try_alloc_elem(tensor.data.data.len(), Default::default())
+            .unwrap();
+        let mut cpu_tensor = Tensor {
+            id: tensor.id,
+            data: Arc::new(buf),
+            shape: tensor.shape,
+            strides: tensor.strides,
+            device: self.cpu.clone(),
+            tape: NoneTape,
+        };
+        let buf = std::sync::Arc::get_mut(&mut cpu_tensor.data).unwrap();
+        self.dev
+            .dtoh_sync_copy_into(&tensor.data.data, &mut buf.data)
+            .unwrap();
+        self.cpu.tensor_to_vec::<S, _>(&cpu_tensor)
     }
 }

--- a/src/tensor/cuda/device.rs
+++ b/src/tensor/cuda/device.rs
@@ -237,10 +237,10 @@ impl<E> Drop for CachableCudaSlice<E> {
     }
 }
 
-impl DeviceStorage for Cuda {
+impl DeviceStorage<E> for Cuda {
     type Vec<E: Unit> = CachableCudaSlice<E>;
 
-    fn try_alloc_len<E: Unit>(&self, len: usize) -> Result<Self::Vec<E>, Self::Err> {
+    fn try_alloc_len<E: Unit>(&self, len: usize) -> Result<Self::Vec, Self::Err> {
         let mut data = unsafe { self.alloc_empty(len) }?;
         self.dev.memset_zeros(&mut data)?;
         Ok(CachableCudaSlice {
@@ -253,7 +253,7 @@ impl DeviceStorage for Cuda {
         self.cpu.random_u64()
     }
 
-    fn len<E: Unit>(&self, v: &Self::Vec<E>) -> usize {
+    fn len<E: Unit>(&self, v: &Self::Vec) -> usize {
         v.len()
     }
 

--- a/src/tensor/ghost.rs
+++ b/src/tensor/ghost.rs
@@ -5,7 +5,7 @@ use crate::{shapes::*, tensor::*};
 ///
 /// This can held reduce memory usage by decreasing reference
 /// count on tensor data, meaning data can be re-used more.
-pub struct GhostTensor<S: Shape, E: Unit, D: DeviceStorage> {
+pub struct GhostTensor<S: Shape, E, D: Storage<E>> {
     pub(crate) id: UniqueId,
     pub(crate) len: usize,
     pub(crate) shape: S,
@@ -14,7 +14,7 @@ pub struct GhostTensor<S: Shape, E: Unit, D: DeviceStorage> {
     marker: std::marker::PhantomData<E>,
 }
 
-impl<S: Shape, E: Unit, D: DeviceStorage, T> Tensor<S, E, D, T> {
+impl<S: Shape, E, D: Storage<E>, T> Tensor<S, E, D, T> {
     /// Creates a ghost tensor that doesn't hold a reference
     /// to the tensor's data.
     pub(crate) fn ghost(&self) -> GhostTensor<S, E, D> {
@@ -29,7 +29,7 @@ impl<S: Shape, E: Unit, D: DeviceStorage, T> Tensor<S, E, D, T> {
     }
 }
 
-impl<S: Shape, E: Unit, D: DeviceStorage> Clone for GhostTensor<S, E, D> {
+impl<S: Shape, E, D: Storage<E>> Clone for GhostTensor<S, E, D> {
     fn clone(&self) -> Self {
         Self {
             id: self.id,
@@ -42,11 +42,11 @@ impl<S: Shape, E: Unit, D: DeviceStorage> Clone for GhostTensor<S, E, D> {
     }
 }
 
-impl<S: Shape, E: Unit, D: DeviceStorage> super::storage_traits::HasErr for GhostTensor<S, E, D> {
+impl<S: Shape, E, D: Storage<E>> super::storage_traits::HasErr for GhostTensor<S, E, D> {
     type Err = D::Err;
 }
 
-impl<S: Shape, E: Unit, D: DeviceStorage> HasShape for GhostTensor<S, E, D> {
+impl<S: Shape, E, D: Storage<E>> HasShape for GhostTensor<S, E, D> {
     type WithShape<New: Shape> = GhostTensor<New, E, D>;
     type Shape = S;
     fn shape(&self) -> &Self::Shape {
@@ -54,10 +54,8 @@ impl<S: Shape, E: Unit, D: DeviceStorage> HasShape for GhostTensor<S, E, D> {
     }
 }
 
-impl<S: Shape, E: Unit, D: DeviceStorage> super::storage_traits::AllocGrad
-    for GhostTensor<S, E, D>
-{
-    type Gradient = D::Vec<E>;
+impl<S: Shape, E, D: Storage<E>> super::storage_traits::AllocGrad for GhostTensor<S, E, D> {
+    type Gradient = D::Vec;
     fn try_alloc_grad(&self) -> Result<Self::Gradient, D::Err> {
         self.dev.try_alloc_len(self.len)
     }

--- a/src/tensor/gradients.rs
+++ b/src/tensor/gradients.rs
@@ -5,8 +5,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::{boxed::Box, vec::Vec};
 
 use super::tensorlike::Tensorlike;
-use super::{storage_traits::DeviceStorage, unique_id, Tensor, UniqueId};
-use crate::shapes::{Shape, Unit};
+use super::{storage_traits::Storage, unique_id, Tensor, UniqueId};
+use crate::shapes::Shape;
 
 /// A generic container for keeping gradients of tensors keyed by the
 /// tensor's [UniqueId].
@@ -17,14 +17,14 @@ use crate::shapes::{Shape, Unit};
 /// 3. Access references to arrays
 /// 4. Access mutable references to arrays
 #[derive(Clone, Debug)]
-pub struct Gradients<E: Unit, D: DeviceStorage> {
+pub struct Gradients<E, D: Storage<E>> {
     /// Using BTreeMap for no-std support
-    gradient_by_id: BTreeMap<UniqueId, D::Vec<E>>,
+    gradient_by_id: BTreeMap<UniqueId, D::Vec>,
     /// Using BTreeSet for no-std support
     leaf_ids: Option<BTreeSet<UniqueId>>,
 }
 
-impl<E: Unit, D: DeviceStorage> Gradients<E, D> {
+impl<E, D: Storage<E>> Gradients<E, D> {
     /// Creates a [Gradients] object without any leaf tensor ids.
     /// **This will never drop gradients for temporary tensors**.
     ///
@@ -42,12 +42,12 @@ impl<E: Unit, D: DeviceStorage> Gradients<E, D> {
     }
 }
 
-impl<E: Unit, D: DeviceStorage> Gradients<E, D> {
+impl<E, D: Storage<E>> Gradients<E, D> {
     /// Retrieves mutable gradient for `t`, allocating one if it isn't present.
     pub(crate) fn get_or_alloc_mut<S: Shape>(
         &mut self,
         t: &Tensor<S, E, D>,
-    ) -> Result<&mut D::Vec<E>, D::Err> {
+    ) -> Result<&mut D::Vec, D::Err> {
         let ghost = t.ghost();
         self.try_alloc_for(&ghost)?;
         Ok(self.get_mut(&ghost))
@@ -81,24 +81,21 @@ impl<E: Unit, D: DeviceStorage> Gradients<E, D> {
     }
 
     /// Returns a reference to the underlying gradient if found.
-    pub(crate) fn get_ref_checked<S: Shape, T>(
-        &self,
-        t: &Tensor<S, E, D, T>,
-    ) -> Option<&D::Vec<E>> {
+    pub(crate) fn get_ref_checked<S: Shape, T>(&self, t: &Tensor<S, E, D, T>) -> Option<&D::Vec> {
         self.gradient_by_id.get(&t.id)
     }
 
     /// Returns a mutable reference to the data associated with `t`.
     ///
     /// **Panics** if data associated with `t` is not found. This indicates an unrecoverable bug.
-    pub(crate) fn get_mut<S: Shape>(&mut self, t: &impl Tensorlike<S, E, D>) -> &mut D::Vec<E> {
+    pub(crate) fn get_mut<S: Shape>(&mut self, t: &impl Tensorlike<S, E, D>) -> &mut D::Vec {
         self.gradient_by_id.get_mut(&t.id()).unwrap()
     }
 
     /// Returns a mutable reference to the data associated with `t`.
     ///
     /// **Panics** if data associated with `t` is not found. This indicates an unrecoverable bug.
-    pub(crate) fn get_ref<S: Shape>(&mut self, t: &impl Tensorlike<S, E, D>) -> &D::Vec<E> {
+    pub(crate) fn get_ref<S: Shape>(&mut self, t: &impl Tensorlike<S, E, D>) -> &D::Vec {
         self.gradient_by_id.get(&t.id()).unwrap()
     }
 
@@ -127,7 +124,7 @@ impl<E: Unit, D: DeviceStorage> Gradients<E, D> {
         &mut self,
         l: &impl Tensorlike<L, E, D>,
         r: &impl Tensorlike<R, E, D>,
-    ) -> (&mut D::Vec<E>, &D::Vec<E>) {
+    ) -> (&mut D::Vec, &D::Vec) {
         assert_ne!(l.id(), r.id());
         let l_ptr = self.get_mut(l) as *mut _;
         let r_ptr = self.get_ref(r) as *const _;
@@ -142,7 +139,7 @@ impl<E: Unit, D: DeviceStorage> Gradients<E, D> {
         l1: &impl Tensorlike<L1, E, D>,
         l2: &impl Tensorlike<L2, E, D>,
         r: &impl Tensorlike<R, E, D>,
-    ) -> (&mut D::Vec<E>, &mut D::Vec<E>, &D::Vec<E>) {
+    ) -> (&mut D::Vec, &mut D::Vec, &D::Vec) {
         assert_ne!(l1.id(), l2.id());
         assert_ne!(l1.id(), r.id());
         assert_ne!(l2.id(), r.id());
@@ -160,17 +157,17 @@ impl<E: Unit, D: DeviceStorage> Gradients<E, D> {
         &mut self,
         ls: &Vec<impl Tensorlike<L, E, D>>,
         r: &impl Tensorlike<R, E, D>,
-    ) -> (Vec<&mut D::Vec<E>>, &D::Vec<E>) {
+    ) -> (Vec<&mut D::Vec>, &D::Vec) {
         for i in 0..ls.len() {
             assert_ne!(ls[i].id(), r.id());
             for j in (i + 1)..ls.len() {
                 assert_ne!(ls[i].id(), ls[j].id());
             }
         }
-        let l_refs: Vec<&mut D::Vec<E>> = ls
+        let l_refs: Vec<&mut D::Vec> = ls
             .iter()
             .map(|l| {
-                let l_ptr = self.get_mut(l) as *mut D::Vec<E>;
+                let l_ptr = self.get_mut(l) as *mut D::Vec;
                 unsafe { &mut *l_ptr }
             })
             .collect();
@@ -181,14 +178,14 @@ impl<E: Unit, D: DeviceStorage> Gradients<E, D> {
 }
 
 /// Contains a [Gradients] and list of backward operations.
-pub struct OwnedTape<E: Unit, D: DeviceStorage> {
+pub struct OwnedTape<E, D: Storage<E>> {
     /// A list of (Time, BackwardOp) pairs. The Time is used to ensure operations
     /// from merged tapes are executed in the correct order.
     pub(crate) operations: Vec<(UniqueId, BackwardOp<E, D, D::Err>)>,
     pub(crate) gradients: Gradients<E, D>,
 }
 
-impl<E: Unit, D: DeviceStorage> Default for OwnedTape<E, D> {
+impl<E, D: Storage<E>> Default for OwnedTape<E, D> {
     fn default() -> Self {
         Self {
             operations: Default::default(),
@@ -197,7 +194,7 @@ impl<E: Unit, D: DeviceStorage> Default for OwnedTape<E, D> {
     }
 }
 
-impl<E: Unit, D: DeviceStorage> std::fmt::Debug for OwnedTape<E, D> {
+impl<E: std::fmt::Debug, D: Storage<E>> std::fmt::Debug for OwnedTape<E, D> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OwnedTape")
             .field("num_operations", &self.operations.len())
@@ -206,7 +203,7 @@ impl<E: Unit, D: DeviceStorage> std::fmt::Debug for OwnedTape<E, D> {
     }
 }
 
-impl<E: Unit, D: DeviceStorage> OwnedTape<E, D> {
+impl<E, D: Storage<E>> OwnedTape<E, D> {
     /// Compute the [Gradients]! This just runs all the operations on a new [Gradients] struct.
     ///
     /// Note that this method takes ownership of self, so it can't be called twice!
@@ -229,7 +226,7 @@ type BackwardOp<E, D, Err> = Box<dyn FnOnce(&mut Gradients<E, D>) -> Result<(), 
 pub struct NoneTape;
 
 /// Something that can track backward operations.
-pub trait Tape<E: Unit, D: DeviceStorage>: Default + Merge<Self> + Merge<NoneTape> {
+pub trait Tape<E, D: Storage<E>>: Default + Merge<Self> + Merge<NoneTape> {
     /// Whether this object is currently tracking gradients. This is known at compile time.
     const OWNS_TAPE: bool;
     fn add_backward_op<F>(&mut self, operation: F)
@@ -237,7 +234,7 @@ pub trait Tape<E: Unit, D: DeviceStorage>: Default + Merge<Self> + Merge<NoneTap
         F: 'static + FnOnce(&mut Gradients<E, D>) -> Result<(), D::Err>;
 }
 
-impl<E: Unit, D: DeviceStorage> Tape<E, D> for OwnedTape<E, D> {
+impl<E, D: Storage<E>> Tape<E, D> for OwnedTape<E, D> {
     const OWNS_TAPE: bool = true;
     fn add_backward_op<F>(&mut self, operation: F)
     where
@@ -247,7 +244,7 @@ impl<E: Unit, D: DeviceStorage> Tape<E, D> for OwnedTape<E, D> {
     }
 }
 
-impl<E: Unit, D: DeviceStorage> Tape<E, D> for NoneTape {
+impl<E, D: Storage<E>> Tape<E, D> for NoneTape {
     const OWNS_TAPE: bool = false;
     fn add_backward_op<F>(&mut self, _: F)
     where
@@ -268,13 +265,13 @@ impl Merge<NoneTape> for NoneTape {
     }
 }
 
-impl<E: Unit, D: DeviceStorage> Merge<NoneTape> for OwnedTape<E, D> {
+impl<E, D: Storage<E>> Merge<NoneTape> for OwnedTape<E, D> {
     fn merge(self, _: NoneTape) -> Self {
         self
     }
 }
 
-impl<E: Unit, D: DeviceStorage> Merge<OwnedTape<E, D>> for OwnedTape<E, D> {
+impl<E, D: Storage<E>> Merge<OwnedTape<E, D>> for OwnedTape<E, D> {
     fn merge(mut self, mut other: Self) -> Self {
         self.gradients
             .gradient_by_id

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -4,7 +4,7 @@
 //! At a high level a tensor is made up of:
 //! 1. The [crate::shapes::Shape] of the array it stores
 //! 2. The [crate::shapes::Dtype] of the elements of the array
-//! 3. The [DeviceStorage] (e.g. [Cpu] or [Cuda]) that it uses to store the nd array
+//! 3. The [Storage] (e.g. [Cpu] or [Cuda]) that it uses to store the nd array
 //! 4. A [Tape], which can either actually be a tape ([OwnedTape])
 //!    or be empty ([NoneTape]).
 //!
@@ -132,8 +132,8 @@
 //! allocation patterns are repetitive. If this results in extra memory use due to
 //! irregular allocation patterns there are two things you can do:
 //!
-//! 1. Call [DeviceStorage::empty_cache()], which will empty out all of the saved allocations.
-//! 2. Disable the cache entirely by calling [DeviceStorage::disable_cache()]. This will
+//! 1. Call [Cache::empty_cache()], which will empty out all of the saved allocations.
+//! 2. Disable the cache entirely by calling [Cache::disable_cache()]. This will
 //! empty out any existing allocations and prevent any new ones from being cached.
 
 pub(crate) mod cache;

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -169,7 +169,7 @@ pub use cuda::{Cuda, CudaError};
 pub type AutoDevice = Cuda;
 
 pub use storage_traits::{AsArray, CopySlice, TensorFrom, TensorFromVec};
-pub use storage_traits::{DeviceStorage, HasErr};
+pub use storage_traits::{Cache, HasErr, RandomU64, Storage, Synchronize};
 pub use storage_traits::{OnesTensor, SampleTensor, TriangleTensor, ZerosTensor};
 
 pub use tensor_impls::{PutTape, SplitTape, Tensor, Trace, WithEmptyTape};

--- a/src/tensor/numpy.rs
+++ b/src/tensor/numpy.rs
@@ -15,7 +15,7 @@ use zip::result::{ZipError, ZipResult};
 const MAGIC_NUMBER: &[u8] = b"\x93NUMPY";
 const VERSION: &[u8] = &[1, 0];
 
-impl<S: Shape, E: Dtype + NumpyDtype, D: DeviceStorage + CopySlice<E>, T> Tensor<S, E, D, T> {
+impl<S: Shape, E: Dtype + NumpyDtype, D: DeviceStorage<E> + CopySlice<E>, T> Tensor<S, E, D, T> {
     /// Writes `data` to a new file in a zip archive named `filename`.
     pub fn write_to_npz<W: Write + Seek>(
         &self,

--- a/src/tensor/numpy.rs
+++ b/src/tensor/numpy.rs
@@ -1,6 +1,6 @@
 use crate::shapes::{Dtype, HasShape, Shape};
 
-use super::{CopySlice, DeviceStorage, Tensor};
+use super::{CopySlice, Tensor};
 
 use std::{
     fs::File,
@@ -15,7 +15,7 @@ use zip::result::{ZipError, ZipResult};
 const MAGIC_NUMBER: &[u8] = b"\x93NUMPY";
 const VERSION: &[u8] = &[1, 0];
 
-impl<S: Shape, E: Dtype + NumpyDtype, D: DeviceStorage<E> + CopySlice<E>, T> Tensor<S, E, D, T> {
+impl<S: Shape, E: Dtype + NumpyDtype, D: CopySlice<E>, T> Tensor<S, E, D, T> {
     /// Writes `data` to a new file in a zip archive named `filename`.
     pub fn write_to_npz<W: Write + Seek>(
         &self,

--- a/src/tensor/safetensors.rs
+++ b/src/tensor/safetensors.rs
@@ -74,7 +74,7 @@ impl From<std::io::Error> for Error {
 }
 
 impl<S: Shape, E: Dtype + SafeDtype, D: CopySlice<E>, T> Tensor<S, E, D, T> {
-    /// Loads data from the [SafeTensors] storage with the given `key`
+    /// Loads data from the [SafeTensors] Storage<E> with the given `key`
     pub fn load_safetensor(&mut self, tensors: &SafeTensors, key: &str) -> Result<(), Error> {
         let tensor = tensors.tensor(key)?;
         let v = tensor.data();

--- a/src/tensor/storage_traits.rs
+++ b/src/tensor/storage_traits.rs
@@ -23,7 +23,7 @@ pub trait RandomU64 {
 
 /// Something that can store nd arrays for a given [Shape] and [Dtype]
 pub trait Storage<E>: 'static + std::fmt::Debug + Default + Clone + HasErr {
-    /// Generic Storage<E> type
+    /// Generic Storage type
     type Vec: 'static + std::fmt::Debug + Clone + Send + Sync;
 
     /// Allocates a gradient for the given nd array
@@ -58,13 +58,13 @@ pub trait Cache: HasErr {
     fn try_enable_cache(&self) -> Result<(), Self::Err>;
 
     /// Disables the cache of the device. This will also empty the cache
-    /// if there are things in it. See [DeviceStorage::empty_cache] for
+    /// if there are things in it. See [Cache::empty_cache] for
     /// more information.
     fn disable_cache(&self) {
         self.try_disable_cache().unwrap()
     }
 
-    /// Tries to disable the cache of the device. See [DeviceStorage::disable_cache] for
+    /// Tries to disable the cache of the device. See [Cache::disable_cache] for
     /// details of when this is useful.
     fn try_disable_cache(&self) -> Result<(), Self::Err>;
 
@@ -81,7 +81,7 @@ pub trait Cache: HasErr {
         self.try_empty_cache().unwrap();
     }
 
-    /// Tries to empty the cache of the device. See [DeviceStorage::empty_cache] for
+    /// Tries to empty the cache of the device. See [Cache::empty_cache] for
     /// details of when this is useful.
     fn try_empty_cache(&self) -> Result<(), Self::Err>;
 }
@@ -420,7 +420,7 @@ pub trait SampleTensor<E>: Storage<E> {
         distr: D,
     ) -> Result<Tensor<S::Shape, E, Self>, Self::Err>;
 
-    /// Fills tensor Storage<E> with data from a given distribution
+    /// Fills tensor `Storage<E>` with data from a given distribution
     fn try_fill_with_distr<D: Distribution<E>>(
         &self,
         storage: &mut Self::Vec,

--- a/src/tensor/storage_traits.rs
+++ b/src/tensor/storage_traits.rs
@@ -16,25 +16,29 @@ pub trait AsVec<E> {
     fn as_vec(&self) -> std::vec::Vec<E>;
 }
 
-/// Something that can store nd arrays for a given [Shape] and [Dtype]
-pub trait DeviceStorage: 'static + std::fmt::Debug + Default + Clone + HasErr {
-    /// Generic storage type
-    type Vec<E: Unit>: 'static + std::fmt::Debug + Clone + Send + Sync;
-
+pub trait RandomU64 {
     /// Generates a random u64 number
     fn random_u64(&self) -> u64;
+}
+
+/// Something that can store nd arrays for a given [Shape] and [Dtype]
+pub trait Storage<E>: 'static + std::fmt::Debug + Default + Clone + HasErr {
+    /// Generic Storage<E> type
+    type Vec: 'static + std::fmt::Debug + Clone + Send + Sync;
 
     /// Allocates a gradient for the given nd array
-    fn try_alloc_grad<E: Unit>(&self, storage: &Self::Vec<E>) -> Result<Self::Vec<E>, Self::Err> {
+    fn try_alloc_grad(&self, storage: &Self::Vec) -> Result<Self::Vec, Self::Err> {
         self.try_alloc_len(self.len(storage))
     }
 
-    fn try_alloc_len<E: Unit>(&self, len: usize) -> Result<Self::Vec<E>, Self::Err>;
+    fn try_alloc_len(&self, len: usize) -> Result<Self::Vec, Self::Err>;
 
-    fn tensor_to_vec<S: Shape, E: Unit, T>(&self, tensor: &Tensor<S, E, Self, T>) -> Vec<E>;
+    fn tensor_to_vec<S: Shape, T>(&self, tensor: &Tensor<S, E, Self, T>) -> Vec<E>;
 
-    fn len<E: Unit>(&self, v: &Self::Vec<E>) -> usize;
+    fn len(&self, v: &Self::Vec) -> usize;
+}
 
+pub trait Synchronize: HasErr {
     /// Blocks until all work on device to complete. Useful for benchmarking.
     fn synchronize(&self) {
         self.try_synchronize().unwrap()
@@ -42,7 +46,9 @@ pub trait DeviceStorage: 'static + std::fmt::Debug + Default + Clone + HasErr {
 
     /// Blocks until all work on device to complete. Useful for benchmarking.
     fn try_synchronize(&self) -> Result<(), Self::Err>;
+}
 
+pub trait Cache: HasErr {
     /// Enables the cache of the device.
     fn enable_cache(&self) {
         self.try_enable_cache().unwrap()
@@ -86,20 +92,20 @@ pub trait AllocGrad: HasErr {
     fn try_alloc_grad(&self) -> Result<Self::Gradient, Self::Err>;
 }
 
-impl<S: Shape, E: Unit, D: DeviceStorage, T> AllocGrad for Tensor<S, E, D, T> {
-    type Gradient = D::Vec<E>;
+impl<S: Shape, E, D: Storage<E>, T> AllocGrad for Tensor<S, E, D, T> {
+    type Gradient = D::Vec;
     fn try_alloc_grad(&self) -> Result<Self::Gradient, D::Err> {
         self.device.try_alloc_grad(self.data.as_ref())
     }
 }
 
 /// Enables copying data into and out of tensors
-pub trait CopySlice<E: Unit>: DeviceStorage {
+pub trait CopySlice<E>: Storage<E> {
     fn copy_from<S: Shape, T>(dst: &mut Tensor<S, E, Self, T>, src: &[E]);
     fn copy_into<S: Shape, T>(src: &Tensor<S, E, Self, T>, dst: &mut [E]);
 }
 
-impl<S: Shape, E: Unit, D: CopySlice<E>, T> Tensor<S, E, D, T> {
+impl<S: Shape, E, D: CopySlice<E>, T> Tensor<S, E, D, T> {
     /// Copy *physical* data from a slice - **panics** if there are not enough elements in the slice.
     ///
     /// ```rust
@@ -130,7 +136,7 @@ impl<S: Shape, E: Unit, D: CopySlice<E>, T> Tensor<S, E, D, T> {
 }
 
 /// Construct tensors filled with zeros.
-pub trait ZerosTensor<E: Unit>: DeviceStorage {
+pub trait ZerosTensor<E>: Storage<E> {
     /// Creates a tensor filled with zeros.
     /// ```rust
     /// # use dfdx::prelude::*;
@@ -170,12 +176,12 @@ pub trait ZerosTensor<E: Unit>: DeviceStorage {
     fn try_zeros_like<S: HasShape>(&self, src: &S) -> Result<Tensor<S::Shape, E, Self>, Self::Err>;
 }
 
-pub trait ZeroFillStorage<E: Unit>: DeviceStorage {
-    fn try_fill_with_zeros(&self, storage: &mut Self::Vec<E>) -> Result<(), Self::Err>;
+pub trait ZeroFillStorage<E>: Storage<E> {
+    fn try_fill_with_zeros(&self, storage: &mut Self::Vec) -> Result<(), Self::Err>;
 }
 
 /// Construct tensors filled with ones.
-pub trait OnesTensor<E: Unit>: DeviceStorage {
+pub trait OnesTensor<E>: Storage<E> {
     /// Creates a tensor filled with ones.
     /// ```rust
     /// # use dfdx::prelude::*;
@@ -215,12 +221,12 @@ pub trait OnesTensor<E: Unit>: DeviceStorage {
     fn try_ones_like<S: HasShape>(&self, src: &S) -> Result<Tensor<S::Shape, E, Self>, Self::Err>;
 }
 
-pub trait OneFillStorage<E: Unit>: DeviceStorage {
-    fn try_fill_with_ones(&self, storage: &mut Self::Vec<E>) -> Result<(), Self::Err>;
+pub trait OneFillStorage<E>: Storage<E> {
+    fn try_fill_with_ones(&self, storage: &mut Self::Vec) -> Result<(), Self::Err>;
 }
 
 /// Build upper & lower triangle tensors.
-pub trait TriangleTensor<E: Unit>: DeviceStorage {
+pub trait TriangleTensor<E>: Storage<E> {
     /// Build a tensor containing the upper triangle part of each lowest 2D matrix
     /// set to the given value, along the given diagonal. The other values will be `E::default()`.
     ///
@@ -355,7 +361,7 @@ pub trait TriangleTensor<E: Unit>: DeviceStorage {
 }
 
 /// Constructs tensors filled with random values from a given distribution.
-pub trait SampleTensor<E: Unit>: DeviceStorage {
+pub trait SampleTensor<E>: Storage<E> {
     /// Samples a const tensor from a uniform distribution
     fn sample_uniform<S: ConstShape>(&self) -> Tensor<S, E, Self>
     where
@@ -414,15 +420,15 @@ pub trait SampleTensor<E: Unit>: DeviceStorage {
         distr: D,
     ) -> Result<Tensor<S::Shape, E, Self>, Self::Err>;
 
-    /// Fills tensor storage with data from a given distribution
+    /// Fills tensor Storage<E> with data from a given distribution
     fn try_fill_with_distr<D: Distribution<E>>(
         &self,
-        storage: &mut Self::Vec<E>,
+        storage: &mut Self::Vec,
         distr: D,
     ) -> Result<(), Self::Err>;
 }
 
-pub trait TensorToArray<S: Shape, E: Unit>: DeviceStorage {
+pub trait TensorToArray<S: Shape, E>: Storage<E> {
     type Array: std::fmt::Debug + PartialEq;
     fn tensor_to_array<T>(&self, tensor: &Tensor<S, E, Self, T>) -> Self::Array;
 }
@@ -432,7 +438,7 @@ pub trait AsArray {
     fn array(&self) -> Self::Array;
 }
 
-impl<S: Shape, E: Unit, D: TensorToArray<S, E>, T> AsArray for Tensor<S, E, D, T> {
+impl<S: Shape, E, D: TensorToArray<S, E>, T> AsArray for Tensor<S, E, D, T> {
     type Array = D::Array;
     /// Convert tensors to rust arrays
     fn array(&self) -> Self::Array {
@@ -440,14 +446,14 @@ impl<S: Shape, E: Unit, D: TensorToArray<S, E>, T> AsArray for Tensor<S, E, D, T
     }
 }
 
-impl<S: Shape, E: Unit, D: DeviceStorage, T> Tensor<S, E, D, T> {
+impl<S: Shape, E, D: Storage<E>, T> Tensor<S, E, D, T> {
     pub fn as_vec(&self) -> std::vec::Vec<E> {
         self.device.tensor_to_vec(self)
     }
 }
 
 /// Construct tensors from rust vectors. This trait is only used to implement TensorFrom.
-pub trait TensorFromVec<E: Unit>: DeviceStorage {
+pub trait TensorFromVec<E>: Storage<E> {
     fn tensor_from_vec<S: Shape>(&self, src: Vec<E>, shape: S) -> Tensor<S, E, Self> {
         self.try_tensor_from_vec::<S>(src, shape).unwrap()
     }
@@ -459,7 +465,7 @@ pub trait TensorFromVec<E: Unit>: DeviceStorage {
     ) -> Result<Tensor<S, E, Self>, Self::Err>;
 }
 
-impl<S: Shape, E: Unit, D: DeviceStorage, T> Tensor<S, E, D, T> {
+impl<S: Shape, E, D: Storage<E>, T> Tensor<S, E, D, T> {
     /// Clones the tensor onto a different device.
     pub fn to_device<Dst: TensorFromVec<E>>(&self, device: &Dst) -> Tensor<S, E, Dst> {
         self.try_to_device(device).unwrap()
@@ -476,7 +482,7 @@ impl<S: Shape, E: Unit, D: DeviceStorage, T> Tensor<S, E, D, T> {
 }
 
 /// Construct tensors from rust data
-pub trait TensorFrom<Src, S: Shape, E: Unit>: DeviceStorage {
+pub trait TensorFrom<Src, S: Shape, E>: Storage<E> {
     /// Create a tensor from rust data
     /// ```rust
     /// # use dfdx::prelude::*;
@@ -494,31 +500,26 @@ pub trait TensorFrom<Src, S: Shape, E: Unit>: DeviceStorage {
     fn try_tensor(&self, src: Src) -> Result<Tensor<S, E, Self>, Self::Err>;
 }
 
-impl<E: Unit, D: DeviceStorage + TensorFromVec<E>> TensorFrom<E, Rank0, E> for D {
+impl<E, D: TensorFromVec<E>> TensorFrom<E, Rank0, E> for D {
     fn try_tensor(&self, src: E) -> Result<Tensor<Rank0, E, Self>, Self::Err> {
         self.try_tensor_from_vec(vec![src], ())
     }
 }
 
-impl<E: Unit, const M: usize, D: DeviceStorage + TensorFromVec<E>> TensorFrom<[E; M], Rank1<M>, E>
-    for D
-{
+impl<E: Copy, const M: usize, D: TensorFromVec<E>> TensorFrom<[E; M], Rank1<M>, E> for D {
     fn try_tensor(&self, src: [E; M]) -> Result<Tensor<Rank1<M>, E, Self>, Self::Err> {
         self.try_tensor(&src)
     }
 }
 
-impl<E: Unit, const M: usize, D: DeviceStorage + TensorFromVec<E>> TensorFrom<&[E; M], Rank1<M>, E>
-    for D
-{
+impl<E: Copy, const M: usize, D: TensorFromVec<E>> TensorFrom<&[E; M], Rank1<M>, E> for D {
     fn try_tensor(&self, src: &[E; M]) -> Result<Tensor<Rank1<M>, E, Self>, Self::Err> {
         self.try_tensor_from_vec(src.to_vec(), (Const::<M>,))
     }
 }
 
-impl<E: Unit, const M: usize, const N: usize, D> TensorFrom<[[E; N]; M], Rank2<M, N>, E> for D
-where
-    D: DeviceStorage + TensorFromVec<E>,
+impl<E: Copy, const M: usize, const N: usize, D: TensorFromVec<E>>
+    TensorFrom<[[E; N]; M], Rank2<M, N>, E> for D
 {
     fn try_tensor(&self, src: [[E; N]; M]) -> Result<Tensor<Rank2<M, N>, E, Self>, Self::Err> {
         let vec: Vec<E> = src.iter().flat_map(|v| v.iter().copied()).collect();
@@ -527,10 +528,8 @@ where
     }
 }
 
-impl<E: Unit, const M: usize, const N: usize, const O: usize, D>
+impl<E: Copy, const M: usize, const N: usize, const O: usize, D: TensorFromVec<E>>
     TensorFrom<[[[E; O]; N]; M], Rank3<M, N, O>, E> for D
-where
-    D: DeviceStorage + TensorFromVec<E>,
 {
     fn try_tensor(
         &self,
@@ -546,10 +545,14 @@ where
     }
 }
 
-impl<E: Unit, const M: usize, const N: usize, const O: usize, const P: usize, D>
-    TensorFrom<[[[[E; P]; O]; N]; M], Rank4<M, N, O, P>, E> for D
-where
-    D: DeviceStorage + TensorFromVec<E>,
+impl<
+        E: Copy,
+        const M: usize,
+        const N: usize,
+        const O: usize,
+        const P: usize,
+        D: TensorFromVec<E>,
+    > TensorFrom<[[[[E; P]; O]; N]; M], Rank4<M, N, O, P>, E> for D
 {
     fn try_tensor(
         &self,
@@ -566,13 +569,13 @@ where
     }
 }
 
-impl<E: Unit, S: ConstShape, D: DeviceStorage + TensorFromVec<E>> TensorFrom<Vec<E>, S, E> for D {
+impl<E, S: ConstShape, D: TensorFromVec<E>> TensorFrom<Vec<E>, S, E> for D {
     fn try_tensor(&self, src: Vec<E>) -> Result<Tensor<S, E, Self>, Self::Err> {
         self.try_tensor_from_vec(src, S::default())
     }
 }
 
-impl<E: Unit, S: Shape, D: DeviceStorage + TensorFromVec<E>> TensorFrom<(Vec<E>, S), S, E> for D {
+impl<E, S: Shape, D: TensorFromVec<E>> TensorFrom<(Vec<E>, S), S, E> for D {
     fn try_tensor(&self, (src, shape): (Vec<E>, S)) -> Result<Tensor<S, E, Self>, Self::Err> {
         self.try_tensor_from_vec(src, shape)
     }

--- a/src/tensor/tensor_impls.rs
+++ b/src/tensor/tensor_impls.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 /// Generics:
 /// 1. [Shape] - the shape of the underlying nd array
 /// 2. [Dtype] - the type of the datas stored in the array
-/// 3. [DeviceStorage] - the device the array is stored on
+/// 3. [Storage] - the device the array is stored on
 /// 4. [Tape] - the tape the tensor has
 ///
 /// Examples:
@@ -114,7 +114,7 @@ impl<S: Shape, E, D: Storage<E>, T> Tensor<S, E, D, T> {
         }
     }
 
-    /// Get a reference to the tensor's `DeviceStorage`
+    /// Get a reference to the tensor's `Storage`
     pub fn device(&self) -> &D {
         &self.device
     }

--- a/src/tensor/tensorlike.rs
+++ b/src/tensor/tensorlike.rs
@@ -1,7 +1,7 @@
 use crate::{
     prelude::{HasErr, HasShape},
-    shapes::{Shape, Unit},
-    tensor::DeviceStorage,
+    shapes::Shape,
+    tensor::Storage,
 };
 
 use super::{storage_traits::AllocGrad, GhostTensor, Tensor, UniqueId};
@@ -10,17 +10,17 @@ use super::{storage_traits::AllocGrad, GhostTensor, Tensor, UniqueId};
 /// exists to unify handling of [Tensor] and [GhostTensor].
 ///
 /// *If it looks like a tensor and barks like a tensor, then pet it like a tensor.*
-pub trait Tensorlike<S: Shape, E: Unit, D: DeviceStorage>:
-    AllocGrad<Gradient = D::Vec<E>> + HasErr<Err = D::Err> + HasShape<Shape = S>
+pub trait Tensorlike<S: Shape, E, D: Storage<E>>:
+    AllocGrad<Gradient = D::Vec> + HasErr<Err = D::Err> + HasShape<Shape = S>
 {
     fn id(&self) -> UniqueId;
     fn len(&self) -> usize;
     fn strides(&self) -> S::Concrete;
     fn dev(&self) -> &D;
-    fn data(&self) -> Option<&D::Vec<E>>;
+    fn data(&self) -> Option<&D::Vec>;
 }
 
-impl<S: Shape, E: Unit, D: DeviceStorage, T> Tensorlike<S, E, D> for Tensor<S, E, D, T> {
+impl<S: Shape, E, D: Storage<E>, T> Tensorlike<S, E, D> for Tensor<S, E, D, T> {
     fn id(&self) -> UniqueId {
         self.id
     }
@@ -37,12 +37,12 @@ impl<S: Shape, E: Unit, D: DeviceStorage, T> Tensorlike<S, E, D> for Tensor<S, E
         &self.device
     }
 
-    fn data(&self) -> Option<&<D as DeviceStorage>::Vec<E>> {
+    fn data(&self) -> Option<&D::Vec> {
         Some(self.data.as_ref())
     }
 }
 
-impl<S: Shape, E: Unit, D: DeviceStorage> Tensorlike<S, E, D> for GhostTensor<S, E, D> {
+impl<S: Shape, E, D: Storage<E>> Tensorlike<S, E, D> for GhostTensor<S, E, D> {
     fn id(&self) -> UniqueId {
         self.id
     }
@@ -59,7 +59,7 @@ impl<S: Shape, E: Unit, D: DeviceStorage> Tensorlike<S, E, D> for GhostTensor<S,
         &self.dev
     }
 
-    fn data(&self) -> Option<&<D as DeviceStorage>::Vec<E>> {
+    fn data(&self) -> Option<&D::Vec> {
         None
     }
 }

--- a/src/tensor_ops/add/mod.rs
+++ b/src/tensor_ops/add/mod.rs
@@ -6,7 +6,7 @@ mod cuda_kernel;
 use super::ops::*;
 use crate::{
     shapes::*,
-    tensor::{DeviceStorage, HasErr, Merge, Tape, Tensor},
+    tensor::{HasErr, Merge, Storage, Tape, Tensor},
 };
 
 #[repr(C)]
@@ -85,7 +85,7 @@ impl<S: Shape, D: UnaryKernel<ScalarAddKernelOp<half::f16>, half::f16>, T: Tape<
     }
 }
 
-impl<S: Shape, E: Dtype, D: DeviceStorage, LhsTape: Tape<E, D>, Rhs> std::ops::Add<Rhs>
+impl<S: Shape, E: Dtype, D: Storage<E>, LhsTape: Tape<E, D>, Rhs> std::ops::Add<Rhs>
     for Tensor<S, E, D, LhsTape>
 where
     Self: TryAdd<Rhs>,

--- a/src/tensor_ops/attention_reshape/cuda_kernel.rs
+++ b/src/tensor_ops/attention_reshape/cuda_kernel.rs
@@ -61,13 +61,13 @@ where
         let num_heads = NUM_HEADS;
 
         let q_shape = (Const, seq, Const);
-        let mut q_Storage<E> = self.dev.alloc_zeros::<E>(q_shape.num_elements())?;
+        let mut q_storage = self.dev.alloc_zeros::<E>(q_shape.num_elements())?;
 
         let k_shape = (Const, Const, total_length);
-        let mut k_Storage<E> = self.dev.alloc_zeros::<E>(k_shape.num_elements())?;
+        let mut k_storage = self.dev.alloc_zeros::<E>(k_shape.num_elements())?;
 
         let v_shape = (Const, total_length, Const);
-        let mut v_Storage<E> = self.dev.alloc_zeros::<E>(v_shape.num_elements())?;
+        let mut v_storage = self.dev.alloc_zeros::<E>(v_shape.num_elements())?;
 
         let numel = q_shape.num_elements() + k_shape.num_elements() + v_shape.num_elements();
         let op = AttentionReshapeOp {

--- a/src/tensor_ops/attention_reshape/cuda_kernel.rs
+++ b/src/tensor_ops/attention_reshape/cuda_kernel.rs
@@ -61,13 +61,13 @@ where
         let num_heads = NUM_HEADS;
 
         let q_shape = (Const, seq, Const);
-        let mut q_storage = self.dev.alloc_zeros::<E>(q_shape.num_elements())?;
+        let mut q_Storage<E> = self.dev.alloc_zeros::<E>(q_shape.num_elements())?;
 
         let k_shape = (Const, Const, total_length);
-        let mut k_storage = self.dev.alloc_zeros::<E>(k_shape.num_elements())?;
+        let mut k_Storage<E> = self.dev.alloc_zeros::<E>(k_shape.num_elements())?;
 
         let v_shape = (Const, total_length, Const);
-        let mut v_storage = self.dev.alloc_zeros::<E>(v_shape.num_elements())?;
+        let mut v_Storage<E> = self.dev.alloc_zeros::<E>(v_shape.num_elements())?;
 
         let numel = q_shape.num_elements() + k_shape.num_elements() + v_shape.num_elements();
         let op = AttentionReshapeOp {

--- a/src/tensor_ops/attention_reshape/mod.rs
+++ b/src/tensor_ops/attention_reshape/mod.rs
@@ -19,7 +19,7 @@ type QkvTuple<const NUM_HEADS: usize, const HEAD_DIM: usize, E, D> = (
 
 /// AttentionReshape qkv + past_key + past_value into (q, k, v) used
 /// in attention layer
-pub trait TryAttentionReshape<E: Dtype>: DeviceStorage {
+pub trait TryAttentionReshape<E: Dtype>: Storage<E> {
     /// This is an inference only kernel:
     /// Within `transformers` architecture, a core component is the `attention`
     /// layer, which can be written in many forms.
@@ -60,7 +60,7 @@ pub trait TryAttentionReshape<E: Dtype>: DeviceStorage {
     ) -> Result<QkvTuple<NUM_HEADS, HEAD_DIM, E, Self>, Self::Err>;
 }
 
-pub trait AttentionReshapeKernel<E: Dtype>: DeviceStorage {
+pub trait AttentionReshapeKernel<E: Dtype>: Storage<E> {
     fn forward<const THREE_HIDDEN_DIM: usize, const NUM_HEADS: usize, const HEAD_DIM: usize>(
         &self,
         qkv: &Tensor<(usize, Const<THREE_HIDDEN_DIM>), E, Self>,

--- a/src/tensor_ops/axpy/cpu_kernel.rs
+++ b/src/tensor_ops/axpy/cpu_kernel.rs
@@ -3,9 +3,9 @@ use crate::{shapes::Dtype, tensor::Cpu};
 impl<E: Dtype> super::AxpyKernel<E> for Cpu {
     fn forward(
         &self,
-        a: &mut Self::Vec<E>,
+        a: &mut Self::Vec,
         alpha: E,
-        b: &Self::Vec<E>,
+        b: &Self::Vec,
         beta: E,
     ) -> Result<(), Self::Err> {
         for (a_i, b_i) in a.iter_mut().zip(b.iter()) {

--- a/src/tensor_ops/axpy/cuda_kernel.rs
+++ b/src/tensor_ops/axpy/cuda_kernel.rs
@@ -27,9 +27,9 @@ where
 {
     fn forward(
         &self,
-        a: &mut Self::Vec<E>,
+        a: &mut Self::Vec,
         alpha: E,
-        b: &Self::Vec<E>,
+        b: &Self::Vec,
         beta: E,
     ) -> Result<(), Self::Err> {
         if !self.dev.has_func(Self::FN, Self::FN) {

--- a/src/tensor_ops/axpy/mod.rs
+++ b/src/tensor_ops/axpy/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::{Dtype, Shape},
-    tensor::{DeviceStorage, Tensor},
+    tensor::{Storage, Tensor},
 };
 
 mod cpu_kernel;
@@ -48,14 +48,9 @@ impl<S: Shape, E: Dtype, D: AxpyKernel<E>> Tensor<S, E, D> {
     }
 }
 
-pub trait AxpyKernel<E: Dtype>: DeviceStorage {
-    fn forward(
-        &self,
-        a: &mut Self::Vec<E>,
-        alpha: E,
-        b: &Self::Vec<E>,
-        beta: E,
-    ) -> Result<(), Self::Err>;
+pub trait AxpyKernel<E: Dtype>: Storage<E> {
+    fn forward(&self, a: &mut Self::Vec, alpha: E, b: &Self::Vec, beta: E)
+        -> Result<(), Self::Err>;
 }
 
 #[cfg(test)]

--- a/src/tensor_ops/boolean/cuda_kernels.rs
+++ b/src/tensor_ops/boolean/cuda_kernels.rs
@@ -25,7 +25,7 @@ impl Cuda {
         let strides = lhs.shape.strides();
         let numel = shape.num_elements();
 
-        let mut storage = unsafe { self.alloc_empty(numel) }?;
+        let mut Storage<E> = unsafe { self.alloc_empty(numel) }?;
 
         let dims: CudaSlice<usize> = self.dev.htod_copy(shape.concrete().into())?;
         let lhs_strides: CudaSlice<usize> = self.dev.htod_copy(lhs.strides.into())?;
@@ -59,7 +59,7 @@ impl BooleanKernel for Cuda {
         }
 
         let numel = inp.data.len();
-        let mut storage = unsafe { self.alloc_empty(numel) }?;
+        let mut Storage<E> = unsafe { self.alloc_empty(numel) }?;
 
         let fwd_fn = self.dev.get_func(MODULE_NAME, "boolean_not").unwrap();
         let cfg = launch_cfg::<128>(numel as u32);

--- a/src/tensor_ops/boolean/cuda_kernels.rs
+++ b/src/tensor_ops/boolean/cuda_kernels.rs
@@ -25,7 +25,7 @@ impl Cuda {
         let strides = lhs.shape.strides();
         let numel = shape.num_elements();
 
-        let mut Storage<E> = unsafe { self.alloc_empty(numel) }?;
+        let mut storage = unsafe { self.alloc_empty(numel) }?;
 
         let dims: CudaSlice<usize> = self.dev.htod_copy(shape.concrete().into())?;
         let lhs_strides: CudaSlice<usize> = self.dev.htod_copy(lhs.strides.into())?;
@@ -59,7 +59,7 @@ impl BooleanKernel for Cuda {
         }
 
         let numel = inp.data.len();
-        let mut Storage<E> = unsafe { self.alloc_empty(numel) }?;
+        let mut storage = unsafe { self.alloc_empty(numel) }?;
 
         let fwd_fn = self.dev.get_func(MODULE_NAME, "boolean_not").unwrap();
         let cfg = launch_cfg::<128>(numel as u32);

--- a/src/tensor_ops/boolean/mod.rs
+++ b/src/tensor_ops/boolean/mod.rs
@@ -6,14 +6,14 @@ mod cuda_kernels;
 use crate::{
     prelude::{OnesTensor, Tensor, ZerosTensor},
     shapes::*,
-    tensor::DeviceStorage,
+    tensor::Storage,
 };
 
 use std::ops::{BitAnd, BitOr, BitXor, Not};
 
 use super::Device;
 
-pub trait BooleanKernel: DeviceStorage + OnesTensor<bool> + ZerosTensor<bool> {
+pub trait BooleanKernel: Storage<bool> + OnesTensor<bool> + ZerosTensor<bool> {
     fn not<S: Shape>(
         &self,
         inp: &Tensor<S, bool, Self>,

--- a/src/tensor_ops/broadcast_to.rs
+++ b/src/tensor_ops/broadcast_to.rs
@@ -55,7 +55,7 @@ pub trait BroadcastTo: HasErr + HasShape {
         Self::Shape: BroadcastShapeTo<Dst::Shape, Ax>;
 }
 
-impl<S: Shape, E: Unit, D: DeviceStorage, T: Tape<E, D>> BroadcastTo for Tensor<S, E, D, T> {
+impl<S: Shape, E, D: Storage<E>, T: Tape<E, D>> BroadcastTo for Tensor<S, E, D, T> {
     fn try_broadcast_like<Dst: HasShape, Ax: Axes>(
         self,
         dst: &Dst,

--- a/src/tensor_ops/choose/cpu_kernel.rs
+++ b/src/tensor_ops/choose/cpu_kernel.rs
@@ -2,7 +2,7 @@ use crate::{
     shapes::{Dtype, Shape},
     tensor::{
         cpu::{LendingIterator, NdIndex},
-        Cpu, Tensor, ZerosTensor,
+        Cpu, Storage, Tensor, ZerosTensor,
     },
 };
 
@@ -32,10 +32,10 @@ impl<E: Dtype> super::ChooseKernel<E> for Cpu {
         &self,
         cond: &Tensor<S, bool, Self>,
         lhs: &Tensor<S, E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut <Self as Storage<E>>::Vec,
         rhs: &Tensor<S, E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut <Self as Storage<E>>::Vec,
+        grad_out: &<Self as Storage<E>>::Vec,
     ) -> Result<(), Self::Err> {
         let mut lhs_idx = NdIndex::new(lhs.shape, lhs.strides);
         let mut rhs_idx = NdIndex::new(rhs.shape, rhs.strides);

--- a/src/tensor_ops/choose/cuda_kernel.rs
+++ b/src/tensor_ops/choose/cuda_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor},
+    tensor::{launch_cfg, Cuda, Storage, Tensor},
 };
 use cudarc::driver::{CudaSlice, LaunchAsync};
 
@@ -45,7 +45,7 @@ where
         let strides = lhs.shape.strides();
         let numel = shape.num_elements();
 
-        let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
+        let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
 
         let dims: CudaSlice<usize> = self.dev.htod_copy(shape.concrete().into())?;
         let cond_strides: CudaSlice<usize> = self.dev.htod_copy(cond.strides.into())?;
@@ -74,10 +74,10 @@ where
         &self,
         cond: &Tensor<S, bool, Self>,
         lhs: &Tensor<S, E, Self>,
-        grad_lhs: &mut Self::Vec,
+        grad_lhs: &mut <Self as Storage<E>>::Vec,
         rhs: &Tensor<S, E, Self>,
-        grad_rhs: &mut Self::Vec,
-        grad_out: &Self::Vec,
+        grad_rhs: &mut <Self as Storage<E>>::Vec,
+        grad_out: &<Self as Storage<E>>::Vec,
     ) -> Result<(), Self::Err> {
         let bwd_fn = self.dev.get_func(Self::MOD, Self::FNS[1]).unwrap();
         let numel = cond.shape.num_elements();

--- a/src/tensor_ops/choose/cuda_kernel.rs
+++ b/src/tensor_ops/choose/cuda_kernel.rs
@@ -45,7 +45,7 @@ where
         let strides = lhs.shape.strides();
         let numel = shape.num_elements();
 
-        let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
+        let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
 
         let dims: CudaSlice<usize> = self.dev.htod_copy(shape.concrete().into())?;
         let cond_strides: CudaSlice<usize> = self.dev.htod_copy(cond.strides.into())?;
@@ -74,10 +74,10 @@ where
         &self,
         cond: &Tensor<S, bool, Self>,
         lhs: &Tensor<S, E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<S, E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let bwd_fn = self.dev.get_func(Self::MOD, Self::FNS[1]).unwrap();
         let numel = cond.shape.num_elements();

--- a/src/tensor_ops/choose/mod.rs
+++ b/src/tensor_ops/choose/mod.rs
@@ -5,10 +5,10 @@ mod cuda_kernel;
 
 use crate::{
     shapes::{Dtype, HasShape, Shape},
-    tensor::{DeviceStorage, HasErr, Merge, PutTape, SplitTape, Tape, Tensor},
+    tensor::{HasErr, Merge, PutTape, SplitTape, Storage, Tape, Tensor},
 };
 
-pub trait ChooseKernel<E: Dtype>: DeviceStorage {
+pub trait ChooseKernel<E: Dtype>: Storage<E> + Storage<bool> {
     fn forward<S: Shape>(
         &self,
         cond: &Tensor<S, bool, Self>,
@@ -20,10 +20,10 @@ pub trait ChooseKernel<E: Dtype>: DeviceStorage {
         &self,
         cond: &Tensor<S, bool, Self>,
         lhs: &Tensor<S, E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut <Self as Storage<E>>::Vec,
         rhs: &Tensor<S, E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut <Self as Storage<E>>::Vec,
+        grad_out: &<Self as Storage<E>>::Vec,
     ) -> Result<(), Self::Err>;
 }
 

--- a/src/tensor_ops/cmp/cuda_kernels.rs
+++ b/src/tensor_ops/cmp/cuda_kernels.rs
@@ -48,7 +48,7 @@ impl<E: Unit, Op: CmpOpCudaKernel<E>> CmpKernel<Op, E> for Cuda {
         let strides = lhs.shape.strides();
         let numel = shape.num_elements();
 
-        let mut Storage<E> = unsafe { self.alloc_empty::<bool>(numel) }?;
+        let mut storage = unsafe { self.alloc_empty::<bool>(numel) }?;
         self.dev.memset_zeros(&mut storage)?;
 
         let dims: CudaSlice<usize> = self.dev.htod_copy(shape.concrete().into())?;
@@ -89,7 +89,7 @@ impl<E: Unit, Op: ScalarCmpOpCudaKernel<E>> ScalarCmpKernel<Op, E> for Cuda {
         let strides = lhs.shape.strides();
         let numel = shape.num_elements();
 
-        let mut Storage<E> = unsafe { self.alloc_empty::<bool>(numel) }?;
+        let mut storage = unsafe { self.alloc_empty::<bool>(numel) }?;
         self.dev.memset_zeros(&mut storage)?;
 
         let dims: CudaSlice<usize> = self.dev.htod_copy(shape.concrete().into())?;

--- a/src/tensor_ops/cmp/cuda_kernels.rs
+++ b/src/tensor_ops/cmp/cuda_kernels.rs
@@ -48,7 +48,7 @@ impl<E: Unit, Op: CmpOpCudaKernel<E>> CmpKernel<Op, E> for Cuda {
         let strides = lhs.shape.strides();
         let numel = shape.num_elements();
 
-        let mut storage = unsafe { self.alloc_empty::<bool>(numel) }?;
+        let mut Storage<E> = unsafe { self.alloc_empty::<bool>(numel) }?;
         self.dev.memset_zeros(&mut storage)?;
 
         let dims: CudaSlice<usize> = self.dev.htod_copy(shape.concrete().into())?;
@@ -89,7 +89,7 @@ impl<E: Unit, Op: ScalarCmpOpCudaKernel<E>> ScalarCmpKernel<Op, E> for Cuda {
         let strides = lhs.shape.strides();
         let numel = shape.num_elements();
 
-        let mut storage = unsafe { self.alloc_empty::<bool>(numel) }?;
+        let mut Storage<E> = unsafe { self.alloc_empty::<bool>(numel) }?;
         self.dev.memset_zeros(&mut storage)?;
 
         let dims: CudaSlice<usize> = self.dev.htod_copy(shape.concrete().into())?;

--- a/src/tensor_ops/concat/cpu_kernel.rs
+++ b/src/tensor_ops/concat/cpu_kernel.rs
@@ -42,9 +42,9 @@ impl<E: Dtype> super::ConcatKernel<E> for Cpu {
     }
     fn backward(
         &self,
-        grad_a: &mut Self::Vec<E>,
-        grad_b: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_a: &mut Self::Vec,
+        grad_b: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let mut offset = 0;
         for ga in grad_a.iter_mut() {

--- a/src/tensor_ops/concat/cuda_kernel.rs
+++ b/src/tensor_ops/concat/cuda_kernel.rs
@@ -30,9 +30,9 @@ impl<E: Dtype + CudaTypeName> super::ConcatKernel<E> for Cuda {
     }
     fn backward(
         &self,
-        grad_a: &mut Self::Vec<E>,
-        grad_b: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_a: &mut Self::Vec,
+        grad_b: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let module_name = std::format!("concat_bwd_{}", E::NAME);
         if !self.dev.has_func(&module_name, "concat_bwd") {

--- a/src/tensor_ops/concat/mod.rs
+++ b/src/tensor_ops/concat/mod.rs
@@ -84,7 +84,7 @@ where
     }
 }
 
-pub trait ConcatKernel<E: Dtype>: DeviceStorage {
+pub trait ConcatKernel<E: Dtype>: Storage<E> {
     fn forward<A: Shape, B: Shape>(
         &self,
         a: &Tensor<A, E, Self>,
@@ -94,9 +94,9 @@ pub trait ConcatKernel<E: Dtype>: DeviceStorage {
         A: ConcatShape<B>;
     fn backward(
         &self,
-        grad_a: &mut Self::Vec<E>,
-        grad_b: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_a: &mut Self::Vec,
+        grad_b: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>;
 }
 

--- a/src/tensor_ops/concat_along/cpu_kernel.rs
+++ b/src/tensor_ops/concat_along/cpu_kernel.rs
@@ -40,10 +40,10 @@ impl<E: Dtype> super::ConcatAlongKernel<E> for Cpu {
         &self,
         ax: usize,
         a: &GhostTensor<A, E, Self>,
-        grad_a: &mut Self::Vec<E>,
+        grad_a: &mut Self::Vec,
         b: &GhostTensor<B, E, Self>,
-        grad_b: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_b: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let mut a_idx = NdIndex::new(a.shape, a.strides);
         let mut b_idx = NdIndex::new(b.shape, b.strides);

--- a/src/tensor_ops/concat_along/cuda_kernel.rs
+++ b/src/tensor_ops/concat_along/cuda_kernel.rs
@@ -63,10 +63,10 @@ impl<E: Dtype + CudaTypeName> super::ConcatAlongKernel<E> for Cuda {
         &self,
         ax: usize,
         a: &GhostTensor<A, E, Self>,
-        grad_a: &mut Self::Vec<E>,
+        grad_a: &mut Self::Vec,
         b: &GhostTensor<B, E, Self>,
-        grad_b: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_b: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let module_name = std::format!("concat_{}", E::NAME);
         let bwd = self.dev.get_func(&module_name, "bwd").unwrap();

--- a/src/tensor_ops/concat_along/mod.rs
+++ b/src/tensor_ops/concat_along/mod.rs
@@ -57,7 +57,7 @@ pub trait TryConcatAlong<Ax>: Sized {
     fn try_concat_along(self, ax: Ax) -> Result<Self::Output, Self::Error>;
 }
 
-pub trait ConcatAlongKernel<E: Dtype>: DeviceStorage {
+pub trait ConcatAlongKernel<E: Dtype>: Storage<E> {
     fn forward<A: Shape, B: Shape, C: Shape>(
         &self,
         ax: usize,
@@ -70,10 +70,10 @@ pub trait ConcatAlongKernel<E: Dtype>: DeviceStorage {
         &self,
         ax: usize,
         a: &GhostTensor<A, E, Self>,
-        grad_a: &mut Self::Vec<E>,
+        grad_a: &mut Self::Vec,
         b: &GhostTensor<B, E, Self>,
-        grad_b: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_b: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>;
 }
 

--- a/src/tensor_ops/conv2d/cpu_kernel.rs
+++ b/src/tensor_ops/conv2d/cpu_kernel.rs
@@ -216,11 +216,11 @@ where
         &self,
         op: Conv2DOp,
         lhs: &Tensor<L, E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<R, E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
         out: &impl Tensorlike<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let f_tr_shape = [
             op.groups,

--- a/src/tensor_ops/conv2d/cuda_kernel.rs
+++ b/src/tensor_ops/conv2d/cuda_kernel.rs
@@ -137,11 +137,11 @@ where
         &self,
         op: super::Conv2DOp,
         lhs: &Tensor<L, E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<R, E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
         _: &impl Tensorlike<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let patches_item_numel = op.chan_out * op.kernel * op.kernel * op.h_in * op.w_in;
         let patches_numel = op.batch * patches_item_numel;

--- a/src/tensor_ops/conv2d/cudnn_kernel.rs
+++ b/src/tensor_ops/conv2d/cudnn_kernel.rs
@@ -89,11 +89,11 @@ where
         &self,
         op: super::Conv2DOp,
         lhs: &Tensor<L, E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<R, E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
         out: &impl Tensorlike<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let mut conv = self.cudnn.create_conv2d::<E>(
             [op.padding as i32, op.padding as i32],

--- a/src/tensor_ops/conv2d/mod.rs
+++ b/src/tensor_ops/conv2d/mod.rs
@@ -28,7 +28,7 @@ pub(super) struct Conv2DOp {
     pub w_out: usize,
 }
 
-pub(super) trait Conv2DKernel<E: Dtype>: DeviceStorage {
+pub(super) trait Conv2DKernel<E: Dtype>: Storage<E> {
     fn alloc<S: Shape>(&self, s: S) -> Result<Tensor<S, E, Self>, Self::Err>;
 
     fn forward<L: Shape, R: Shape, O: Shape>(
@@ -44,11 +44,11 @@ pub(super) trait Conv2DKernel<E: Dtype>: DeviceStorage {
         &self,
         op: Conv2DOp,
         lhs: &Tensor<L, E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<R, E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
         out: &impl Tensorlike<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>;
 }
 

--- a/src/tensor_ops/convtrans2d/cpu_kernel.rs
+++ b/src/tensor_ops/convtrans2d/cpu_kernel.rs
@@ -201,11 +201,11 @@ where
         &self,
         op: ConvTrans2DOp,
         lhs: &Tensor<L, E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<R, E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
         out: &impl Tensorlike<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let f_tr_shape = op.filters_tr_shape();
         let mut patches = self.try_alloc_zeros::<E>(op.out_patches_shape().num_elements())?;

--- a/src/tensor_ops/convtrans2d/cuda_kernel.rs
+++ b/src/tensor_ops/convtrans2d/cuda_kernel.rs
@@ -107,11 +107,11 @@ where
         &self,
         op: super::ConvTrans2DOp,
         lhs: &Tensor<L, E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<R, E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
         _: &impl Tensorlike<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let patches_numel = op.batch * op.chan_out * op.kernel * op.kernel * op.h_in * op.w_in;
         let filters_numel = op.chan_in * op.chan_out * op.kernel * op.kernel;

--- a/src/tensor_ops/convtrans2d/mod.rs
+++ b/src/tensor_ops/convtrans2d/mod.rs
@@ -51,7 +51,7 @@ impl ConvTrans2DOp {
     }
 }
 
-pub(super) trait ConvTrans2DKernel<E: Dtype>: DeviceStorage {
+pub(super) trait ConvTrans2DKernel<E: Dtype>: Storage<E> {
     fn forward<L: Shape, R: Shape, O: Shape>(
         &self,
         op: ConvTrans2DOp,
@@ -65,11 +65,11 @@ pub(super) trait ConvTrans2DKernel<E: Dtype>: DeviceStorage {
         &self,
         op: ConvTrans2DOp,
         lhs: &Tensor<L, E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<R, E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
         out: &impl Tensorlike<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>;
 }
 
@@ -125,7 +125,7 @@ pub trait TryConvTrans2D<F> {
     }
 }
 
-impl<S: Shape, E: Dtype, D: DeviceStorage, T, F> TryConvTrans2D<F> for Tensor<S, E, D, T> {}
+impl<S: Shape, E: Dtype, D: Storage<E>, T, F> TryConvTrans2D<F> for Tensor<S, E, D, T> {}
 
 impl<
         const C: usize,

--- a/src/tensor_ops/div/mod.rs
+++ b/src/tensor_ops/div/mod.rs
@@ -83,7 +83,7 @@ impl<S: Shape, D: UnaryKernel<ScalarDivKernelOp<half::f16>, half::f16>, T: Tape<
     }
 }
 
-impl<S: Shape, E: Dtype, D: DeviceStorage, LhsTape: Tape<E, D>, Rhs> std::ops::Div<Rhs>
+impl<S: Shape, E: Dtype, D: Storage<E>, LhsTape: Tape<E, D>, Rhs> std::ops::Div<Rhs>
     for Tensor<S, E, D, LhsTape>
 where
     Self: TryDiv<Rhs>,

--- a/src/tensor_ops/dropout/cpu_kernel.rs
+++ b/src/tensor_ops/dropout/cpu_kernel.rs
@@ -37,8 +37,8 @@ impl<E: Float + Dtype> super::DropoutKernel<E> for Cpu {
         &self,
         op: super::DropoutKernelOp,
         inp: &Tensor<S, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let mut rng = StdRng::seed_from_u64(op.seed);
         let dist = Bernoulli::new(op.prob).unwrap();

--- a/src/tensor_ops/dropout/cuda_kernel.rs
+++ b/src/tensor_ops/dropout/cuda_kernel.rs
@@ -57,7 +57,7 @@ where
         }
 
         let numel = inp.data.len();
-        let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
+        let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
 
         let fwd_fn = self.dev.get_func(Self::MOD, Self::FNS[0]).unwrap();
         let cfg = launch_cfg::<128>(numel as u32);

--- a/src/tensor_ops/dropout/cuda_kernel.rs
+++ b/src/tensor_ops/dropout/cuda_kernel.rs
@@ -57,7 +57,7 @@ where
         }
 
         let numel = inp.data.len();
-        let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
+        let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
 
         let fwd_fn = self.dev.get_func(Self::MOD, Self::FNS[0]).unwrap();
         let cfg = launch_cfg::<128>(numel as u32);
@@ -69,8 +69,8 @@ where
         &self,
         op: super::DropoutKernelOp,
         inp: &Tensor<S, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let mask = {
             let mut rng = StdRng::seed_from_u64(op.seed);

--- a/src/tensor_ops/dropout/mod.rs
+++ b/src/tensor_ops/dropout/mod.rs
@@ -5,7 +5,7 @@ mod cuda_kernel;
 
 use crate::{
     shapes::*,
-    tensor::{DeviceStorage, PutTape, SplitTape, Tape, Tensor},
+    tensor::{PutTape, RandomU64, SplitTape, Storage, Tape, Tensor},
 };
 
 #[repr(C)]
@@ -15,7 +15,7 @@ pub struct DropoutKernelOp {
     pub prob: f64,
 }
 
-pub trait DropoutKernel<E: Dtype>: DeviceStorage {
+pub trait DropoutKernel<E: Dtype>: Storage<E> + RandomU64 {
     fn forward<S: Shape>(
         &self,
         op: DropoutKernelOp,
@@ -25,8 +25,8 @@ pub trait DropoutKernel<E: Dtype>: DeviceStorage {
         &self,
         op: DropoutKernelOp,
         inp: &Tensor<S, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>;
 }
 

--- a/src/tensor_ops/log_softmax.rs
+++ b/src/tensor_ops/log_softmax.rs
@@ -30,14 +30,14 @@ where
 }
 
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Tensor<S, E, D, T> {
-    /// See [log_softmax]
+    /// See [log_softmax()]
     pub fn log_softmax<Ax: Axes>(self) -> Self
     where
         S: ReduceShape<Ax>,
     {
         self.try_log_softmax::<Ax>().unwrap()
     }
-    /// See [log_softmax]
+    /// See [log_softmax()]
     pub fn try_log_softmax<Ax: Axes>(self) -> Result<Self, D::Err>
     where
         S: ReduceShape<Ax>,

--- a/src/tensor_ops/matmul/cpu_kernel.rs
+++ b/src/tensor_ops/matmul/cpu_kernel.rs
@@ -207,10 +207,10 @@ where
     fn backward<M: Dim, K: Dim, N: Dim>(
         &self,
         lhs: &Tensor<(M, K), E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<(K, N), E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let (m, k) = lhs.shape;
         let n = rhs.shape.1;
@@ -269,10 +269,10 @@ where
     fn backward<B: Dim, M: Dim, K: Dim, N: Dim>(
         &self,
         lhs: &Tensor<(B, M, K), E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<(K, N), E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let (batch, m, k) = lhs.shape;
         let n = rhs.shape.1;
@@ -335,10 +335,10 @@ where
     fn backward<B: Dim, M: Dim, K: Dim, N: Dim>(
         &self,
         lhs: &Tensor<(B, M, K), E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<(B, K, N), E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let (b, m, k) = lhs.shape;
         let n = rhs.shape.2;
@@ -401,10 +401,10 @@ where
     fn backward<B: Dim, S: Dim, M: Dim, K: Dim, N: Dim>(
         &self,
         lhs: &Tensor<(B, S, M, K), E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<(B, S, K, N), E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let (b, s, m, k) = lhs.shape;
         let n = rhs.shape.3;

--- a/src/tensor_ops/matmul/cuda_kernel.rs
+++ b/src/tensor_ops/matmul/cuda_kernel.rs
@@ -174,7 +174,7 @@ where
         let (k, n) = rhs.shape;
         let shape = (m, n);
         let strides = shape.strides();
-        let mut storage = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
+        let mut Storage<E> = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
 
         unsafe {
             self.gemm(
@@ -195,10 +195,10 @@ where
     fn backward<M: Dim, K: Dim, N: Dim>(
         &self,
         lhs: &Tensor<(M, K), E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<(K, N), E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let (m, _) = lhs.shape;
         let (k, n) = rhs.shape;
@@ -249,7 +249,7 @@ where
         let (k, n) = rhs.shape;
         let shape = (batch, m, n);
         let strides = shape.strides();
-        let mut storage = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
+        let mut Storage<E> = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
         unsafe {
             self.gemm_batch(
                 (batch, m, k, n),
@@ -267,10 +267,10 @@ where
     fn backward<B: Dim, M: Dim, K: Dim, N: Dim>(
         &self,
         lhs: &Tensor<(B, M, K), E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<(K, N), E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let (batch, m, _) = lhs.shape;
         let (k, n) = rhs.shape;
@@ -327,7 +327,7 @@ where
         let (_, k, n) = rhs.shape;
         let shape = (batch, m, n);
         let strides = shape.strides();
-        let mut storage = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
+        let mut Storage<E> = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
         unsafe {
             self.gemm_batch(
                 (batch, m, k, n),
@@ -345,10 +345,10 @@ where
     fn backward<B: Dim, M: Dim, K: Dim, N: Dim>(
         &self,
         lhs: &Tensor<(B, M, K), E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<(B, K, N), E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let (batch, m, _) = lhs.shape;
         let (_, k, n) = rhs.shape;
@@ -404,7 +404,7 @@ where
         let (_, _, k, n) = rhs.shape;
         let shape = (batch, seq, m, n);
         let strides = shape.strides();
-        let mut storage = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
+        let mut Storage<E> = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
 
         let half_batch = batch.size() / 2;
 
@@ -447,10 +447,10 @@ where
     fn backward<B: Dim, S: Dim, M: Dim, K: Dim, N: Dim>(
         &self,
         lhs: &Tensor<(B, S, M, K), E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &Tensor<(B, S, K, N), E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let (batch, seq, m, _) = lhs.shape;
         let (_, _, k, n) = rhs.shape;

--- a/src/tensor_ops/matmul/cuda_kernel.rs
+++ b/src/tensor_ops/matmul/cuda_kernel.rs
@@ -174,7 +174,7 @@ where
         let (k, n) = rhs.shape;
         let shape = (m, n);
         let strides = shape.strides();
-        let mut Storage<E> = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
+        let mut storage = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
 
         unsafe {
             self.gemm(
@@ -249,7 +249,7 @@ where
         let (k, n) = rhs.shape;
         let shape = (batch, m, n);
         let strides = shape.strides();
-        let mut Storage<E> = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
+        let mut storage = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
         unsafe {
             self.gemm_batch(
                 (batch, m, k, n),
@@ -327,7 +327,7 @@ where
         let (_, k, n) = rhs.shape;
         let shape = (batch, m, n);
         let strides = shape.strides();
-        let mut Storage<E> = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
+        let mut storage = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
         unsafe {
             self.gemm_batch(
                 (batch, m, k, n),
@@ -404,7 +404,7 @@ where
         let (_, _, k, n) = rhs.shape;
         let shape = (batch, seq, m, n);
         let strides = shape.strides();
-        let mut Storage<E> = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
+        let mut storage = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
 
         let half_batch = batch.size() / 2;
 

--- a/src/tensor_ops/max_to/cpu_kernel.rs
+++ b/src/tensor_ops/max_to/cpu_kernel.rs
@@ -41,9 +41,9 @@ impl<E: Dtype + Float> super::MaxReduceKernel<E> for Cpu {
     fn backward<Src: Shape, Dst: Shape, Ax: Axes>(
         &self,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &Tensor<Dst, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>
     where
         Src: ReduceShapeTo<Dst, Ax>,

--- a/src/tensor_ops/max_to/cuda_kernel.rs
+++ b/src/tensor_ops/max_to/cuda_kernel.rs
@@ -53,8 +53,8 @@ where
 
         let fill_fn = self.dev.get_func(Self::MOD, Self::FNS[2]).unwrap();
         let fwd_fn = self.dev.get_func(Self::MOD, Self::FNS[0]).unwrap();
-        let mut Storage<E> = unsafe {
-            let mut Storage<E> = self.alloc_empty::<E>(dst.num_elements())?;
+        let mut storage = unsafe {
+            let mut storage = self.alloc_empty::<E>(dst.num_elements())?;
             fill_fn.launch(
                 launch_cfg::<128>(dst.num_elements() as u32),
                 (&mut storage, Self::INIT, dst.num_elements()),

--- a/src/tensor_ops/max_to/cuda_kernel.rs
+++ b/src/tensor_ops/max_to/cuda_kernel.rs
@@ -53,8 +53,8 @@ where
 
         let fill_fn = self.dev.get_func(Self::MOD, Self::FNS[2]).unwrap();
         let fwd_fn = self.dev.get_func(Self::MOD, Self::FNS[0]).unwrap();
-        let mut storage = unsafe {
-            let mut storage = self.alloc_empty::<E>(dst.num_elements())?;
+        let mut Storage<E> = unsafe {
+            let mut Storage<E> = self.alloc_empty::<E>(dst.num_elements())?;
             fill_fn.launch(
                 launch_cfg::<128>(dst.num_elements() as u32),
                 (&mut storage, Self::INIT, dst.num_elements()),
@@ -92,9 +92,9 @@ where
     fn backward<Src: Shape, Dst: Shape, Ax: Axes>(
         &self,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &Tensor<Dst, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>
     where
         Src: ReduceShapeTo<Dst, Ax>,

--- a/src/tensor_ops/max_to/mod.rs
+++ b/src/tensor_ops/max_to/mod.rs
@@ -5,7 +5,7 @@ mod cuda_kernel;
 
 use crate::{shapes::*, tensor::*};
 
-pub trait MaxReduceKernel<E: Dtype>: DeviceStorage {
+pub trait MaxReduceKernel<E: Dtype>: Storage<E> {
     fn forward<Src: Shape, Dst: Shape, Ax: Axes>(
         &self,
         dst: Dst,
@@ -16,9 +16,9 @@ pub trait MaxReduceKernel<E: Dtype>: DeviceStorage {
     fn backward<Src: Shape, Dst: Shape, Ax: Axes>(
         &self,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &Tensor<Dst, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>
     where
         Src: ReduceShapeTo<Dst, Ax>;

--- a/src/tensor_ops/min_to/cpu_kernel.rs
+++ b/src/tensor_ops/min_to/cpu_kernel.rs
@@ -41,9 +41,9 @@ impl<E: Dtype + Float> super::MinReduceKernel<E> for Cpu {
     fn backward<Src: Shape, Dst: Shape, Ax: Axes>(
         &self,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &Tensor<Dst, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>
     where
         Src: ReduceShapeTo<Dst, Ax>,

--- a/src/tensor_ops/min_to/cuda_kernel.rs
+++ b/src/tensor_ops/min_to/cuda_kernel.rs
@@ -54,8 +54,8 @@ where
         let fill_fn = self.dev.get_func(Self::MOD, Self::FNS[2]).unwrap();
         let fwd_fn = self.dev.get_func(Self::MOD, Self::FNS[0]).unwrap();
 
-        let mut storage = unsafe {
-            let mut storage = self.alloc_empty::<E>(dst.num_elements())?;
+        let mut Storage<E> = unsafe {
+            let mut Storage<E> = self.alloc_empty::<E>(dst.num_elements())?;
             fill_fn.launch(
                 launch_cfg::<128>(dst.num_elements() as u32),
                 (&mut storage, Self::INIT, dst.num_elements()),
@@ -92,9 +92,9 @@ where
     fn backward<Src: Shape, Dst: Shape, Ax: Axes>(
         &self,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &Tensor<Dst, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>
     where
         Src: ReduceShapeTo<Dst, Ax>,

--- a/src/tensor_ops/min_to/cuda_kernel.rs
+++ b/src/tensor_ops/min_to/cuda_kernel.rs
@@ -54,8 +54,8 @@ where
         let fill_fn = self.dev.get_func(Self::MOD, Self::FNS[2]).unwrap();
         let fwd_fn = self.dev.get_func(Self::MOD, Self::FNS[0]).unwrap();
 
-        let mut Storage<E> = unsafe {
-            let mut Storage<E> = self.alloc_empty::<E>(dst.num_elements())?;
+        let mut storage = unsafe {
+            let mut storage = self.alloc_empty::<E>(dst.num_elements())?;
             fill_fn.launch(
                 launch_cfg::<128>(dst.num_elements() as u32),
                 (&mut storage, Self::INIT, dst.num_elements()),

--- a/src/tensor_ops/min_to/mod.rs
+++ b/src/tensor_ops/min_to/mod.rs
@@ -5,7 +5,7 @@ mod cuda_kernel;
 
 use crate::{shapes::*, tensor::*};
 
-pub trait MinReduceKernel<E: Dtype>: DeviceStorage {
+pub trait MinReduceKernel<E: Dtype>: Storage<E> {
     fn forward<Src: Shape, Dst: Shape, Ax: Axes>(
         &self,
         dst: Dst,
@@ -16,9 +16,9 @@ pub trait MinReduceKernel<E: Dtype>: DeviceStorage {
     fn backward<Src: Shape, Dst: Shape, Ax: Axes>(
         &self,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &Tensor<Dst, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>
     where
         Src: ReduceShapeTo<Dst, Ax>;

--- a/src/tensor_ops/mul/mod.rs
+++ b/src/tensor_ops/mul/mod.rs
@@ -78,7 +78,7 @@ impl<S: Shape, D: UnaryKernel<ScalarMulKernelOp<half::f16>, half::f16>, T: Tape<
     }
 }
 
-impl<S: Shape, E: Dtype, D: DeviceStorage, LhsTape: Tape<E, D>, Rhs> std::ops::Mul<Rhs>
+impl<S: Shape, E: Dtype, D: Storage<E>, LhsTape: Tape<E, D>, Rhs> std::ops::Mul<Rhs>
     for Tensor<S, E, D, LhsTape>
 where
     Self: TryMul<Rhs>,

--- a/src/tensor_ops/permute_to.rs
+++ b/src/tensor_ops/permute_to.rs
@@ -35,7 +35,7 @@ pub trait PermuteTo: HasErr + HasShape {
         Self::Shape: PermuteShapeTo<Dst, Ax>;
 }
 
-impl<S: Shape, E: Unit, D: DeviceStorage, T: Tape<E, D>> PermuteTo for Tensor<S, E, D, T> {
+impl<S: Shape, E, D: Storage<E>, T: Tape<E, D>> PermuteTo for Tensor<S, E, D, T> {
     fn try_permute<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
     where
         Self::Shape: PermuteShapeTo<Dst, Ax>,

--- a/src/tensor_ops/pool2d/cpu_kernel.rs
+++ b/src/tensor_ops/pool2d/cpu_kernel.rs
@@ -103,9 +103,9 @@ impl<E: Float + Dtype> super::Pool2DKernel<E> for Cpu {
         &self,
         op: super::Pool2DOp,
         inp: &Tensor<I, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &Tensor<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let istr = make_4d::<I>(inp.strides);
         let ostr = make_4d::<O>(out.strides);

--- a/src/tensor_ops/pool2d/cuda_kernel.rs
+++ b/src/tensor_ops/pool2d/cuda_kernel.rs
@@ -77,9 +77,9 @@ where
         &self,
         op: super::Pool2DOp,
         inp: &Tensor<I, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &Tensor<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let inp_strides = self.dev.htod_copy(make_4d::<I>(inp.strides).into())?;
         let out_strides = self.dev.htod_copy(make_4d::<O>(out.strides).into())?;

--- a/src/tensor_ops/pool2d/mod.rs
+++ b/src/tensor_ops/pool2d/mod.rs
@@ -31,7 +31,7 @@ pub struct Pool2DOp {
     pub w_out: usize,
 }
 
-pub(super) trait Pool2DKernel<E: Dtype>: DeviceStorage {
+pub(super) trait Pool2DKernel<E: Dtype>: Storage<E> {
     fn alloc<S: Shape>(&self, s: S) -> Result<Tensor<S, E, Self>, Self::Err>;
 
     fn forward<I: Shape, O: Shape>(
@@ -46,9 +46,9 @@ pub(super) trait Pool2DKernel<E: Dtype>: DeviceStorage {
         &self,
         op: Pool2DOp,
         inp: &Tensor<I, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &Tensor<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>;
 }
 

--- a/src/tensor_ops/pow/cuda_kernel.rs
+++ b/src/tensor_ops/pow/cuda_kernel.rs
@@ -44,9 +44,9 @@ where
         &self,
         op: super::PowiKernelOp,
         inp: &impl Tensorlike<S, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &impl Tensorlike<S, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         self.backward(
             super::PowfKernelOp(E::from_i32(op.0).unwrap()),

--- a/src/tensor_ops/realize_to.rs
+++ b/src/tensor_ops/realize_to.rs
@@ -35,7 +35,7 @@ pub trait RealizeTo: HasErr + HasShape {
         Self::Shape: RealizeShapeTo<Dst>;
 }
 
-impl<S: Shape, E: Dtype, D: DeviceStorage, T: Tape<E, D>> RealizeTo for Tensor<S, E, D, T> {
+impl<S: Shape, E, D: Storage<E>, T: Tape<E, D>> RealizeTo for Tensor<S, E, D, T> {
     fn try_realize<Dst: Shape<Concrete = S::Concrete>>(self) -> Result<Self::WithShape<Dst>, Self>
     where
         Self::Shape: RealizeShapeTo<Dst>,

--- a/src/tensor_ops/reshape_to/cpu_kernel.rs
+++ b/src/tensor_ops/reshape_to/cpu_kernel.rs
@@ -22,8 +22,8 @@ impl<E: Dtype> super::ReshapeKernel<E> for Cpu {
         &self,
         dst: &Dst,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let mut inp_idx = NdIndex::new(inp.shape, inp.strides);
         let mut out_idx = NdIndex::new(*dst, dst.strides());

--- a/src/tensor_ops/reshape_to/cuda_kernel.rs
+++ b/src/tensor_ops/reshape_to/cuda_kernel.rs
@@ -33,7 +33,7 @@ impl<E: Dtype + CudaTypeName> super::ReshapeKernel<E> for Cuda {
         let fwd_fn = self.dev.get_func(&module, "reshape_fwd").unwrap();
 
         let numel = inp.shape.num_elements();
-        let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
+        let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
 
         let mut info = Vec::with_capacity(Src::NUM_DIMS * 2 + Dst::NUM_DIMS * 2);
         info.extend(inp.shape.concrete());

--- a/src/tensor_ops/reshape_to/cuda_kernel.rs
+++ b/src/tensor_ops/reshape_to/cuda_kernel.rs
@@ -33,7 +33,7 @@ impl<E: Dtype + CudaTypeName> super::ReshapeKernel<E> for Cuda {
         let fwd_fn = self.dev.get_func(&module, "reshape_fwd").unwrap();
 
         let numel = inp.shape.num_elements();
-        let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
+        let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
 
         let mut info = Vec::with_capacity(Src::NUM_DIMS * 2 + Dst::NUM_DIMS * 2);
         info.extend(inp.shape.concrete());
@@ -60,8 +60,8 @@ impl<E: Dtype + CudaTypeName> super::ReshapeKernel<E> for Cuda {
         &self,
         dst: &Dst,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let module = std::format!("reshape_bwd_{}", E::NAME);
         if !self.dev.has_func(&module, "reshape_bwd") {

--- a/src/tensor_ops/reshape_to/mod.rs
+++ b/src/tensor_ops/reshape_to/mod.rs
@@ -5,7 +5,7 @@ mod cuda_kernel;
 
 use crate::{shapes::*, tensor::*};
 
-pub trait ReshapeKernel<E: Dtype>: DeviceStorage {
+pub trait ReshapeKernel<E: Dtype>: Storage<E> {
     fn forward<Src: Shape, Dst: Shape>(
         &self,
         dst: &Dst,
@@ -15,8 +15,8 @@ pub trait ReshapeKernel<E: Dtype>: DeviceStorage {
         &self,
         dst: &Dst,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>;
 }
 

--- a/src/tensor_ops/roll/cpu_kernel.rs
+++ b/src/tensor_ops/roll/cpu_kernel.rs
@@ -37,8 +37,8 @@ impl<E: Dtype> super::RollKernel<E> for Cpu {
         &self,
         op: super::RollOp,
         inp: &Tensor<S, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let dims = inp.shape.concrete();
         let strides = inp.shape.strides();

--- a/src/tensor_ops/roll/cuda_kernel.rs
+++ b/src/tensor_ops/roll/cuda_kernel.rs
@@ -63,8 +63,8 @@ where
         &self,
         op: super::RollOp,
         inp: &Tensor<S, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let numel = inp.shape.num_elements();
         let strides = inp.shape.strides();

--- a/src/tensor_ops/roll/mod.rs
+++ b/src/tensor_ops/roll/mod.rs
@@ -14,7 +14,7 @@ pub struct RollOp {
     amount: usize,
 }
 
-pub trait RollKernel<E: Dtype>: DeviceStorage {
+pub trait RollKernel<E: Dtype>: Storage<E> {
     fn forward<S: Shape>(
         &self,
         op: RollOp,
@@ -24,8 +24,8 @@ pub trait RollKernel<E: Dtype>: DeviceStorage {
         &self,
         op: RollOp,
         inp: &Tensor<S, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>;
 }
 

--- a/src/tensor_ops/select_and_gather/cpu_kernel.rs
+++ b/src/tensor_ops/select_and_gather/cpu_kernel.rs
@@ -3,7 +3,7 @@
 use crate::shapes::{Axes, Dtype, RemoveDimTo, ReplaceDimTo, Shape};
 use crate::tensor::{
     cpu::{index_to_i, LendingIterator, NdIndex},
-    Cpu, Tensor, ZerosTensor,
+    Cpu, Storage, Tensor, ZerosTensor,
 };
 
 impl<E: Dtype> super::ReplaceDimKernel<E> for Cpu {
@@ -49,10 +49,10 @@ impl<E: Dtype> super::ReplaceDimKernel<E> for Cpu {
     fn backward<Src: Shape, Dst: Shape, Idx: Shape>(
         &self,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut <Self as Storage<E>>::Vec,
         idx: &Tensor<Idx, usize, Self>,
         out: &Tensor<Dst, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &<Self as Storage<E>>::Vec,
     ) -> Result<(), Self::Err>
     where
         Src: ReplaceDimTo<Dst, Idx>,
@@ -122,10 +122,10 @@ impl<E: Dtype> super::RemoveDimKernel<E> for Cpu {
     fn backward<Src: Shape, Dst: Shape, Idx: Shape>(
         &self,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut <Self as Storage<E>>::Vec,
         idx: &Tensor<Idx, usize, Self>,
         out: &Tensor<Dst, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &<Self as Storage<E>>::Vec,
     ) -> Result<(), Self::Err>
     where
         Src: RemoveDimTo<Dst, Idx>,

--- a/src/tensor_ops/select_and_gather/cuda_kernel.rs
+++ b/src/tensor_ops/select_and_gather/cuda_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::{RemoveDimTo, ReplaceDimTo, Shape},
-    tensor::{launch_cfg, Cuda, Tensor},
+    tensor::{launch_cfg, Cuda, Storage, Tensor},
 };
 use cudarc::driver::{DeviceSlice, LaunchAsync};
 
@@ -28,7 +28,7 @@ macro_rules! impl_cuda_kernels {
 
                 let dst = inp.shape.replace(idx.shape);
                 let numel = dst.num_elements();
-                let mut Storage<E> = unsafe { self.alloc_empty::<$TypeName>(numel) }?;
+                let mut storage = unsafe { self.alloc_empty::<$TypeName>(numel) }?;
                 self.dev.memset_zeros(&mut storage)?;
 
                 let inp_dims = self.dev.htod_copy(inp.shape.concrete().into())?;
@@ -59,10 +59,10 @@ macro_rules! impl_cuda_kernels {
             fn backward<Src: Shape, Dst: Shape, Idx: Shape>(
                 &self,
                 inp: &Tensor<Src, $TypeName, Self>,
-                grad_inp: &mut Self::Vec<$TypeName>,
+                grad_inp: &mut <Self as Storage<$TypeName>>::Vec,
                 idx: &Tensor<Idx, usize, Self>,
                 _: &Tensor<Dst, $TypeName, Self>,
-                grad_out: &Self::Vec<$TypeName>,
+                grad_out: &<Self as Storage<$TypeName>>::Vec,
             ) -> Result<(), Self::Err>
             where
                 Src: ReplaceDimTo<Dst, Idx>,
@@ -113,7 +113,7 @@ macro_rules! impl_cuda_kernels {
 
                 let dst = inp.shape.remove(idx.shape);
                 let numel = dst.num_elements();
-                let mut Storage<E> = unsafe { self.alloc_empty::<$TypeName>(numel) }?;
+                let mut storage = unsafe { self.alloc_empty::<$TypeName>(numel) }?;
                 self.dev.memset_zeros(&mut storage)?;
 
                 let inp_dims = self.dev.htod_copy(inp.shape.concrete().into())?;
@@ -147,10 +147,10 @@ macro_rules! impl_cuda_kernels {
             fn backward<Src: Shape, Dst: Shape, Idx: Shape>(
                 &self,
                 inp: &Tensor<Src, $TypeName, Self>,
-                grad_inp: &mut Self::Vec<$TypeName>,
+                grad_inp: &mut <Self as Storage<$TypeName>>::Vec,
                 idx: &Tensor<Idx, usize, Self>,
                 out: &Tensor<Dst, $TypeName, Self>,
-                grad_out: &Self::Vec<$TypeName>,
+                grad_out: &<Self as Storage<$TypeName>>::Vec,
             ) -> Result<(), Self::Err>
             where
                 Src: RemoveDimTo<Dst, Idx>,

--- a/src/tensor_ops/select_and_gather/cuda_kernel.rs
+++ b/src/tensor_ops/select_and_gather/cuda_kernel.rs
@@ -28,7 +28,7 @@ macro_rules! impl_cuda_kernels {
 
                 let dst = inp.shape.replace(idx.shape);
                 let numel = dst.num_elements();
-                let mut storage = unsafe { self.alloc_empty::<$TypeName>(numel) }?;
+                let mut Storage<E> = unsafe { self.alloc_empty::<$TypeName>(numel) }?;
                 self.dev.memset_zeros(&mut storage)?;
 
                 let inp_dims = self.dev.htod_copy(inp.shape.concrete().into())?;
@@ -113,7 +113,7 @@ macro_rules! impl_cuda_kernels {
 
                 let dst = inp.shape.remove(idx.shape);
                 let numel = dst.num_elements();
-                let mut storage = unsafe { self.alloc_empty::<$TypeName>(numel) }?;
+                let mut Storage<E> = unsafe { self.alloc_empty::<$TypeName>(numel) }?;
                 self.dev.memset_zeros(&mut storage)?;
 
                 let inp_dims = self.dev.htod_copy(inp.shape.concrete().into())?;

--- a/src/tensor_ops/slice/cpu_kernel.rs
+++ b/src/tensor_ops/slice/cpu_kernel.rs
@@ -28,8 +28,8 @@ impl<E: Unit> SliceKernel<E> for Cpu {
     fn backward<Src: Shape + SliceShape<Slice>, Slice>(
         &self,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
         slice: &Slice,
     ) -> Result<(), Self::Err> {
         let dst = inp.shape.slice(slice).unwrap();

--- a/src/tensor_ops/slice/cuda_kernel.rs
+++ b/src/tensor_ops/slice/cuda_kernel.rs
@@ -61,7 +61,7 @@ where
         let start_idx = NdIndex::new(inp.shape, inp.strides)
             .get_strided_index(inp.shape.first_idx_in_slice(slice));
 
-        let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
+        let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
 
         let dims: CudaSlice<usize> = self.dev.htod_copy(dst.concrete().into())?;
         let strides: CudaSlice<usize> = self.dev.htod_copy(strides.into())?;

--- a/src/tensor_ops/slice/cuda_kernel.rs
+++ b/src/tensor_ops/slice/cuda_kernel.rs
@@ -61,7 +61,7 @@ where
         let start_idx = NdIndex::new(inp.shape, inp.strides)
             .get_strided_index(inp.shape.first_idx_in_slice(slice));
 
-        let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
+        let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
 
         let dims: CudaSlice<usize> = self.dev.htod_copy(dst.concrete().into())?;
         let strides: CudaSlice<usize> = self.dev.htod_copy(strides.into())?;
@@ -84,8 +84,8 @@ where
     fn backward<Src: Shape + SliceShape<Slice>, Slice>(
         &self,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
         slice: &Slice,
     ) -> Result<(), Self::Err> {
         if !self.dev.has_func(Self::MOD, Self::FNS[1]) {

--- a/src/tensor_ops/slice/mod.rs
+++ b/src/tensor_ops/slice/mod.rs
@@ -4,7 +4,7 @@ mod cpu_kernel;
 #[cfg(feature = "cuda")]
 mod cuda_kernel;
 
-pub trait SliceKernel<E: Unit>: DeviceStorage {
+pub trait SliceKernel<E: Unit>: Storage<E> {
     fn forward<Src: Shape + SliceShape<Slice>, Slice>(
         &self,
         inp: &Tensor<Src, E, Self>,
@@ -14,8 +14,8 @@ pub trait SliceKernel<E: Unit>: DeviceStorage {
     fn backward<Src: Shape + SliceShape<Slice>, Slice>(
         &self,
         inp: &Tensor<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
         slice: &Slice,
     ) -> Result<(), Self::Err>;
 }

--- a/src/tensor_ops/softmax.rs
+++ b/src/tensor_ops/softmax.rs
@@ -25,14 +25,14 @@ where
 }
 
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Tensor<S, E, D, T> {
-    /// See [softmax]
+    /// See [softmax()]
     pub fn softmax<Ax: Axes>(self) -> Self
     where
         S: ReduceShape<Ax>,
     {
         self.try_softmax::<Ax>().unwrap()
     }
-    /// See [softmax]
+    /// See [softmax()]
     pub fn try_softmax<Ax: Axes>(self) -> Result<Self, D::Err>
     where
         S: ReduceShape<Ax>,

--- a/src/tensor_ops/stack/cpu_kernel.rs
+++ b/src/tensor_ops/stack/cpu_kernel.rs
@@ -50,8 +50,8 @@ impl<E: Dtype> super::StackKernel<E> for Cpu {
     }
     fn backward(
         &self,
-        mut grad_inp: Vec<&mut Self::Vec<E>>,
-        grad_out: &Self::Vec<E>,
+        mut grad_inp: Vec<&mut Self::Vec>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let mut offset = 0;
         for item in grad_inp.drain(..) {

--- a/src/tensor_ops/stack/cuda_kernel.rs
+++ b/src/tensor_ops/stack/cuda_kernel.rs
@@ -52,8 +52,8 @@ impl<E: Dtype + CudaTypeName> super::StackKernel<E> for Cuda {
 
     fn backward(
         &self,
-        mut grad_inp: Vec<&mut Self::Vec<E>>,
-        grad_out: &Self::Vec<E>,
+        mut grad_inp: Vec<&mut Self::Vec>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let module_name = std::format!("stack_bwd_{}", E::NAME);
         if !self.dev.has_func(&module_name, "stack_bwd") {

--- a/src/tensor_ops/stack/mod.rs
+++ b/src/tensor_ops/stack/mod.rs
@@ -110,7 +110,7 @@ impl<D1: Dim, D2: Dim, D3: Dim, D4: Dim, New: Dim> AddDim<New> for (D1, D2, D3, 
     }
 }
 
-pub trait StackKernel<E: Dtype>: DeviceStorage {
+pub trait StackKernel<E: Dtype>: Storage<E> {
     fn forward<S: Shape, Num: Dim>(
         &self,
         num: Num,
@@ -120,8 +120,8 @@ pub trait StackKernel<E: Dtype>: DeviceStorage {
         S: AddDim<Num>;
     fn backward(
         &self,
-        grad_inp: Vec<&mut Self::Vec<E>>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: Vec<&mut Self::Vec>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>;
 }
 
@@ -152,7 +152,7 @@ where
         assert_eq!(t.shape(), &shape);
     }
 
-    // we map to storage refs so kernels don't have to know about tensors
+    // we map to Storage<E> refs so kernels don't have to know about tensors
     let out = device.forward(new_dim, &tensors)?;
 
     let inp_ghosts: Vec<_> = tensors.iter().map(|t| t.ghost()).collect();

--- a/src/tensor_ops/sub/mod.rs
+++ b/src/tensor_ops/sub/mod.rs
@@ -79,7 +79,7 @@ impl<S: Shape, D: UnaryKernel<ScalarSubKernelOp<half::f16>, half::f16>, T: Tape<
     }
 }
 
-impl<S: Shape, E: Dtype, D: DeviceStorage, LTape: Tape<E, D>, Rhs> std::ops::Sub<Rhs>
+impl<S: Shape, E: Dtype, D: Storage<E>, LTape: Tape<E, D>, Rhs> std::ops::Sub<Rhs>
     for Tensor<S, E, D, LTape>
 where
     Self: TrySub<Rhs>,

--- a/src/tensor_ops/sum_to/cpu_kernel.rs
+++ b/src/tensor_ops/sum_to/cpu_kernel.rs
@@ -40,8 +40,8 @@ impl<E: Dtype> super::SumKernel<E> for Cpu {
         &self,
         _dst: Dst,
         inp: &impl Tensorlike<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>
     where
         Src: ReduceShapeTo<Dst, Ax>,

--- a/src/tensor_ops/sum_to/cuda_kernel.rs
+++ b/src/tensor_ops/sum_to/cuda_kernel.rs
@@ -71,7 +71,7 @@ where
 
         let cfg = launch_cfg::<128>(physical_numel as u32);
 
-        let mut Storage<E> = unsafe { self.alloc_empty::<E>(dst_physical_numel) }?;
+        let mut storage = unsafe { self.alloc_empty::<E>(dst_physical_numel) }?;
         self.dev.memset_zeros(&mut storage)?;
         let params = (
             physical_numel,    // const size_t numel,

--- a/src/tensor_ops/sum_to/cuda_kernel.rs
+++ b/src/tensor_ops/sum_to/cuda_kernel.rs
@@ -71,7 +71,7 @@ where
 
         let cfg = launch_cfg::<128>(physical_numel as u32);
 
-        let mut storage = unsafe { self.alloc_empty::<E>(dst_physical_numel) }?;
+        let mut Storage<E> = unsafe { self.alloc_empty::<E>(dst_physical_numel) }?;
         self.dev.memset_zeros(&mut storage)?;
         let params = (
             physical_numel,    // const size_t numel,
@@ -90,8 +90,8 @@ where
         &self,
         dst: Dst,
         inp: &impl Tensorlike<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>
     where
         Src: ReduceShapeTo<Dst, Ax>,

--- a/src/tensor_ops/sum_to/mod.rs
+++ b/src/tensor_ops/sum_to/mod.rs
@@ -5,7 +5,7 @@ mod cuda_kernel;
 
 use crate::{shapes::*, tensor::*};
 
-pub trait SumKernel<E: Dtype>: DeviceStorage {
+pub trait SumKernel<E: Dtype>: Storage<E> {
     fn forward<Src: Shape, Dst: Shape, Ax: Axes>(
         &self,
         dst: Dst,
@@ -17,8 +17,8 @@ pub trait SumKernel<E: Dtype>: DeviceStorage {
         &self,
         dst: Dst,
         inp: &impl Tensorlike<Src, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>
     where
         Src: ReduceShapeTo<Dst, Ax>;

--- a/src/tensor_ops/to_dtype/mod.rs
+++ b/src/tensor_ops/to_dtype/mod.rs
@@ -2,9 +2,9 @@ mod cpu_kernel;
 #[cfg(feature = "cuda")]
 mod cuda_kernel;
 
-use crate::prelude::{DeviceStorage, Shape, Tensor, Unit};
+use crate::prelude::{Shape, Storage, Tensor, Unit};
 
-pub trait ToDtypeKernel<E1: Unit, E2: Unit>: DeviceStorage {
+pub trait ToDtypeKernel<E1: Unit, E2: Unit>: Storage<E1> + Storage<E2> {
     fn forward<S: Shape>(inp: Tensor<S, E1, Self>) -> Result<Tensor<S, E2, Self>, Self::Err>;
 }
 
@@ -28,7 +28,7 @@ pub fn to_dtype<E2: Unit, S: Shape, E1: Unit, D: ToDtypeKernel<E1, E2>>(
     tensor.to_dtype()
 }
 
-impl<S: Shape, E: Unit, D: DeviceStorage> Tensor<S, E, D> {
+impl<S: Shape, E: Unit, D: Storage<E>> Tensor<S, E, D> {
     pub fn try_to_dtype<E2: Unit>(self) -> Result<Tensor<S, E2, D>, D::Err>
     where
         D: ToDtypeKernel<E, E2>,

--- a/src/tensor_ops/upscale2d/cpu_kernel.rs
+++ b/src/tensor_ops/upscale2d/cpu_kernel.rs
@@ -53,9 +53,9 @@ impl<E: Float + Unit + std::ops::AddAssign + std::ops::DivAssign>
         &self,
         op: super::Upscale2DOp,
         inp: &Tensor<I, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &Tensor<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let istr = make_4d::<I>(inp.strides);
         let ostr = make_4d::<O>(out.strides);
@@ -135,9 +135,9 @@ impl<E: Float + Dtype> super::Upscale2DKernel<E, Bilinear> for Cpu {
         &self,
         op: super::Upscale2DOp,
         inp: &Tensor<I, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &Tensor<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let istr = make_4d::<I>(inp.strides);
         let ostr = make_4d::<O>(out.strides);

--- a/src/tensor_ops/upscale2d/cuda_kernel.rs
+++ b/src/tensor_ops/upscale2d/cuda_kernel.rs
@@ -82,9 +82,9 @@ where
         &self,
         op: super::Upscale2DOp,
         inp: &Tensor<I, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &Tensor<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let strides = self.dev.htod_copy(make_4d::<I>(inp.strides).into())?;
         let bwd_fn = self.dev.get_func(Self::FWD, Self::BWD).unwrap();

--- a/src/tensor_ops/upscale2d/mod.rs
+++ b/src/tensor_ops/upscale2d/mod.rs
@@ -5,7 +5,7 @@ mod cuda_kernel;
 
 use crate::{
     shapes::*,
-    tensor::{DeviceStorage, HasErr, PutTape, SplitTape, Tape, Tensor, ZerosTensor},
+    tensor::{HasErr, PutTape, SplitTape, Storage, Tape, Tensor, ZerosTensor},
 };
 
 #[repr(C)]
@@ -59,7 +59,7 @@ impl UpscaleMethod for NearestNeighbor {}
 pub struct Bilinear;
 impl UpscaleMethod for Bilinear {}
 
-pub trait Upscale2DKernel<E: Unit, M: UpscaleMethod>: DeviceStorage {
+pub trait Upscale2DKernel<E: Unit, M: UpscaleMethod>: Storage<E> {
     fn forward<I: Shape, O: Shape>(
         &self,
         op: Upscale2DOp,
@@ -71,9 +71,9 @@ pub trait Upscale2DKernel<E: Unit, M: UpscaleMethod>: DeviceStorage {
         &self,
         op: Upscale2DOp,
         inp: &Tensor<I, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &Tensor<O, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>;
 }
 
@@ -153,7 +153,7 @@ pub trait TryUpscale2D {
         GenericUpscale2D::generic_upscale2d_like(self, method, height, width)
     }
 }
-impl<S: Shape, E: Dtype, D: DeviceStorage, T> TryUpscale2D for Tensor<S, E, D, T> {}
+impl<S: Shape, E: Dtype, D: Storage<E>, T> TryUpscale2D for Tensor<S, E, D, T> {}
 
 impl<
         C: Dim,

--- a/src/tensor_ops/utilities/backward.rs
+++ b/src/tensor_ops/utilities/backward.rs
@@ -1,10 +1,10 @@
-use crate::shapes::{Dtype, Rank0};
+use crate::shapes::Rank0;
 use crate::tensor::*;
 
 /// Runs backprop algorithm with all operations contained in the tape that `t` has.
 ///
 /// This function takes ownership of `self` and returns [Gradients].
-pub trait Backward<E: Dtype, D: DeviceStorage>: HasErr {
+pub trait Backward<E, D: Storage<E>>: HasErr {
     /// Runs backprop
     fn backward(self) -> Gradients<E, D> {
         self.try_backward().unwrap()
@@ -13,7 +13,9 @@ pub trait Backward<E: Dtype, D: DeviceStorage>: HasErr {
     fn try_backward(self) -> Result<Gradients<E, D>, Self::Err>;
 }
 
-impl<E: Dtype, D: OneFillStorage<E>> Backward<E, D> for Tensor<Rank0, E, D, OwnedTape<E, D>> {
+impl<E: 'static + Clone, D: OneFillStorage<E>> Backward<E, D>
+    for Tensor<Rank0, E, D, OwnedTape<E, D>>
+{
     fn try_backward(self) -> Result<Gradients<E, D>, Self::Err> {
         let (t, mut tape) = self.split_tape();
         let t_ghost = t.ghost();

--- a/src/tensor_ops/utilities/cpu_kernels.rs
+++ b/src/tensor_ops/utilities/cpu_kernels.rs
@@ -81,9 +81,9 @@ impl<E: Dtype, Op: UnaryDerivative<E>> UnaryKernel<Op, E> for Cpu {
         &self,
         op: Op,
         inp: &impl Tensorlike<S, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &impl Tensorlike<S, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         match (inp.data(), out.data()) {
             (None, None) => {
@@ -165,10 +165,10 @@ impl<E: Dtype, Op: BinaryDerivative<E>> BinaryKernel<Op, E> for Cpu {
         &self,
         op: Op,
         lhs: &impl Tensorlike<S, E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &impl Tensorlike<S, E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         match (lhs.data(), rhs.data()) {
             (Some(lhs_buf), Some(rhs_buf)) => {

--- a/src/tensor_ops/utilities/cuda_kernels.rs
+++ b/src/tensor_ops/utilities/cuda_kernels.rs
@@ -78,7 +78,7 @@ impl<E: Dtype, K: UnaryOpCudaKernel<E> + DeviceRepr> UnaryKernel<K, E> for Cuda 
         match inp {
             Cow::Borrowed(inp) => {
                 let numel = inp.data.len();
-                let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
+                let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
 
                 let cfg = launch_cfg::<128>(numel as u32);
                 let params = (op, numel, inp.data.as_ref(), &mut storage);
@@ -100,9 +100,9 @@ impl<E: Dtype, K: UnaryOpCudaKernel<E> + DeviceRepr> UnaryKernel<K, E> for Cuda 
         &self,
         op: K,
         inp: &impl Tensorlike<S, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &impl Tensorlike<S, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let bwd_fn = self.dev.get_func(K::MODULE_NAME, K::BWD_FN_NAME).unwrap();
         match (inp.data(), out.data()) {
@@ -251,7 +251,7 @@ impl<E: Dtype, K: BinaryOpCudaKernel<E> + DeviceRepr + Clone> BinaryKernel<K, E>
 
         match (lhs, rhs) {
             (Cow::Borrowed(lhs), Cow::Borrowed(rhs)) => {
-                let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
+                let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
                 let params = (
                     op,
                     numel,             // const size_t numel,
@@ -298,7 +298,7 @@ impl<E: Dtype, K: BinaryOpCudaKernel<E> + DeviceRepr + Clone> BinaryKernel<K, E>
                         Ok(lhs)
                     }
                 } else {
-                    let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
+                    let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
                     let params = (
                         op,
                         numel,             // const size_t numel,
@@ -322,10 +322,10 @@ impl<E: Dtype, K: BinaryOpCudaKernel<E> + DeviceRepr + Clone> BinaryKernel<K, E>
         &self,
         op: K,
         lhs: &impl Tensorlike<S, E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &impl Tensorlike<S, E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err> {
         let bwd_lhs_fn = self
             .dev

--- a/src/tensor_ops/utilities/cuda_kernels.rs
+++ b/src/tensor_ops/utilities/cuda_kernels.rs
@@ -78,7 +78,7 @@ impl<E: Dtype, K: UnaryOpCudaKernel<E> + DeviceRepr> UnaryKernel<K, E> for Cuda 
         match inp {
             Cow::Borrowed(inp) => {
                 let numel = inp.data.len();
-                let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
+                let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
 
                 let cfg = launch_cfg::<128>(numel as u32);
                 let params = (op, numel, inp.data.as_ref(), &mut storage);
@@ -251,7 +251,7 @@ impl<E: Dtype, K: BinaryOpCudaKernel<E> + DeviceRepr + Clone> BinaryKernel<K, E>
 
         match (lhs, rhs) {
             (Cow::Borrowed(lhs), Cow::Borrowed(rhs)) => {
-                let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
+                let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
                 let params = (
                     op,
                     numel,             // const size_t numel,
@@ -298,7 +298,7 @@ impl<E: Dtype, K: BinaryOpCudaKernel<E> + DeviceRepr + Clone> BinaryKernel<K, E>
                         Ok(lhs)
                     }
                 } else {
-                    let mut Storage<E> = unsafe { self.alloc_empty::<E>(numel) }?;
+                    let mut storage = unsafe { self.alloc_empty::<E>(numel) }?;
                     let params = (
                         op,
                         numel,             // const size_t numel,

--- a/src/tensor_ops/utilities/device.rs
+++ b/src/tensor_ops/utilities/device.rs
@@ -1,12 +1,13 @@
 use super::super::ops::{BinaryKernel, UnaryKernel};
 use crate::{
     shapes::Dtype,
-    tensor::{CopySlice, DeviceStorage},
+    tensor::{CopySlice, RandomU64, Storage},
 };
 
 /// A [DeviceStorage] that requires all the tensor ops implementations
 pub trait Device<E: Dtype>:
-    DeviceStorage
+    Storage<E>
+    + RandomU64
     + CopySlice<E>
     + crate::tensor::TensorFromVec<E>
     + crate::tensor::TensorFromVec<usize>

--- a/src/tensor_ops/utilities/device.rs
+++ b/src/tensor_ops/utilities/device.rs
@@ -4,7 +4,7 @@ use crate::{
     tensor::{CopySlice, RandomU64, Storage},
 };
 
-/// A [DeviceStorage] that requires all the tensor ops implementations
+/// A [Storage] that requires all the tensor ops implementations
 pub trait Device<E: Dtype>:
     Storage<E>
     + RandomU64

--- a/src/tensor_ops/utilities/ops.rs
+++ b/src/tensor_ops/utilities/ops.rs
@@ -1,10 +1,10 @@
 use crate::{
     shapes::{Dtype, HasShape, Shape},
-    tensor::{DeviceStorage, Merge, PutTape, SplitTape, Tape, Tensor, Tensorlike},
+    tensor::{Merge, PutTape, SplitTape, Storage, Tape, Tensor, Tensorlike},
 };
 use std::borrow::Cow;
 
-pub trait UnaryKernel<Op, E: Dtype>: DeviceStorage {
+pub trait UnaryKernel<Op, E: Dtype>: Storage<E> {
     const BACKWARD_WITHOUT_INP: bool;
     const BACKWARD_WITHOUT_DATA: bool;
     fn forward<S: Shape>(
@@ -16,13 +16,13 @@ pub trait UnaryKernel<Op, E: Dtype>: DeviceStorage {
         &self,
         op: Op,
         inp: &impl Tensorlike<S, E, Self>,
-        grad_inp: &mut Self::Vec<E>,
+        grad_inp: &mut Self::Vec,
         out: &impl Tensorlike<S, E, Self>,
-        grad_out: &Self::Vec<E>,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>;
 }
 
-pub trait BinaryKernel<Op, E: Dtype>: DeviceStorage {
+pub trait BinaryKernel<Op, E: Dtype>: Storage<E> {
     const BACKWARD_WITHOUT_DATA: bool;
     fn forward<S: Shape>(
         &self,
@@ -34,10 +34,10 @@ pub trait BinaryKernel<Op, E: Dtype>: DeviceStorage {
         &self,
         op: Op,
         lhs: &impl Tensorlike<S, E, Self>,
-        grad_lhs: &mut Self::Vec<E>,
+        grad_lhs: &mut Self::Vec,
         rhs: &impl Tensorlike<S, E, Self>,
-        grad_rhs: &mut Self::Vec<E>,
-        grad_out: &Self::Vec<E>,
+        grad_rhs: &mut Self::Vec,
+        grad_out: &Self::Vec,
     ) -> Result<(), Self::Err>;
 }
 


### PR DESCRIPTION
- Renames DeviceStorage -> Storage
- Move DeviceStorage::Vec<E> to Storage<E>::Vec
- Adds trait RandomU64
- Adds trait Cache
- Adds trait Synchronize

Duplicates some changes in #633 