### PR TITLE
fixed __CUDA_ARCH__ check for compat with cuda 12.2

### DIFF
--- a/src/tensor_ops/utilities/compatibility.cuh
+++ b/src/tensor_ops/utilities/compatibility.cuh
@@ -14,7 +14,7 @@
 // }
 // #endif
 
-#if __CUDA_ARCH__ < 700
+#if (__CUDACC_VER_MAJOR__ < 12 || __CUDACC_VER_MINOR__ < 2) && __CUDA_ARCH__ < 800
 __device__ __forceinline__ __half __hmax_nan(__half a, __half b) {
     return __hisnan(a) ? a : (__hisnan(b) ? b : __hmax(a, b));
 }

--- a/src/tensor_ops/utilities/compatibility.cuh
+++ b/src/tensor_ops/utilities/compatibility.cuh
@@ -14,7 +14,7 @@
 // }
 // #endif
 
-#if __CUDA_ARCH__ < 800
+#if __CUDA_ARCH__ < 700
 __device__ __forceinline__ __half __hmax_nan(__half a, __half b) {
     return __hisnan(a) ? a : (__hisnan(b) ? b : __hmax(a, b));
 }


### PR DESCRIPTION
Hi, thanks for the inspiring work on this crate. I couldn't compile dfdx when using the "cuda" feature with CUDA 12.2 (driver version 535.86.10) on Pop!OS 22.04 LTS. Changing this line in compatibility.cuh fixed my build. Here's my nvidia-smi output if you're curious:

```
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.86.10              Driver Version: 535.86.10    CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA GeForce GTX 1650        Off | 00000000:01:00.0  On |                  N/A |
| N/A   42C    P8               2W /  50W |    493MiB /  4096MiB |      6%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+

```