### PR TITLE
Eric0000 refactor unstack

### DIFF
--- a/src/tensor/gradients.rs
+++ b/src/tensor/gradients.rs
@@ -171,6 +171,30 @@ impl<E, D: Storage<E>> Gradients<E, D> {
         let r_ref = unsafe { &*r_ptr };
         (l_refs, r_ref)
     }
+
+    #[inline]
+    pub(crate) fn many_mut_and_ref<L: Shape, R: Shape>(
+        &mut self,
+        ls: &Vec<impl Tensorlike<L, E, D>>,
+        r: &impl Tensorlike<R, E, D>,
+    ) -> (Vec<&D::Vec>, &mut D::Vec) {
+        for i in 0..ls.len() {
+            assert_ne!(ls[i].id(), r.id());
+            for j in (i + 1)..ls.len() {
+                assert_ne!(ls[i].id(), ls[j].id());
+            }
+        }
+        let l_refs: Vec<&D::Vec> = ls
+            .iter()
+            .map(|l| {
+                let l_ptr = self.get_ref(l) as *const D::Vec;
+                unsafe { &*l_ptr }
+            })
+            .collect();
+        let r_ptr = self.get_mut(r) as *mut _;
+        let r_ref = unsafe { &mut *r_ptr };
+        (l_refs, r_ref)
+    }
 }
 
 /// Contains a [Gradients] and list of backward operations.

--- a/src/tensor_ops/mod.rs
+++ b/src/tensor_ops/mod.rs
@@ -203,6 +203,7 @@ mod sum_to;
 mod tanh;
 mod to_dtype;
 mod tri;
+mod unstack;
 mod upscale2d;
 mod var_to;
 
@@ -263,6 +264,7 @@ pub use sum_to::SumTo;
 pub use tanh::tanh;
 pub use to_dtype::to_dtype;
 pub use tri::{lower_tri, upper_tri};
+pub use unstack::TryUnstack;
 pub use upscale2d::{Bilinear, GenericUpscale2D, NearestNeighbor, TryUpscale2D, UpscaleMethod};
 pub use var_to::VarTo;
 

--- a/src/tensor_ops/unstack/cpu_kernel.rs
+++ b/src/tensor_ops/unstack/cpu_kernel.rs
@@ -18,7 +18,6 @@ impl<E: Dtype> super::UnstackKernel<E> for Cpu {
             item_strides[i] = inp.strides[i + 1];
         }
 
-        // let num_items = num.size();
         let num_items = inp.shape().concrete()[0];
         let item_size = inp.data.len() / num_items;
 

