### PR TITLE
feat: N-sized tuple (2 <= n <= 8)

### DIFF
--- a/src/nn/add_into.rs
+++ b/src/nn/add_into.rs
@@ -3,7 +3,7 @@ use crate::{shapes::Dtype, tensor_ops::Device};
 use super::*;
 
 /// Add inputs together into a single tensor. `T` should be a tuple
-//// where every element of the tuple has the same output type
+/// where every element of the tuple has the same output type
 ///
 /// This provides a utility for networks where multiple inputs are needed
 ///


### PR DESCRIPTION
This makes collate work for any tuple from (A, B, ... H).

I'm new to making macros, so my only main point of concern is that the autoformatter spreads out the macro declaration for tuple sizes 5..8 on many different lines, but I have little clue on how to deal with that idiomatically.