### PR TITLE
Exposed NumpyDType publicly

### DIFF
--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -145,6 +145,8 @@ mod gradients;
 mod masks;
 #[cfg(feature = "numpy")]
 pub(crate) mod numpy;
+#[cfg(feature = "numpy")]
+pub use numpy::NumpyDtype;
 #[cfg(feature = "safetensors")]
 pub mod safetensors;
 mod tensorlike;


### PR DESCRIPTION
In training code, I need to specify in a function that a generic datatype can be saved, which requires the NumpyDType. This is currently totally private, so I exposed it publicly.