--- a/src/tensor_ops/unstack/cpu_kernel.rs
+++ b/src/tensor_ops/unstack/cpu_kernel.rs
@@ -1,0 +1,58 @@
+use crate::{
+    shapes::*,
+    tensor::{unique_id, Cpu, Tensor},
+};
+
+use std::vec::Vec;
+impl<E: Dtype> super::UnstackKernel<E> for Cpu {
+    fn forward<S: Shape, const N: usize>(
+        &self,
+        num: Const<N>,
+        inp: &Tensor<S, E, Self>,
+    ) -> Result<Vec<Tensor<S::Smaller, E, Self>>, Self::Err>
+    where
+        S: super::SubDim<Const<N>>,
+    {
+        let shape: S::Smaller = inp.shape().sub_dim(num);
+        let mut item_strides = shape.strides();
+        for i in 0..S::Smaller::NUM_DIMS {
+            item_strides[i] = inp.strides[i + 1];
+        }
+
+        // let num_items = num.size();
+        let num_items = inp.shape().concrete()[0];
+        let item_size = inp.data.len() / num_items;
+
+        let mut tensors = Vec::with_capacity(num_items);
+        for i in 0..num_items {
+            let mut data = self.try_alloc_elem(item_size, E::default())?;
+            data.copy_from_slice(&inp.data[i * item_size..(i + 1) * item_size]);
+
+            tensors.push(Tensor {
+                id: unique_id(),
+                data: std::sync::Arc::new(data),
+                shape: shape.clone(),
+                strides: item_strides.clone(),
+                device: self.clone(),
+                tape: Default::default(),
+            });
+        }
+        Ok(tensors)
+    }
+
+    fn backward(
+        &self,
+        grad_inp: &mut Self::Vec,
+        grad_out: Vec<&Self::Vec>,
+    ) -> Result<(), Self::Err> {
+        let item_size = grad_inp.len() / grad_out.len();
+
+        for (i, item) in grad_out.into_iter().enumerate() {
+            for (j, value) in item.iter().enumerate() {
+                grad_inp[i * item_size + j] += *value;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/tensor_ops/unstack/cpu_kernel.rs
+++ b/src/tensor_ops/unstack/cpu_kernel.rs
@@ -5,15 +5,14 @@ use crate::{
 
 use std::vec::Vec;
 impl<E: Dtype> super::UnstackKernel<E> for Cpu {
-    fn forward<S: Shape, const N: usize>(
+    fn forward<S: Shape>(
         &self,
-        num: Const<N>,
         inp: &Tensor<S, E, Self>,
     ) -> Result<Vec<Tensor<S::Smaller, E, Self>>, Self::Err>
     where
-        S: super::SubDim<Const<N>>,
+        S: super::SubDim,
     {
-        let shape: S::Smaller = inp.shape().sub_dim(num);
+        let shape: S::Smaller = inp.shape().sub_dim();
         let mut item_strides = shape.strides();
         for i in 0..S::Smaller::NUM_DIMS {
             item_strides[i] = inp.strides[i + 1];

--- a/src/tensor_ops/unstack/mod.rs
+++ b/src/tensor_ops/unstack/mod.rs
@@ -176,7 +176,18 @@ mod tests {
             assert_eq!(unstacked.len(), 4);
             for (index, item) in unstacked.into_iter().enumerate() {
                 assert_eq!(item.shape(), &(Const::<3>,));
-                // assert_eq!(item.data[0], stacked.data[index * 3]);
+                for (i, &value) in item.data.iter().enumerate() {
+                    assert_eq!(value, stacked.data[index * 3 + i]);
+                }
+            }
+        }
+
+        {
+            let stacked: Tensor<(usize, usize), TestDtype, _> = dev.sample_normal_like(&(4, 3));
+            let unstacked = stacked.clone().unstack();
+            assert_eq!(unstacked.len(), 4);
+            for (index, item) in unstacked.into_iter().enumerate() {
+                assert_eq!(item.shape(), &(3,));
                 for (i, &value) in item.data.iter().enumerate() {
                     assert_eq!(value, stacked.data[index * 3 + i]);
                 }

--- a/src/tensor_ops/unstack/mod.rs
+++ b/src/tensor_ops/unstack/mod.rs
@@ -1,0 +1,95 @@
+use crate::{shapes::*, tensor::*};
+
+use std::vec::Vec;
+
+mod cpu_kernel;
+
+/// Split a tensor along a dimension into a Vec of tensors
+///
+/// **Pytorch equivalent** `torch.unbind`.
+///
+/// ```rust
+/// # use dfdx::prelude::*;
+/// # let dev: Cpu = Default::default();
+/// let tensor: Tensor<Rank3<2, 3, 4>, f32, _> = dev.zeros();
+/// let result: Vec<Tensor<Rank2<3, 4>, f32, _>> = tensor.unstack();
+/// ```
+pub trait TryUnstack: Sized {
+    type Unstacked;
+    type Err: std::fmt::Debug;
+
+    /// Unstack a tensor along a dimension.
+    fn unstack(self) -> Self::Unstacked {
+        self.try_unstack().unwrap()
+    }
+    /// Fallible version of [TryUnstack::unstack]
+    fn try_unstack(self) -> Result<Self::Unstacked, Self::Err>;
+}
+
+impl<S: Shape, E: Dtype, D: UnstackKernel<E>, T> TryUnstack for Tensor<S, E, D, T>
+where
+    S: SubDim<Const<N>>,
+    T: Tape<E, D>,
+{
+    type Err = D::Err;
+    type Unstacked = Vec<Tensor<S::Smaller, E, D, T>>;
+
+    fn try_unstack(self) -> Result<Self::Unstacked, Self::Err> {
+        try_unstack(self)
+    }
+}
+
+pub trait SubDim<D: Dim>: Shape {
+    type Smaller: Shape;
+    fn sub_dim(&self, dim: D) -> Self::Smaller;
+}
+
+impl<D1: Dim> SubDim<D1> for (D1,) {
+    type Smaller = ();
+
+    fn sub_dim(&self, dim: D1) -> Self::Smaller {
+        ()
+    }
+}
+
+pub trait UnstackKernel<E: Dtype>: Storage<E> {
+    fn forward<S: Shape, Num: Dim>(
+        &self,
+        num: Num,
+        inp: Tensor<S, E, Self>,
+    ) -> Result<Vec<Tensor<S::Smaller, E, Self>>, Self::Err>
+    where
+        S: SubDim<Num>;
+    fn backward(
+        &self,
+        grad_inp: Vec<&mut Self::Vec>,
+        grad_out: &Self::Vec,
+    ) -> Result<(), Self::Err>;
+}
+
+fn try_unstack<S: Shape, E: Dtype, D: UnstackKernel<E>, T>(
+    tensor: Tensor<S, E, D, T>,
+) -> Result<Vec<Tensor<S::Smaller, E, D, T>>, D::Err>
+where
+    S: SubDim<Const<N>>,
+    T: Tape<E, D>,
+{
+    let (input, tape): (Tensor<S, E, D>, T) = tensor.split_tape();
+    let device = input.device.clone();
+    let tensors = device.forward(input.dim(), input)?;
+
+    let out_ghosts: Vec<_> = tensors.iter().map(|t| t.ghost()).collect();
+    let inp_ghost = input.ghost();
+    tape.add_backward_op(move |grads| {
+        for t in out_ghosts.iter() {
+            grads.try_alloc_for(t)?;
+        }
+        grads.try_alloc_for(&inp_ghost)?;
+        let (grad_out, grad_inp) = grads.many_and_ref(&out_ghosts, &inp_ghost);
+        device.backward(grad_inp, grad_out)
+    });
+    Ok(tensors
+        .into_iter()
+        .map(|t| t.put_tape(tape.clone()))
+        .collect())
+}


### PR DESCRIPTION
1. Adds an empty `.rustfmt.toml` so formatting for this project will be respected in workspaces with different formatting.
1. Adds `unstack`, which is the inverse of `stack`.

Note: I've never before made such liberal use of the Rust type system, so I basically did a lot of pattern-matching with `stack` to figure out what to do.
You'll probably want to review it carefully.
(The tests do pass, though.)

Note: I'm not confident in my ability to write correct CUDA kernels using your library, so I only implemented the CPU backend.