### PR TITLE
Making all shape traits public

### DIFF
--- a/src/shapes/mod.rs
+++ b/src/shapes/mod.rs
@@ -18,18 +18,17 @@ mod same_numel;
 mod shape;
 mod slice;
 
-pub(crate) use axes::Axes;
-pub(crate) use broadcasts::{
+pub use broadcasts::{
     BroadcastShapeTo, BroadcastStridesTo, ReduceShape, ReduceShapeTo, ReduceStridesTo,
 };
-pub(crate) use permutes::{PermuteShapeTo, PermuteStridesTo};
-pub(crate) use realize::RealizeShapeTo;
-pub(crate) use replace_dim::{RemoveDimTo, ReplaceDimTo};
+pub use permutes::{PermuteShapeTo, PermuteStridesTo};
+pub use realize::RealizeShapeTo;
+pub use replace_dim::{RemoveDimTo, ReplaceDimTo};
 
-pub(crate) use same_numel::AssertSameNumel;
-pub(crate) use slice::SliceShape;
+pub use same_numel::AssertSameNumel;
+pub use slice::SliceShape;
 
-pub use axes::{Axes2, Axes3, Axes4, Axes5, Axes6, Axis, HasAxes};
+pub use axes::{Axes, Axes2, Axes3, Axes4, Axes5, Axes6, Axis, HasAxes};
 pub use shape::{Array, Const, ConstDim, Dim};
 pub use shape::{ConstShape, HasShape, Shape};
 pub use shape::{Dtype, HasDtype, HasUnitType, Unit};


### PR DESCRIPTION
Related to #796 

Necessary for implementing generic batchnorm2d outside of repo