### PR TITLE
Make `storage_traits::TensorToArray` pub

### DIFF
--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -170,7 +170,7 @@ pub use cuda::{Cuda, CudaError};
 #[cfg(feature = "cuda")]
 pub type AutoDevice = Cuda;
 
-pub use storage_traits::{AsArray, CopySlice, TensorFrom, TensorFromVec};
+pub use storage_traits::{AsArray, CopySlice, TensorFrom, TensorFromVec, TensorToArray};
 pub use storage_traits::{Cache, HasErr, RandomU64, Storage, Synchronize};
 pub use storage_traits::{OnesTensor, SampleTensor, TriangleTensor, ZerosTensor};
 


### PR DESCRIPTION
Thank you for all the amazing work!

This tiny PR makes [`tensor::storage_traits::TensorToArray`](https://github.com/coreylowman/dfdx/blob/05c9dfc96fad85371c6dfe2009f21fc37dd14e0c/src/tensor/storage_traits.rs#L431-L434) public as `tensor::TensorToArray`, similar to other `storage_traits` interfaces like `tensor::TensorFromVec`.

- This change enables usage of [`storage_traits::AsArray`](https://github.com/coreylowman/dfdx/blob/05c9dfc96fad85371c6dfe2009f21fc37dd14e0c/src/tensor/storage_traits.rs#L436-L439) over generic [`storage_traits::Storage`](https://github.com/coreylowman/dfdx/blob/05c9dfc96fad85371c6dfe2009f21fc37dd14e0c/src/tensor/storage_traits.rs#L25-L39) outside of `dfdx` as `D: Storage<E> + TensorToArray<S, E>`.
- Related to https://github.com/coreylowman/dfdx/issues/796
