### PR TITLE
Add hyperparameter support to TensorCollection

### DIFF
--- a/src/nn/tensor_collection/mod.rs
+++ b/src/nn/tensor_collection/mod.rs
@@ -6,8 +6,8 @@ mod collection;
 mod visitor;
 mod visitor_impls;
 
-pub use collection::{ModuleVisitor, TensorCollection, TensorOptions};
+pub use collection::{HyperparameterOptions, ModuleVisitor, TensorCollection, TensorOptions};
 pub use visitor::{
-    ModuleField, ModuleFields, RecursiveWalker, TensorField, TensorViewer, TensorVisitor,
-    ViewTensorMut, ViewTensorName, ViewTensorRef,
+    HyperparameterField, ModuleField, ModuleFields, RecursiveWalker, TensorField, TensorViewer,
+    TensorVisitor, ViewTensorMut, ViewTensorName, ViewTensorRef,
 };

--- a/src/shapes/shape.rs
+++ b/src/shapes/shape.rs
@@ -70,6 +70,7 @@ pub trait Dtype:
     + std::ops::MulAssign
     + std::ops::DivAssign
     + num_traits::FromPrimitive
+    + num_traits::ToPrimitive
 {
 }
 impl Dtype for f32 {}

--- a/src/tensor/numpy.rs
+++ b/src/tensor/numpy.rs
@@ -41,7 +41,7 @@ impl<S: Shape, E: Dtype + NumpyDtype, D: CopySlice<E>, T> Tensor<S, E, D, T> {
         }
         let mut f = r
             .by_name(&filename)
-            .expect(&std::format!("'{}' not found", filename));
+            .unwrap_or_else(|_| panic!("'{filename}' not found"));
         self.read_from(&mut f)?;
         Ok(())
     }


### PR DESCRIPTION
Currently, adds infrastructure to use scalar values with the TensorCollection system. Resolves #485. A limitation of this is that boolean attributes cannot be used, as `bool` does not implement `num_traits::ToPrimitive`, and this cannot be worked around with conversions due to lifetime issues.