### PR TITLE
Removing __hmax and __hmin compat functions

### DIFF
--- a/src/tensor_ops/utilities/compatibility.cuh
+++ b/src/tensor_ops/utilities/compatibility.cuh
@@ -5,14 +5,14 @@
 
 // FIXME: the minimum compute capabilities are just guesses since the table is not specific enough
 
-#if __CUDA_ARCH__ < 800
-__device__ __forceinline__ __half __hmax(__half a, __half b) {
-    return __float2half(fmaxf(__half2float(a), __half2float(b)));
-}
-__device__ __forceinline__ __half __hmin(__half a, __half b) {
-    return __float2half(fminf(__half2float(a), __half2float(b)));
-}
-#endif
+// #if __CUDA_ARCH__ < 600
+// __device__ __forceinline__ __half __hmax(__half a, __half b) {
+//     return __float2half(fmaxf(__half2float(a), __half2float(b)));
+// }
+// __device__ __forceinline__ __half __hmin(__half a, __half b) {
+//     return __float2half(fminf(__half2float(a), __half2float(b)));
+// }
+// #endif
 
 #if __CUDA_ARCH__ < 800
 __device__ __forceinline__ __half __hmax_nan(__half a, __half b) {


### PR DESCRIPTION
Resolves #762 

With the following nvidia-smi:
```
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 525.85.12    Driver Version: 525.85.12    CUDA Version: 12.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA A10          On   | 00000000:06:00.0 Off |                    0 |
|  0%   35C    P8    15W / 150W |      0MiB / 23028MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
```

these functions are no longer needed for compute_cap 53 all the way to 90.

I suspect there may be issues with older drivers. In the future, we can probably query nvidia-smi for driver version and add a compilation variable.