### PR TITLE
[Breaking] Combining separate device errors into single `dfdx::tensor::Error` enum

### DIFF
--- a/dfdx-core/src/tensor/cpu/allocate.rs
+++ b/dfdx-core/src/tensor/cpu/allocate.rs
@@ -22,13 +22,13 @@ impl Cpu {
         numel: usize,
         elem: E,
     ) -> Result<CachableVec<E>, Error> {
-        let data = self.cache.try_pop::<E>(numel).map_or_else(
+        let data: Result<Vec<E>, Error> = self.cache.try_pop::<E>(numel).map_or_else(
             #[cfg(feature = "fast-alloc")]
             || Ok(std::vec![elem; numel]),
             #[cfg(not(feature = "fast-alloc"))]
             || {
                 let mut data: Vec<E> = Vec::new();
-                data.try_reserve(numel).map_err(|_| CpuError::OutOfMemory)?;
+                data.try_reserve(numel).map_err(|_| Error::OutOfMemory)?;
                 data.resize(numel, elem);
                 Ok(data)
             },
@@ -45,10 +45,10 @@ impl Cpu {
                 data.fill(elem);
                 Ok(data)
             },
-        )?;
+        );
 
         Ok(CachableVec {
-            data,
+            data: data?,
             cache: self.cache.clone(),
         })
     }

--- a/dfdx-core/src/tensor/cpu/allocate.rs
+++ b/dfdx-core/src/tensor/cpu/allocate.rs
@@ -2,20 +2,17 @@
 
 use crate::{
     shapes::*,
-    tensor::{masks::triangle_mask, storage_traits::*, unique_id, Tensor},
+    tensor::{masks::triangle_mask, storage_traits::*, unique_id, Error, Tensor},
 };
 
-use super::{CachableVec, Cpu, CpuError, LendingIterator};
+use super::{CachableVec, Cpu, LendingIterator};
 
 use rand::{distributions::Distribution, Rng};
 use std::{sync::Arc, vec::Vec};
 
 impl Cpu {
     #[inline]
-    pub(crate) fn try_alloc_zeros<E: Unit>(
-        &self,
-        numel: usize,
-    ) -> Result<CachableVec<E>, CpuError> {
+    pub(crate) fn try_alloc_zeros<E: Unit>(&self, numel: usize) -> Result<CachableVec<E>, Error> {
         self.try_alloc_elem::<E>(numel, Default::default())
     }
 
@@ -24,7 +21,7 @@ impl Cpu {
         &self,
         numel: usize,
         elem: E,
-    ) -> Result<CachableVec<E>, CpuError> {
+    ) -> Result<CachableVec<E>, Error> {
         let data = self.cache.try_pop::<E>(numel).map_or_else(
             #[cfg(feature = "fast-alloc")]
             || Ok(std::vec![elem; numel]),
@@ -58,7 +55,7 @@ impl Cpu {
 }
 
 impl<E: Unit> ZerosTensor<E> for Cpu {
-    fn try_zeros_like<S: HasShape>(&self, src: &S) -> Result<Tensor<S::Shape, E, Self>, Self::Err> {
+    fn try_zeros_like<S: HasShape>(&self, src: &S) -> Result<Tensor<S::Shape, E, Self>, Error> {
         let shape = *src.shape();
         let strides = shape.strides();
         let data = self.try_alloc_zeros::<E>(shape.num_elements())?;
@@ -75,14 +72,14 @@ impl<E: Unit> ZerosTensor<E> for Cpu {
 }
 
 impl<E: Unit> ZeroFillStorage<E> for Cpu {
-    fn try_fill_with_zeros(&self, storage: &mut Self::Vec) -> Result<(), Self::Err> {
+    fn try_fill_with_zeros(&self, storage: &mut Self::Vec) -> Result<(), Error> {
         storage.fill(Default::default());
         Ok(())
     }
 }
 
 impl<E: Unit> OnesTensor<E> for Cpu {
-    fn try_ones_like<S: HasShape>(&self, src: &S) -> Result<Tensor<S::Shape, E, Self>, Self::Err> {
+    fn try_ones_like<S: HasShape>(&self, src: &S) -> Result<Tensor<S::Shape, E, Self>, Error> {
         let shape = *src.shape();
         let strides = shape.strides();
         let data = self.try_alloc_elem::<E>(shape.num_elements(), E::ONE)?;
@@ -104,7 +101,7 @@ impl<E: Unit> TriangleTensor<E> for Cpu {
         src: &S,
         val: E,
         diagonal: impl Into<Option<isize>>,
-    ) -> Result<Tensor<S::Shape, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S::Shape, E, Self>, Error> {
         let shape = *src.shape();
         let strides = shape.strides();
         let mut data = self.try_alloc_elem::<E>(shape.num_elements(), val)?;
@@ -126,7 +123,7 @@ impl<E: Unit> TriangleTensor<E> for Cpu {
         src: &S,
         val: E,
         diagonal: impl Into<Option<isize>>,
-    ) -> Result<Tensor<S::Shape, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S::Shape, E, Self>, Error> {
         let shape = *src.shape();
         let strides = shape.strides();
         let mut data = self.try_alloc_elem::<E>(shape.num_elements(), val)?;
@@ -145,7 +142,7 @@ impl<E: Unit> TriangleTensor<E> for Cpu {
 }
 
 impl<E: Unit> OneFillStorage<E> for Cpu {
-    fn try_fill_with_ones(&self, storage: &mut Self::Vec) -> Result<(), Self::Err> {
+    fn try_fill_with_ones(&self, storage: &mut Self::Vec) -> Result<(), Error> {
         storage.fill(E::ONE);
         Ok(())
     }
@@ -156,7 +153,7 @@ impl<E: Unit> SampleTensor<E> for Cpu {
         &self,
         src: &S,
         distr: D,
-    ) -> Result<Tensor<S::Shape, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S::Shape, E, Self>, Error> {
         let mut tensor = self.try_zeros_like(src)?;
         {
             #[cfg(not(feature = "no-std"))]
@@ -173,7 +170,7 @@ impl<E: Unit> SampleTensor<E> for Cpu {
         &self,
         storage: &mut Self::Vec,
         distr: D,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         {
             #[cfg(not(feature = "no-std"))]
             let mut rng = self.rng.lock().unwrap();
@@ -201,11 +198,11 @@ impl<E: Unit> TensorFromVec<E> for Cpu {
         &self,
         src: Vec<E>,
         shape: S,
-    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         let num_elements = shape.num_elements();
 
         if src.len() != num_elements {
-            Err(CpuError::WrongNumElements)
+            Err(Error::WrongNumElements)
         } else {
             let src = CachableVec {
                 data: src,

--- a/dfdx-core/src/tensor/cpu/mod.rs
+++ b/dfdx-core/src/tensor/cpu/mod.rs
@@ -7,7 +7,7 @@ pub(crate) use index::index_to_i;
 pub(crate) use iterate::{LendingIterator, NdIndex};
 
 pub(crate) use device::CachableVec;
-pub use device::{Cpu, CpuError};
+pub use device::Cpu;
 
 #[cfg(test)]
 mod tests {

--- a/dfdx-core/src/tensor/cuda/allocate.rs
+++ b/dfdx-core/src/tensor/cuda/allocate.rs
@@ -44,7 +44,7 @@ impl Cuda {
 }
 
 impl<E: Unit> ZerosTensor<E> for Cuda {
-    fn try_zeros_like<S: HasShape>(&self, src: &S) -> Result<Tensor<S::Shape, E, Self>, Self::Err> {
+    fn try_zeros_like<S: HasShape>(&self, src: &S) -> Result<Tensor<S::Shape, E, Self>, Error> {
         let shape = *src.shape();
         let strides = shape.strides();
         let mut data = unsafe { self.alloc_empty(shape.num_elements()) }?;
@@ -54,7 +54,7 @@ impl<E: Unit> ZerosTensor<E> for Cuda {
 }
 
 impl<E: Unit> ZeroFillStorage<E> for Cuda {
-    fn try_fill_with_zeros(&self, storage: &mut Self::Vec) -> Result<(), Self::Err> {
+    fn try_fill_with_zeros(&self, storage: &mut Self::Vec) -> Result<(), Error> {
         self.dev.memset_zeros(&mut storage.data)?;
         Ok(())
     }
@@ -64,7 +64,7 @@ impl<E: Unit> OnesTensor<E> for Cuda
 where
     Cpu: OnesTensor<E>,
 {
-    fn try_ones_like<S: HasShape>(&self, src: &S) -> Result<Tensor<S::Shape, E, Self>, Self::Err> {
+    fn try_ones_like<S: HasShape>(&self, src: &S) -> Result<Tensor<S::Shape, E, Self>, Error> {
         let shape = *src.shape();
         let buf = std::vec![E::ONE; shape.num_elements()];
         self.tensor_from_host_buf(shape, buf)
@@ -80,7 +80,7 @@ where
         src: &S,
         val: E,
         diagonal: impl Into<Option<isize>>,
-    ) -> Result<Tensor<S::Shape, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S::Shape, E, Self>, Error> {
         let shape = *src.shape();
         let mut data = std::vec![val; shape.num_elements()];
         let offset = diagonal.into().unwrap_or(0);
@@ -93,7 +93,7 @@ where
         src: &S,
         val: E,
         diagonal: impl Into<Option<isize>>,
-    ) -> Result<Tensor<S::Shape, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S::Shape, E, Self>, Error> {
         let shape = *src.shape();
         let mut data = std::vec![val; shape.num_elements()];
         let offset = diagonal.into().unwrap_or(0);
@@ -103,7 +103,7 @@ where
 }
 
 impl<E: Unit> OneFillStorage<E> for Cuda {
-    fn try_fill_with_ones(&self, storage: &mut Self::Vec) -> Result<(), Self::Err> {
+    fn try_fill_with_ones(&self, storage: &mut Self::Vec) -> Result<(), Error> {
         self.dev
             .htod_copy_into(std::vec![E::ONE; storage.len()], &mut storage.data)?;
         Ok(())
@@ -118,7 +118,7 @@ where
         &self,
         src: &S,
         distr: D,
-    ) -> Result<Tensor<S::Shape, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S::Shape, E, Self>, Error> {
         let shape = *src.shape();
         let mut buf = Vec::with_capacity(shape.num_elements());
         {
@@ -134,7 +134,7 @@ where
         &self,
         storage: &mut Self::Vec,
         distr: D,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let mut buf = Vec::with_capacity(storage.len());
         {
             #[cfg(not(feature = "no-std"))]
@@ -180,7 +180,7 @@ impl<E: Unit> TensorFromVec<E> for Cuda {
         &self,
         src: Vec<E>,
         shape: S,
-    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         let num_elements = shape.num_elements();
 
         if src.len() != num_elements {

--- a/dfdx-core/src/tensor/cuda/allocate.rs
+++ b/dfdx-core/src/tensor/cuda/allocate.rs
@@ -2,10 +2,10 @@
 
 use crate::{
     shapes::*,
-    tensor::{masks::triangle_mask, storage_traits::*, unique_id, Cpu, CpuError, NoneTape, Tensor},
+    tensor::{masks::triangle_mask, storage_traits::*, unique_id, Cpu, Error, NoneTape, Tensor},
 };
 
-use super::{device::CachableCudaSlice, Cuda, CudaError};
+use super::{device::CachableCudaSlice, Cuda};
 
 use cudarc::driver::{CudaSlice, DeviceSlice};
 use rand::Rng;
@@ -16,7 +16,7 @@ impl Cuda {
         &self,
         shape: S,
         buf: Vec<E>,
-    ) -> Result<Tensor<S, E, Self>, CudaError> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         let mut slice = unsafe { self.alloc_empty(buf.len()) }?;
         self.dev.htod_copy_into(buf, &mut slice)?;
         Ok(self.build_tensor(shape, shape.strides(), slice))
@@ -184,7 +184,7 @@ impl<E: Unit> TensorFromVec<E> for Cuda {
         let num_elements = shape.num_elements();
 
         if src.len() != num_elements {
-            Err(CudaError::Cpu(CpuError::WrongNumElements))
+            Err(Error::WrongNumElements)
         } else {
             self.tensor_from_host_buf(shape, src)
         }

--- a/dfdx-core/src/tensor/cuda/device.rs
+++ b/dfdx-core/src/tensor/cuda/device.rs
@@ -246,17 +246,17 @@ impl RandomU64 for Cuda {
 }
 
 impl Cache for Cuda {
-    fn try_enable_cache(&self) -> Result<(), Self::Err> {
+    fn try_enable_cache(&self) -> Result<(), Error> {
         self.cache.enable();
         Ok(())
     }
 
-    fn try_disable_cache(&self) -> Result<(), Self::Err> {
+    fn try_disable_cache(&self) -> Result<(), Error> {
         self.cache.disable();
         self.try_empty_cache()
     }
 
-    fn try_empty_cache(&self) -> Result<(), Self::Err> {
+    fn try_empty_cache(&self) -> Result<(), Error> {
         #[cfg(not(feature = "no-std"))]
         let mut cache = self.cache.allocations.write().unwrap();
         #[cfg(feature = "no-std")]
@@ -281,7 +281,7 @@ impl Synchronize for Cuda {
 impl<E: Unit> Storage<E> for Cuda {
     type Vec = CachableCudaSlice<E>;
 
-    fn try_alloc_len(&self, len: usize) -> Result<Self::Vec, Self::Err> {
+    fn try_alloc_len(&self, len: usize) -> Result<Self::Vec, Error> {
         let mut data = unsafe { self.alloc_empty(len) }?;
         self.dev.memset_zeros(&mut data)?;
         Ok(CachableCudaSlice {

--- a/dfdx-core/src/tensor/cuda/device.rs
+++ b/dfdx-core/src/tensor/cuda/device.rs
@@ -1,7 +1,7 @@
 use crate::shapes::{Shape, Unit};
-use crate::tensor::cpu::{Cpu, CpuError};
+use crate::tensor::cpu::Cpu;
 use crate::tensor::{
-    cache::TensorCache, Cache, HasErr, NoneTape, RandomU64, Storage, Synchronize, Tensor,
+    cache::TensorCache, Cache, Error, NoneTape, RandomU64, Storage, Synchronize, Tensor,
 };
 
 use cudarc::driver::{DevicePtr, DevicePtrMut, DeviceRepr};
@@ -32,37 +32,22 @@ pub struct Cuda {
     pub(crate) cache: Arc<TensorCache<CUdeviceptr>>,
 }
 
-#[derive(Debug)]
-pub enum CudaError {
-    Blas(CublasError),
-    #[cfg(feature = "cudnn")]
-    Cudnn(cudarc::cudnn::CudnnError),
-    Driver(DriverError),
-    Cpu(CpuError),
-}
-
-impl From<CpuError> for CudaError {
-    fn from(value: CpuError) -> Self {
-        Self::Cpu(value)
-    }
-}
-
-impl From<CublasError> for CudaError {
+impl From<CublasError> for Error {
     fn from(value: CublasError) -> Self {
-        Self::Blas(value)
+        Self::CublasError(value)
     }
 }
 
-impl From<DriverError> for CudaError {
+impl From<DriverError> for Error {
     fn from(value: DriverError) -> Self {
-        Self::Driver(value)
+        Self::CudaDriverError(value)
     }
 }
 
 #[cfg(feature = "cudnn")]
-impl From<cudarc::cudnn::CudnnError> for CudaError {
+impl From<cudarc::cudnn::CudnnError> for Error {
     fn from(value: cudarc::cudnn::CudnnError) -> Self {
-        Self::Cudnn(value)
+        Self::CudnnError(value)
     }
 }
 
@@ -79,12 +64,12 @@ impl Cuda {
     }
 
     /// Constructs rng with the given seed.
-    pub fn try_seed_from_u64(seed: u64) -> Result<Self, CudaError> {
+    pub fn try_seed_from_u64(seed: u64) -> Result<Self, Error> {
         Self::try_build(0, seed)
     }
 
     /// Constructs with the given seed & device ordinal
-    pub fn try_build(ordinal: usize, seed: u64) -> Result<Self, CudaError> {
+    pub fn try_build(ordinal: usize, seed: u64) -> Result<Self, Error> {
         let cpu = Cpu::seed_from_u64(seed);
         let dev = CudaDevice::new(ordinal)?;
         let blas = Arc::new(CudaBlas::new(dev.clone())?);
@@ -112,7 +97,7 @@ impl Cuda {
     pub(crate) unsafe fn alloc_empty<E: DeviceRepr>(
         &self,
         len: usize,
-    ) -> Result<CudaSlice<E>, CudaError> {
+    ) -> Result<CudaSlice<E>, Error> {
         let data = self.cache.try_pop::<E>(len).map_or_else(
             || self.dev.alloc::<E>(len),
             |ptr| Ok(self.dev.upgrade_device_ptr(ptr, len)),
@@ -123,7 +108,7 @@ impl Cuda {
     pub(crate) unsafe fn get_workspace<E>(
         &self,
         len: usize,
-    ) -> Result<MutexGuard<CudaSlice<u8>>, CudaError> {
+    ) -> Result<MutexGuard<CudaSlice<u8>>, Error> {
         let num_bytes_required = len * std::mem::size_of::<E>();
         let mut workspace = self.workspace.as_ref().lock().unwrap();
 
@@ -135,16 +120,6 @@ impl Cuda {
 
         Ok(workspace)
     }
-}
-
-impl std::fmt::Display for CudaError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
-impl HasErr for Cuda {
-    type Err = CudaError;
 }
 
 /// A [CudaSlice] that can be cloned without allocating new memory.
@@ -273,8 +248,8 @@ impl Cache for Cuda {
 }
 
 impl Synchronize for Cuda {
-    fn try_synchronize(&self) -> Result<(), CudaError> {
-        self.dev.synchronize().map_err(CudaError::from)
+    fn try_synchronize(&self) -> Result<(), Error> {
+        self.dev.synchronize().map_err(Error::from)
     }
 }
 

--- a/dfdx-core/src/tensor/cuda/mod.rs
+++ b/dfdx-core/src/tensor/cuda/mod.rs
@@ -1,7 +1,7 @@
 mod allocate;
 mod device;
 
-pub use device::{Cuda, CudaError};
+pub use device::Cuda;
 
 pub(crate) fn launch_cfg<const NUM_THREADS: u32>(n: u32) -> cudarc::driver::LaunchConfig {
     let num_blocks = (n + NUM_THREADS - 1) / NUM_THREADS;

--- a/dfdx-core/src/tensor/error.rs
+++ b/dfdx-core/src/tensor/error.rs
@@ -1,0 +1,31 @@
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum Error {
+    /// Device is out of memory
+    OutOfMemory,
+    /// Not enough elements were provided when creating a tensor
+    WrongNumElements,
+
+    UnusedTensors(Vec<crate::tensor::UniqueId>),
+
+    #[cfg(feature = "cuda")]
+    CublasError(cudarc::cublas::CublasError),
+    #[cfg(feature = "cuda")]
+    CudaDriverError(cudarc::driver::DriverError),
+
+    #[cfg(feature = "cudnn")]
+    CudnnError(cudarc::cudnn::CudnnError),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::OutOfMemory => f.write_str("Error::OutOfMemory"),
+            Self::WrongNumElements => f.write_str("Error::WrongNumElements"),
+            _ => todo!(),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/dfdx-core/src/tensor/error.rs
+++ b/dfdx-core/src/tensor/error.rs
@@ -9,7 +9,7 @@ pub enum Error {
     UnusedTensors(Vec<crate::tensor::UniqueId>),
 
     #[cfg(feature = "cuda")]
-    CublasError(cudarc::cublas::CublasError),
+    CublasError(cudarc::cublas::result::CublasError),
     #[cfg(feature = "cuda")]
     CudaDriverError(cudarc::driver::DriverError),
 
@@ -19,11 +19,7 @@ pub enum Error {
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::OutOfMemory => f.write_str("Error::OutOfMemory"),
-            Self::WrongNumElements => f.write_str("Error::WrongNumElements"),
-            _ => todo!(),
-        }
+        write!(f, "{self:?}")
     }
 }
 

--- a/dfdx-core/src/tensor/error.rs
+++ b/dfdx-core/src/tensor/error.rs
@@ -1,3 +1,5 @@
+/// Represents a number of different errors that can occur from creating tensors
+/// or launching tensor operations. This encompasses both Cpu and CUDA errors.
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum Error {
@@ -5,9 +7,8 @@ pub enum Error {
     OutOfMemory,
     /// Not enough elements were provided when creating a tensor
     WrongNumElements,
-
-    UnusedTensors(Vec<crate::tensor::UniqueId>),
-
+    /// Some tensors were unused by an optimizer in a graph.
+    UnusedTensors(std::vec::Vec<crate::tensor::UniqueId>),
     #[cfg(feature = "cuda")]
     CublasError(cudarc::cublas::result::CublasError),
     #[cfg(feature = "cuda")]

--- a/dfdx-core/src/tensor/ghost.rs
+++ b/dfdx-core/src/tensor/ghost.rs
@@ -42,10 +42,6 @@ impl<S: Shape, E, D: Storage<E>> Clone for GhostTensor<S, E, D> {
     }
 }
 
-impl<S: Shape, E, D: Storage<E>> super::storage_traits::HasErr for GhostTensor<S, E, D> {
-    type Err = D::Err;
-}
-
 impl<S: Shape, E, D: Storage<E>> HasShape for GhostTensor<S, E, D> {
     type WithShape<New: Shape> = GhostTensor<New, E, D>;
     type Shape = S;
@@ -56,7 +52,7 @@ impl<S: Shape, E, D: Storage<E>> HasShape for GhostTensor<S, E, D> {
 
 impl<S: Shape, E, D: Storage<E>> super::storage_traits::AllocGrad for GhostTensor<S, E, D> {
     type Gradient = D::Vec;
-    fn try_alloc_grad(&self) -> Result<Self::Gradient, D::Err> {
+    fn try_alloc_grad(&self) -> Result<Self::Gradient, Error> {
         self.dev.try_alloc_len(self.len)
     }
 }

--- a/dfdx-core/src/tensor/mod.rs
+++ b/dfdx-core/src/tensor/mod.rs
@@ -147,6 +147,7 @@ mod masks;
 pub(crate) mod numpy;
 #[cfg(feature = "numpy")]
 pub use numpy::NumpyDtype;
+mod error;
 #[cfg(feature = "safetensors")]
 pub mod safetensors;
 mod tensorlike;
@@ -155,11 +156,12 @@ mod unique_id;
 pub(crate) mod storage_traits;
 mod tensor_impls;
 
+pub use error::Error;
 pub(crate) use ghost::GhostTensor;
 pub(crate) use storage_traits::{OneFillStorage, ZeroFillStorage};
 pub use tensorlike::Tensorlike;
 
-pub use cpu::{Cpu, CpuError};
+pub use cpu::Cpu;
 #[cfg(not(feature = "cuda"))]
 pub type AutoDevice = Cpu;
 
@@ -171,7 +173,7 @@ pub use cuda::{Cuda, CudaError};
 pub type AutoDevice = Cuda;
 
 pub use storage_traits::{AsArray, CopySlice, TensorFrom, TensorFromVec, TensorToArray};
-pub use storage_traits::{Cache, HasErr, RandomU64, Storage, Synchronize};
+pub use storage_traits::{Cache, RandomU64, Storage, Synchronize};
 pub use storage_traits::{OnesTensor, SampleTensor, TriangleTensor, ZerosTensor};
 
 pub use tensor_impls::{PutTape, SplitTape, Tensor, Trace, WithEmptyTape};

--- a/dfdx-core/src/tensor/mod.rs
+++ b/dfdx-core/src/tensor/mod.rs
@@ -168,7 +168,7 @@ pub type AutoDevice = Cpu;
 #[cfg(feature = "cuda")]
 pub(crate) use cuda::launch_cfg;
 #[cfg(feature = "cuda")]
-pub use cuda::{Cuda, CudaError};
+pub use cuda::Cuda;
 #[cfg(feature = "cuda")]
 pub type AutoDevice = Cuda;
 

--- a/dfdx-core/src/tensor/tensor_impls.rs
+++ b/dfdx-core/src/tensor/tensor_impls.rs
@@ -54,10 +54,6 @@ impl<S: Shape, E: Dtype, D: Storage<E>, T> HasDtype for Tensor<S, E, D, T> {
     type Dtype = E;
 }
 
-impl<S: Shape, E, D: Storage<E>, T> HasErr for Tensor<S, E, D, T> {
-    type Err = D::Err;
-}
-
 /// Something that can trace gradients
 pub trait Trace<E, D: Storage<E>>: Clone {
     type Traced;
@@ -198,7 +194,7 @@ impl<S: Shape, E: Dtype, D: ZeroFillStorage<E>, T> Tensor<S, E, D, T> {
         self.try_fill_with_zeros().unwrap()
     }
     /// Fallible version of [Tensor::fill_with_zeros]
-    pub fn try_fill_with_zeros(&mut self) -> Result<(), D::Err> {
+    pub fn try_fill_with_zeros(&mut self) -> Result<(), Error> {
         self.device
             .try_fill_with_zeros(Arc::make_mut(&mut self.data))
     }
@@ -210,7 +206,7 @@ impl<S: Shape, E: Dtype, D: OneFillStorage<E>, T> Tensor<S, E, D, T> {
         self.try_fill_with_ones().unwrap()
     }
     /// Fallible version of [Tensor::fill_with_ones]
-    pub fn try_fill_with_ones(&mut self) -> Result<(), D::Err> {
+    pub fn try_fill_with_ones(&mut self) -> Result<(), Error> {
         self.device
             .try_fill_with_ones(Arc::make_mut(&mut self.data))
     }
@@ -226,7 +222,7 @@ impl<S: Shape, E: Unit, D: SampleTensor<E>, T> Tensor<S, E, D, T> {
     pub fn try_fill_with_distr<Distr: Distribution<E>>(
         &mut self,
         distr: Distr,
-    ) -> Result<(), D::Err> {
+    ) -> Result<(), Error> {
         self.device
             .try_fill_with_distr(Arc::make_mut(&mut self.data), distr)
     }

--- a/dfdx-core/src/tensor/tensorlike.rs
+++ b/dfdx-core/src/tensor/tensorlike.rs
@@ -1,8 +1,4 @@
-use crate::{
-    prelude::{HasErr, HasShape},
-    shapes::Shape,
-    tensor::Storage,
-};
+use crate::{prelude::HasShape, shapes::Shape, tensor::Storage};
 
 use super::{storage_traits::AllocGrad, GhostTensor, Tensor, UniqueId};
 
@@ -12,7 +8,7 @@ use super::{storage_traits::AllocGrad, GhostTensor, Tensor, UniqueId};
 /// *If it looks like a tensor and barks like a tensor, then pet it like a tensor.*
 #[allow(clippy::len_without_is_empty)]
 pub trait Tensorlike<S: Shape, E, D: Storage<E>>:
-    AllocGrad<Gradient = D::Vec> + HasErr<Err = D::Err> + HasShape<Shape = S>
+    AllocGrad<Gradient = D::Vec> + HasShape<Shape = S>
 {
     fn id(&self) -> UniqueId;
     fn len(&self) -> usize;

--- a/dfdx-core/src/tensor_ops/abs/mod.rs
+++ b/dfdx-core/src/tensor_ops/abs/mod.rs
@@ -34,7 +34,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<AbsKernelOp, E>, T: Tape<E, D>> Tensor<S
         self.try_abs().unwrap()
     }
     /// See [abs]
-    pub fn try_abs(self) -> Result<Self, D::Err> {
+    pub fn try_abs(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(AbsKernelOp, self)
     }
 }

--- a/dfdx-core/src/tensor_ops/accurate_gelu/mod.rs
+++ b/dfdx-core/src/tensor_ops/accurate_gelu/mod.rs
@@ -47,7 +47,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<AccurateGeLUKernelOp, E>, T: Tape<E, D>>
         self.try_accurate_gelu().unwrap()
     }
     /// See [accurate_gelu]
-    pub fn try_accurate_gelu(self) -> Result<Self, D::Err> {
+    pub fn try_accurate_gelu(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(AccurateGeLUKernelOp, self)
     }
 }

--- a/dfdx-core/src/tensor_ops/adam/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/adam/cpu_kernel.rs
@@ -1,7 +1,7 @@
 use super::{AdamConfig, AdamKernel, WeightDecay};
 use crate::{
     dtypes::{Dtype, NotMixedPrecision},
-    tensor::Cpu,
+    tensor::{Cpu, Error},
 };
 
 #[cfg(feature = "f16")]
@@ -14,7 +14,7 @@ impl AdamKernel<crate::dtypes::AMP<crate::dtypes::f16>> for Cpu {
         moment1: &mut Self::Vec,
         moment2: &mut Self::Vec,
         grad: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let betas = cfg.betas.map(|x| x as f32);
         let eps = cfg.eps as f32;
         let lr = cfg.lr as f32;
@@ -60,7 +60,7 @@ impl<E: num_traits::Float + Dtype + NotMixedPrecision> AdamKernel<E> for Cpu {
         moment1: &mut Self::Vec,
         moment2: &mut Self::Vec,
         grad: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let betas = cfg.betas.map(E::from_f64).map(Option::unwrap);
         let eps = E::from_f64(cfg.eps).unwrap();
         let lr = E::from_f64(cfg.lr).unwrap();

--- a/dfdx-core/src/tensor_ops/adam/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/adam/cuda_kernel.rs
@@ -72,7 +72,7 @@ where
         moment1: &mut Self::Vec,
         moment2: &mut Self::Vec,
         grad: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         if !self.dev.has_func(Self::MOD, Self::FWD) {
             self.dev.load_ptx(PTX_SRC.into(), Self::MOD, &[Self::FWD])?;
         }

--- a/dfdx-core/src/tensor_ops/adam/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/adam/cuda_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     dtypes::*,
-    tensor::{launch_cfg, Cuda},
+    tensor::{launch_cfg, Cuda, Error},
     tensor_ops::optim::*,
 };
 

--- a/dfdx-core/src/tensor_ops/adam/mod.rs
+++ b/dfdx-core/src/tensor_ops/adam/mod.rs
@@ -5,7 +5,7 @@ mod cuda_kernel;
 
 use crate::{
     shapes::{Dtype, Shape},
-    tensor::{Storage, Tensor},
+    tensor::{Error, Storage, Tensor},
 };
 
 use super::WeightDecay;
@@ -57,7 +57,7 @@ pub trait AdamKernel<E: Dtype>: Storage<E> {
         moment1: &mut Self::Vec,
         moment2: &mut Self::Vec,
         grad: &Self::Vec,
-    ) -> Result<(), Self::Err>;
+    ) -> Result<(), Error>;
 }
 
 impl AdamConfig {
@@ -68,7 +68,7 @@ impl AdamConfig {
         moment1: &mut D::Vec,
         moment2: &mut D::Vec,
         grad: &D::Vec,
-    ) -> Result<(), D::Err> {
+    ) -> Result<(), crate::tensor::Error> {
         param.device.adam_kernel(
             t,
             self,

--- a/dfdx-core/src/tensor_ops/add/mod.rs
+++ b/dfdx-core/src/tensor_ops/add/mod.rs
@@ -6,7 +6,7 @@ mod cuda_kernel;
 use super::ops::*;
 use crate::{
     shapes::*,
-    tensor::{HasErr, Merge, Storage, Tape, Tensor},
+    tensor::{Error, Merge, Storage, Tape, Tensor},
 };
 
 #[repr(C)]
@@ -49,9 +49,9 @@ where
 }
 
 /// Fallible version of [std::ops::Add]. See [add]
-pub trait TryAdd<Rhs = Self>: HasErr {
+pub trait TryAdd<Rhs = Self> {
     type Output;
-    fn try_add(self, rhs: Rhs) -> Result<Self::Output, Self::Err>;
+    fn try_add(self, rhs: Rhs) -> Result<Self::Output, Error>;
 }
 
 impl<S: Shape, E: Dtype, D, LhsTape: Tape<E, D>, R> TryAdd<Tensor<S, E, D, R>>
@@ -62,7 +62,7 @@ where
 {
     type Output = Self;
     /// See [add]
-    fn try_add(self, rhs: Tensor<S, E, D, R>) -> Result<Self, Self::Err> {
+    fn try_add(self, rhs: Tensor<S, E, D, R>) -> Result<Self, Error> {
         try_binary_op(BinaryAddKernelOp, self, rhs)
     }
 }
@@ -73,7 +73,7 @@ where
 {
     type Output = Self;
     /// See [add]
-    fn try_add(self, rhs: Rhs) -> Result<Self, Self::Err> {
+    fn try_add(self, rhs: Rhs) -> Result<Self, Error> {
         let rhs: f64 = rhs.into();
         let scalar = E::from_f64(rhs).unwrap();
         try_unary_op(ScalarAddKernelOp { scalar }, self)

--- a/dfdx-core/src/tensor_ops/attention_reshape/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/attention_reshape/cpu_kernel.rs
@@ -13,7 +13,7 @@ impl<E: Dtype> super::AttentionReshapeKernel<E> for Cpu {
             Tensor<(Const<NUM_HEADS>, Const<HEAD_DIM>, usize), E, Self>,
             Tensor<(Const<NUM_HEADS>, usize, Const<HEAD_DIM>), E, Self>,
         ),
-        Self::Err,
+        Error,
     > {
         let sequence_length = qkv.shape().0;
         let past_sequence_length = past_key.shape().2;

--- a/dfdx-core/src/tensor_ops/attention_reshape/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/attention_reshape/cuda_kernel.rs
@@ -54,7 +54,7 @@ where
             Tensor<(Const<NUM_HEADS>, Const<HEAD_DIM>, usize), E, Self>,
             Tensor<(Const<NUM_HEADS>, usize, Const<HEAD_DIM>), E, Self>,
         ),
-        Self::Err,
+        Error,
     > {
         if !self.dev.has_func(Self::FN, Self::FN) {
             self.dev.load_ptx(PTX.into(), Self::FN, &[Self::FN])?;

--- a/dfdx-core/src/tensor_ops/attention_reshape/mod.rs
+++ b/dfdx-core/src/tensor_ops/attention_reshape/mod.rs
@@ -57,7 +57,7 @@ pub trait TryAttentionReshape<E: Dtype>: Storage<E> {
         qkv: &Tensor<(usize, Const<THREE_HIDDEN_DIM>), E, Self>,
         past_key: &Tensor<(Const<NUM_HEADS>, Const<HEAD_DIM>, usize), E, Self>,
         past_value: &Tensor<(Const<NUM_HEADS>, usize, Const<HEAD_DIM>), E, Self>,
-    ) -> Result<QkvTuple<NUM_HEADS, HEAD_DIM, E, Self>, Self::Err>;
+    ) -> Result<QkvTuple<NUM_HEADS, HEAD_DIM, E, Self>, Error>;
 }
 
 pub trait AttentionReshapeKernel<E: Dtype>: Storage<E> {
@@ -66,7 +66,7 @@ pub trait AttentionReshapeKernel<E: Dtype>: Storage<E> {
         qkv: &Tensor<(usize, Const<THREE_HIDDEN_DIM>), E, Self>,
         past_key: &Tensor<(Const<NUM_HEADS>, Const<HEAD_DIM>, usize), E, Self>,
         past_value: &Tensor<(Const<NUM_HEADS>, usize, Const<HEAD_DIM>), E, Self>,
-    ) -> Result<QkvTuple<NUM_HEADS, HEAD_DIM, E, Self>, Self::Err>;
+    ) -> Result<QkvTuple<NUM_HEADS, HEAD_DIM, E, Self>, Error>;
 }
 
 impl<E: Dtype, D: AttentionReshapeKernel<E>> TryAttentionReshape<E> for D {
@@ -80,7 +80,7 @@ impl<E: Dtype, D: AttentionReshapeKernel<E>> TryAttentionReshape<E> for D {
         qkv: &Tensor<(usize, Const<THREE_HIDDEN_DIM>), E, Self>,
         past_key: &Tensor<(Const<NUM_HEADS>, Const<HEAD_DIM>, usize), E, Self>,
         past_value: &Tensor<(Const<NUM_HEADS>, usize, Const<HEAD_DIM>), E, Self>,
-    ) -> Result<QkvTuple<NUM_HEADS, HEAD_DIM, E, Self>, Self::Err> {
+    ) -> Result<QkvTuple<NUM_HEADS, HEAD_DIM, E, Self>, Error> {
         let device = qkv.device.clone();
         device.forward(qkv, past_key, past_value)
     }

--- a/dfdx-core/src/tensor_ops/axpy/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/axpy/cpu_kernel.rs
@@ -1,13 +1,10 @@
-use crate::{shapes::Dtype, tensor::Cpu};
+use crate::{
+    shapes::Dtype,
+    tensor::{Cpu, Error},
+};
 
 impl<E: Dtype> super::AxpyKernel<E> for Cpu {
-    fn forward(
-        &self,
-        a: &mut Self::Vec,
-        alpha: E,
-        b: &Self::Vec,
-        beta: E,
-    ) -> Result<(), Self::Err> {
+    fn forward(&self, a: &mut Self::Vec, alpha: E, b: &Self::Vec, beta: E) -> Result<(), Error> {
         for (a_i, b_i) in a.iter_mut().zip(b.iter()) {
             *a_i = *a_i * alpha + *b_i * beta;
         }

--- a/dfdx-core/src/tensor_ops/axpy/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/axpy/cuda_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     dtypes::*,
-    tensor::{launch_cfg, Cuda},
+    tensor::{launch_cfg, Cuda, Error},
 };
 
 use cudarc::driver::{DeviceSlice, LaunchAsync};

--- a/dfdx-core/src/tensor_ops/axpy/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/axpy/cuda_kernel.rs
@@ -29,13 +29,7 @@ impl<E: Dtype> super::AxpyKernel<E> for Cuda
 where
     Self: HasCudaKernel<E>,
 {
-    fn forward(
-        &self,
-        a: &mut Self::Vec,
-        alpha: E,
-        b: &Self::Vec,
-        beta: E,
-    ) -> Result<(), Self::Err> {
+    fn forward(&self, a: &mut Self::Vec, alpha: E, b: &Self::Vec, beta: E) -> Result<(), Error> {
         if !self.dev.has_func(Self::FN, Self::FN) {
             self.dev.load_ptx(PTX_SRC.into(), Self::FN, &[Self::FN])?;
         }

--- a/dfdx-core/src/tensor_ops/axpy/mod.rs
+++ b/dfdx-core/src/tensor_ops/axpy/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::{Dtype, Shape},
-    tensor::{Storage, Tensor},
+    tensor::{Error, Storage, Tensor},
 };
 
 mod cpu_kernel;
@@ -36,7 +36,7 @@ impl<S: Shape, E: Dtype, D: AxpyKernel<E>> Tensor<S, E, D> {
         alpha: impl Into<f64>,
         b: &Tensor<S, E, D, T>,
         beta: impl Into<f64>,
-    ) -> Result<(), D::Err> {
+    ) -> Result<(), crate::tensor::Error> {
         assert_eq!(self.shape, b.shape);
         assert_eq!(self.strides, b.strides, "Strides must be equal for axpy");
         self.device.clone().forward(
@@ -49,8 +49,7 @@ impl<S: Shape, E: Dtype, D: AxpyKernel<E>> Tensor<S, E, D> {
 }
 
 pub trait AxpyKernel<E: Dtype>: Storage<E> {
-    fn forward(&self, a: &mut Self::Vec, alpha: E, b: &Self::Vec, beta: E)
-        -> Result<(), Self::Err>;
+    fn forward(&self, a: &mut Self::Vec, alpha: E, b: &Self::Vec, beta: E) -> Result<(), Error>;
 }
 
 #[cfg(test)]

--- a/dfdx-core/src/tensor_ops/bce/mod.rs
+++ b/dfdx-core/src/tensor_ops/bce/mod.rs
@@ -45,7 +45,10 @@ impl<S: Shape, E: Dtype, D: BinaryKernel<BCEKernelOp, E>, LTape: Tape<E, D>>
         self.try_bce_with_logits(prob).unwrap()
     }
     /// See [bce_with_logits]
-    pub fn try_bce_with_logits<RTape>(self, prob: Tensor<S, E, D, RTape>) -> Result<Self, D::Err>
+    pub fn try_bce_with_logits<RTape>(
+        self,
+        prob: Tensor<S, E, D, RTape>,
+    ) -> Result<Self, crate::tensor::Error>
     where
         RTape: Tape<E, D>,
         LTape: Merge<RTape>,

--- a/dfdx-core/src/tensor_ops/boolean/cpu_kernels.rs
+++ b/dfdx-core/src/tensor_ops/boolean/cpu_kernels.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::{Shape, Unit},
-    tensor::{cpu::LendingIterator, Cpu, HasErr, Tensor, ZerosTensor},
+    tensor::{cpu::LendingIterator, Cpu, Error, Tensor, ZerosTensor},
 };
 
 use super::BooleanKernel;
@@ -11,7 +11,7 @@ impl Cpu {
         op: O,
         lhs: &Tensor<S, E, Self>,
         rhs: &Tensor<S, E, Self>,
-    ) -> Result<Tensor<S, E, Self>, <Self as HasErr>::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         let mut out = self.try_zeros_like(&lhs.shape)?;
         let mut lhs_iter = lhs.iter();
         let mut rhs_iter = rhs.iter();
@@ -24,10 +24,7 @@ impl Cpu {
 }
 
 impl BooleanKernel for Cpu {
-    fn not<S: Shape>(
-        &self,
-        inp: &Tensor<S, bool, Self>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err> {
+    fn not<S: Shape>(&self, inp: &Tensor<S, bool, Self>) -> Result<Tensor<S, bool, Self>, Error> {
         let mut out = inp.clone();
         for x in out.buf_iter_mut() {
             *x = !*x;
@@ -39,7 +36,7 @@ impl BooleanKernel for Cpu {
         &self,
         lhs: &Tensor<S, bool, Self>,
         rhs: &Tensor<S, bool, Self>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err> {
+    ) -> Result<Tensor<S, bool, Self>, Error> {
         self.eval_binary(|l, r| l && r, lhs, rhs)
     }
 
@@ -47,7 +44,7 @@ impl BooleanKernel for Cpu {
         &self,
         lhs: &Tensor<S, bool, Self>,
         rhs: &Tensor<S, bool, Self>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err> {
+    ) -> Result<Tensor<S, bool, Self>, Error> {
         self.eval_binary(|l, r| l || r, lhs, rhs)
     }
 
@@ -55,7 +52,7 @@ impl BooleanKernel for Cpu {
         &self,
         lhs: &Tensor<S, bool, Self>,
         rhs: &Tensor<S, bool, Self>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err> {
+    ) -> Result<Tensor<S, bool, Self>, Error> {
         self.eval_binary(|l, r| l ^ r, lhs, rhs)
     }
 }

--- a/dfdx-core/src/tensor_ops/boolean/cuda_kernels.rs
+++ b/dfdx-core/src/tensor_ops/boolean/cuda_kernels.rs
@@ -49,10 +49,7 @@ impl Cuda {
 }
 
 impl BooleanKernel for Cuda {
-    fn not<S: Shape>(
-        &self,
-        inp: &Tensor<S, bool, Self>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err> {
+    fn not<S: Shape>(&self, inp: &Tensor<S, bool, Self>) -> Result<Tensor<S, bool, Self>, Error> {
         if !self.dev.has_func(MODULE_NAME, "boolean_not") {
             self.dev
                 .load_ptx(PTX_SRC.into(), MODULE_NAME, &ALL_FN_NAMES)?;
@@ -77,7 +74,7 @@ impl BooleanKernel for Cuda {
         &self,
         lhs: &Tensor<S, bool, Self>,
         rhs: &Tensor<S, bool, Self>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err> {
+    ) -> Result<Tensor<S, bool, Self>, Error> {
         self.call_binary("boolean_and", lhs, rhs)
     }
 
@@ -85,7 +82,7 @@ impl BooleanKernel for Cuda {
         &self,
         lhs: &Tensor<S, bool, Self>,
         rhs: &Tensor<S, bool, Self>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err> {
+    ) -> Result<Tensor<S, bool, Self>, Error> {
         self.call_binary("boolean_or", lhs, rhs)
     }
 
@@ -93,7 +90,7 @@ impl BooleanKernel for Cuda {
         &self,
         lhs: &Tensor<S, bool, Self>,
         rhs: &Tensor<S, bool, Self>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err> {
+    ) -> Result<Tensor<S, bool, Self>, Error> {
         self.call_binary("boolean_xor", lhs, rhs)
     }
 }

--- a/dfdx-core/src/tensor_ops/boolean/cuda_kernels.rs
+++ b/dfdx-core/src/tensor_ops/boolean/cuda_kernels.rs
@@ -1,7 +1,7 @@
 use super::BooleanKernel;
 use crate::{
     shapes::Shape,
-    tensor::{launch_cfg, Cuda, CudaError, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Tensor},
 };
 use cudarc::driver::*;
 
@@ -15,7 +15,7 @@ impl Cuda {
         fn_name: &str,
         lhs: &Tensor<S, bool, Self>,
         rhs: &Tensor<S, bool, Self>,
-    ) -> Result<Tensor<S, bool, Self>, CudaError> {
+    ) -> Result<Tensor<S, bool, Self>, Error> {
         if !self.dev.has_func(MODULE_NAME, fn_name) {
             self.dev
                 .load_ptx(PTX_SRC.into(), MODULE_NAME, &ALL_FN_NAMES)?;

--- a/dfdx-core/src/tensor_ops/boolean/mod.rs
+++ b/dfdx-core/src/tensor_ops/boolean/mod.rs
@@ -6,7 +6,7 @@ mod cuda_kernels;
 use crate::{
     prelude::{OnesTensor, Tensor, ZerosTensor},
     shapes::*,
-    tensor::Storage,
+    tensor::{Error, Storage},
 };
 
 use std::ops::{BitAnd, BitOr, BitXor, Not};
@@ -14,34 +14,31 @@ use std::ops::{BitAnd, BitOr, BitXor, Not};
 use super::Device;
 
 pub trait BooleanKernel: Storage<bool> + OnesTensor<bool> + ZerosTensor<bool> {
-    fn not<S: Shape>(
-        &self,
-        inp: &Tensor<S, bool, Self>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err>;
+    fn not<S: Shape>(&self, inp: &Tensor<S, bool, Self>) -> Result<Tensor<S, bool, Self>, Error>;
 
     fn and<S: Shape>(
         &self,
         lhs: &Tensor<S, bool, Self>,
         rhs: &Tensor<S, bool, Self>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err>;
+    ) -> Result<Tensor<S, bool, Self>, Error>;
 
     fn or<S: Shape>(
         &self,
         lhs: &Tensor<S, bool, Self>,
         rhs: &Tensor<S, bool, Self>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err>;
+    ) -> Result<Tensor<S, bool, Self>, Error>;
 
     fn xor<S: Shape>(
         &self,
         lhs: &Tensor<S, bool, Self>,
         rhs: &Tensor<S, bool, Self>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err>;
+    ) -> Result<Tensor<S, bool, Self>, Error>;
 }
 
 fn scalar_and<D: BooleanKernel, S: Shape>(
     lhs: &Tensor<S, bool, D>,
     rhs: bool,
-) -> Result<Tensor<S, bool, D>, D::Err> {
+) -> Result<Tensor<S, bool, D>, crate::tensor::Error> {
     if rhs {
         Ok(lhs.clone())
     } else {
@@ -52,7 +49,7 @@ fn scalar_and<D: BooleanKernel, S: Shape>(
 fn scalar_or<D: BooleanKernel, S: Shape>(
     lhs: &Tensor<S, bool, D>,
     rhs: bool,
-) -> Result<Tensor<S, bool, D>, D::Err> {
+) -> Result<Tensor<S, bool, D>, crate::tensor::Error> {
     if rhs {
         lhs.device.try_ones_like(lhs)
     } else {
@@ -63,7 +60,7 @@ fn scalar_or<D: BooleanKernel, S: Shape>(
 fn scalar_xor<D: BooleanKernel, S: Shape>(
     lhs: &Tensor<S, bool, D>,
     rhs: bool,
-) -> Result<Tensor<S, bool, D>, D::Err> {
+) -> Result<Tensor<S, bool, D>, crate::tensor::Error> {
     if rhs {
         Ok(lhs.device.not(lhs)?)
     } else {

--- a/dfdx-core/src/tensor_ops/broadcast_to.rs
+++ b/dfdx-core/src/tensor_ops/broadcast_to.rs
@@ -23,7 +23,7 @@ use crate::{shapes::*, tensor::*};
 /// // It's ambiguous what axes to broadcast here - explicitly say axes 0 and 2
 /// let _: Tensor<Rank3<1, 1, 1>, _, _> = a.clone().broadcast::<_, Axes2<0, 2>>();
 /// ```
-pub trait BroadcastTo: HasErr + HasShape {
+pub trait BroadcastTo: Sized + HasShape {
     /// Broadcast into shape `Dst` along axes `Ax`.
     fn broadcast<Dst: ConstShape, Ax: Axes>(self) -> Self::WithShape<Dst>
     where
@@ -33,7 +33,7 @@ pub trait BroadcastTo: HasErr + HasShape {
             .unwrap()
     }
     /// Fallible version of [BroadcastTo::broadcast]
-    fn try_broadcast<Dst: ConstShape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_broadcast<Dst: ConstShape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: BroadcastShapeTo<Dst, Ax>,
     {
@@ -50,7 +50,7 @@ pub trait BroadcastTo: HasErr + HasShape {
     fn try_broadcast_like<Dst: HasShape, Ax: Axes>(
         self,
         dst: &Dst,
-    ) -> Result<Self::WithShape<Dst::Shape>, Self::Err>
+    ) -> Result<Self::WithShape<Dst::Shape>, Error>
     where
         Self::Shape: BroadcastShapeTo<Dst::Shape, Ax>;
 }
@@ -59,7 +59,7 @@ impl<S: Shape, E, D: Storage<E>, T: Tape<E, D>> BroadcastTo for Tensor<S, E, D, 
     fn try_broadcast_like<Dst: HasShape, Ax: Axes>(
         self,
         dst: &Dst,
-    ) -> Result<Self::WithShape<Dst::Shape>, Self::Err>
+    ) -> Result<Self::WithShape<Dst::Shape>, Error>
     where
         Self::Shape: BroadcastShapeTo<Dst::Shape, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/choose/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/choose/cpu_kernel.rs
@@ -2,7 +2,7 @@ use crate::{
     shapes::{Dtype, Shape},
     tensor::{
         cpu::{LendingIterator, NdIndex},
-        Cpu, Storage, Tensor, ZerosTensor,
+        Cpu, Error, Storage, Tensor, ZerosTensor,
     },
 };
 
@@ -12,7 +12,7 @@ impl<E: Dtype> super::ChooseKernel<E> for Cpu {
         cond: &Tensor<S, bool, Self>,
         lhs: &Tensor<S, E, Self>,
         rhs: &Tensor<S, E, Self>,
-    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         let mut out = self.try_zeros_like(&lhs.shape)?;
         let mut cond_iter = cond.iter();
         let mut lhs_iter = lhs.iter();
@@ -36,7 +36,7 @@ impl<E: Dtype> super::ChooseKernel<E> for Cpu {
         rhs: &Tensor<S, E, Self>,
         grad_rhs: &mut <Self as Storage<E>>::Vec,
         grad_out: &<Self as Storage<E>>::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let mut lhs_idx = NdIndex::new(lhs.shape, lhs.strides);
         let mut rhs_idx = NdIndex::new(rhs.shape, rhs.strides);
         let mut out_idx = NdIndex::new(lhs.shape, lhs.shape.strides());

--- a/dfdx-core/src/tensor_ops/choose/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/choose/cuda_kernel.rs
@@ -43,7 +43,7 @@ where
         cond: &Tensor<S, bool, Self>,
         lhs: &Tensor<S, E, Self>,
         rhs: &Tensor<S, E, Self>,
-    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         if !self.dev.has_func(Self::MOD, Self::FNS[0]) {
             self.dev.load_ptx(PTX_SRC.into(), Self::MOD, Self::FNS)?;
         }
@@ -85,7 +85,7 @@ where
         rhs: &Tensor<S, E, Self>,
         grad_rhs: &mut <Self as Storage<E>>::Vec,
         grad_out: &<Self as Storage<E>>::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let bwd_fn = self.dev.get_func(Self::MOD, Self::FNS[1]).unwrap();
         let numel = cond.shape.num_elements();
 

--- a/dfdx-core/src/tensor_ops/choose/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/choose/cuda_kernel.rs
@@ -1,7 +1,7 @@
 use crate::{
     dtypes::*,
     shapes::*,
-    tensor::{launch_cfg, Cuda, Storage, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Storage, Tensor},
 };
 use cudarc::driver::{CudaSlice, LaunchAsync};
 

--- a/dfdx-core/src/tensor_ops/clamp/mod.rs
+++ b/dfdx-core/src/tensor_ops/clamp/mod.rs
@@ -37,7 +37,11 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<ClampKernelOp<E>, E>, T: Tape<E, D>> Ten
         self.try_clamp(min, max).unwrap()
     }
     /// See [clamp]
-    pub fn try_clamp(self, min: impl Into<f64>, max: impl Into<f64>) -> Result<Self, D::Err> {
+    pub fn try_clamp(
+        self,
+        min: impl Into<f64>,
+        max: impl Into<f64>,
+    ) -> Result<Self, crate::tensor::Error> {
         try_unary_op(
             ClampKernelOp {
                 min: E::from_f64(min.into()).unwrap(),

--- a/dfdx-core/src/tensor_ops/cmp/cpu_kernels.rs
+++ b/dfdx-core/src/tensor_ops/cmp/cpu_kernels.rs
@@ -2,7 +2,7 @@ use crate::{
     shapes::{Shape, Unit},
     tensor::{
         cpu::{Cpu, LendingIterator},
-        Tensor, ZerosTensor,
+        Error, Tensor, ZerosTensor,
     },
 };
 
@@ -20,7 +20,7 @@ impl<Op: CmpOpCpuKernel<E>, E: Unit> CmpKernel<Op, E> for Cpu {
         &self,
         lhs: &Tensor<S, E, Self, T>,
         rhs: &Tensor<S, E, Self, T>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err> {
+    ) -> Result<Tensor<S, bool, Self>, Error> {
         let mut out: Tensor<S, bool, Self> = self.try_zeros_like(&lhs.shape)?;
         let mut lhs_iter = lhs.iter();
         let mut rhs_iter = rhs.iter();
@@ -37,7 +37,7 @@ impl<Op: CmpOpCpuKernel<E>, E: Unit> ScalarCmpKernel<Op, E> for Cpu {
         &self,
         lhs: &Tensor<S, E, Self, T>,
         scalar: E,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err> {
+    ) -> Result<Tensor<S, bool, Self>, Error> {
         let mut out: Tensor<S, bool, Self> = self.try_zeros_like(&lhs.shape)?;
         let mut lhs_iter = lhs.iter();
         let mut out_iter = out.iter_mut();

--- a/dfdx-core/src/tensor_ops/cmp/cuda_kernels.rs
+++ b/dfdx-core/src/tensor_ops/cmp/cuda_kernels.rs
@@ -39,7 +39,7 @@ impl<E: Unit, Op: CmpOpCudaKernel<E>> CmpKernel<Op, E> for Cuda {
         &self,
         lhs: &Tensor<S, E, Self, T>,
         rhs: &Tensor<S, E, Self, T>,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err> {
+    ) -> Result<Tensor<S, bool, Self>, Error> {
         if !self.dev.has_func(Op::MODULE_NAME, Op::FWD_FN_NAME) {
             self.dev
                 .load_ptx(Op::PTX_SRC.into(), Op::MODULE_NAME, &[Op::FWD_FN_NAME])?;
@@ -80,7 +80,7 @@ impl<E: Unit, Op: ScalarCmpOpCudaKernel<E>> ScalarCmpKernel<Op, E> for Cuda {
         &self,
         lhs: &Tensor<S, E, Self, T>,
         scalar: E,
-    ) -> Result<Tensor<S, bool, Self>, Self::Err> {
+    ) -> Result<Tensor<S, bool, Self>, Error> {
         if !self.dev.has_func(Op::MODULE_NAME, Op::FWD_FN_NAME) {
             self.dev
                 .load_ptx(Op::PTX_SRC.into(), Op::MODULE_NAME, &[Op::FWD_FN_NAME])?;

--- a/dfdx-core/src/tensor_ops/cmp/cuda_kernels.rs
+++ b/dfdx-core/src/tensor_ops/cmp/cuda_kernels.rs
@@ -1,7 +1,7 @@
 use crate::{
     dtypes::*,
     shapes::Shape,
-    tensor::{launch_cfg, Cuda, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Tensor},
 };
 use cudarc::driver::{CudaSlice, LaunchAsync};
 

--- a/dfdx-core/src/tensor_ops/concat/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/concat/cpu_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::{Dtype, Shape},
-    tensor::{unique_id, Cpu, Tensor},
+    tensor::{unique_id, Cpu, Error, Tensor},
 };
 
 impl<E: Dtype> super::ConcatKernel<E> for Cpu {
@@ -8,7 +8,7 @@ impl<E: Dtype> super::ConcatKernel<E> for Cpu {
         &self,
         a: &Tensor<A, E, Self>,
         b: &Tensor<B, E, Self>,
-    ) -> Result<Tensor<A::Catted, E, Self>, Self::Err>
+    ) -> Result<Tensor<A::Catted, E, Self>, Error>
     where
         A: super::ConcatShape<B>,
     {
@@ -45,7 +45,7 @@ impl<E: Dtype> super::ConcatKernel<E> for Cpu {
         grad_a: &mut Self::Vec,
         grad_b: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let mut offset = 0;
         for ga in grad_a.iter_mut() {
             *ga += grad_out[offset];

--- a/dfdx-core/src/tensor_ops/concat/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/concat/cuda_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Tensor},
 };
 use cudarc::{
     driver::{DeviceSlice, LaunchAsync},

--- a/dfdx-core/src/tensor_ops/concat/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/concat/cuda_kernel.rs
@@ -13,7 +13,7 @@ impl<E: Dtype + CudaTypeName> super::ConcatKernel<E> for Cuda {
         &self,
         a: &Tensor<A, E, Self>,
         b: &Tensor<B, E, Self>,
-    ) -> Result<Tensor<A::Catted, E, Self>, Self::Err>
+    ) -> Result<Tensor<A::Catted, E, Self>, Error>
     where
         A: super::ConcatShape<B>,
     {
@@ -33,7 +33,7 @@ impl<E: Dtype + CudaTypeName> super::ConcatKernel<E> for Cuda {
         grad_a: &mut Self::Vec,
         grad_b: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let module_name = std::format!("concat_bwd_{}", E::NAME);
         if !self.dev.has_func(&module_name, "concat_bwd") {
             let src = BWD_KERNEL.replace("$Ty", E::NAME);

--- a/dfdx-core/src/tensor_ops/concat/mod.rs
+++ b/dfdx-core/src/tensor_ops/concat/mod.rs
@@ -27,7 +27,7 @@ mod cuda_kernel;
 /// assert_eq!(c.shape().0, 6);
 /// ```
 #[deprecated = "Use TryConcatAlong instead"]
-pub trait TryConcat<Rhs>: HasErr {
+pub trait TryConcat<Rhs>: Sized {
     type Output;
 
     /// Concatenate two tensors along the first dimension.
@@ -41,7 +41,7 @@ pub trait TryConcat<Rhs>: HasErr {
     /// Fallible version of [TryConcat::concat].
     #[deprecated = "Use TryConcatAlong::try_concat_along instead"]
     #[allow(deprecated)]
-    fn try_concat(self, rhs: Rhs) -> Result<Self::Output, Self::Err>;
+    fn try_concat(self, rhs: Rhs) -> Result<Self::Output, Error>;
 }
 
 #[allow(deprecated)]
@@ -54,7 +54,7 @@ where
 {
     type Output = Tensor<A::Catted, E, D, T>;
     #[allow(deprecated)]
-    fn try_concat(self, rhs: Tensor<B, E, D, R>) -> Result<Self::Output, Self::Err> {
+    fn try_concat(self, rhs: Tensor<B, E, D, R>) -> Result<Self::Output, Error> {
         assert_eq!(
             self.strides,
             self.shape.strides(),
@@ -89,7 +89,7 @@ pub trait ConcatKernel<E: Dtype>: Storage<E> {
         &self,
         a: &Tensor<A, E, Self>,
         b: &Tensor<B, E, Self>,
-    ) -> Result<Tensor<A::Catted, E, Self>, Self::Err>
+    ) -> Result<Tensor<A::Catted, E, Self>, Error>
     where
         A: ConcatShape<B>;
     fn backward(
@@ -97,7 +97,7 @@ pub trait ConcatKernel<E: Dtype>: Storage<E> {
         grad_a: &mut Self::Vec,
         grad_b: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err>;
+    ) -> Result<(), Error>;
 }
 
 pub trait ConcatShape<Rhs: Shape>: Shape {

--- a/dfdx-core/src/tensor_ops/concat_along/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/concat_along/cpu_kernel.rs
@@ -10,7 +10,7 @@ impl<E: Dtype> super::ConcatAlongKernel<E> for Cpu {
         a: &Tensor<A, E, Self>,
         b: &Tensor<B, E, Self>,
         c: &mut Tensor<C, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let mut a_idx = NdIndex::new(a.shape, a.strides);
         let mut b_idx = NdIndex::new(b.shape, b.strides);
 
@@ -44,7 +44,7 @@ impl<E: Dtype> super::ConcatAlongKernel<E> for Cpu {
         b: &GhostTensor<B, E, Self>,
         grad_b: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let mut a_idx = NdIndex::new(a.shape, a.strides);
         let mut b_idx = NdIndex::new(b.shape, b.strides);
 

--- a/dfdx-core/src/tensor_ops/concat_along/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/concat_along/cuda_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::*,
-    tensor::{launch_cfg, Cuda, GhostTensor, Tensor},
+    tensor::{launch_cfg, Cuda, Error, GhostTensor, Tensor},
 };
 use cudarc::{
     driver::{DeviceSlice, LaunchAsync},

--- a/dfdx-core/src/tensor_ops/concat_along/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/concat_along/cuda_kernel.rs
@@ -15,7 +15,7 @@ impl<E: Dtype + CudaTypeName> super::ConcatAlongKernel<E> for Cuda {
         a: &Tensor<A, E, Self>,
         b: &Tensor<B, E, Self>,
         c: &mut Tensor<C, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let module_name = std::format!("concat_{}", E::NAME);
         if !self.dev.has_func(&module_name, "fwd") {
             let src = KERNEL.replace("$Ty", E::NAME);
@@ -67,7 +67,7 @@ impl<E: Dtype + CudaTypeName> super::ConcatAlongKernel<E> for Cuda {
         b: &GhostTensor<B, E, Self>,
         grad_b: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let module_name = std::format!("concat_{}", E::NAME);
         let bwd = self.dev.get_func(&module_name, "bwd").unwrap();
         let cfg = launch_cfg::<128>(grad_out.data.len() as u32);

--- a/dfdx-core/src/tensor_ops/conv1d/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/conv1d/cpu_kernel.rs
@@ -34,7 +34,7 @@ impl Cpu {
         filters: &[E],
         out: &mut [E],
         buf: &mut [E],
-    ) -> Result<(), CpuError>
+    ) -> Result<(), Error>
     where
         Self: MatMulImpl<E>,
     {
@@ -85,7 +85,7 @@ impl Cpu {
         grad_filters_tr: &mut [E],
         grad_out: &[E],
         buf: &mut [E],
-    ) -> Result<(), CpuError>
+    ) -> Result<(), Error>
     where
         Self: MatMulImpl<E>,
     {
@@ -150,7 +150,7 @@ impl<E: Dtype> Conv1DKernel<E> for Cpu
 where
     Self: MatMulImpl<E>,
 {
-    fn alloc<S: Shape>(&self, s: S) -> Result<Tensor<S, E, Self>, Self::Err> {
+    fn alloc<S: Shape>(&self, s: S) -> Result<Tensor<S, E, Self>, Error> {
         self.try_zeros_like(&s)
     }
 
@@ -160,7 +160,7 @@ where
         lhs: &Tensor<L, E, Self>,
         rhs: &Tensor<R, E, Self>,
         out: &mut Tensor<O, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let patches = (op.chan_in, op.kernel, op.l_out);
         let mut patches = self.try_alloc_zeros::<E>(patches.num_elements())?;
         let [lstride, ostride] = match L::NUM_DIMS {
@@ -192,7 +192,7 @@ where
         grad_rhs: &mut Self::Vec,
         out: &impl Tensorlike<O, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let f_tr_shape = [
             op.groups,
             op.chan_in / op.groups,

--- a/dfdx-core/src/tensor_ops/conv1d/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/conv1d/cuda_kernel.rs
@@ -4,7 +4,7 @@ use cudarc::driver::{DeviceRepr, LaunchAsync, ValidAsZeroBits};
 use crate::{
     dtypes::*,
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor, Tensorlike},
+    tensor::{launch_cfg, Cuda, Error, Tensor, Tensorlike},
 };
 
 use std::sync::Arc;

--- a/dfdx-core/src/tensor_ops/conv1d/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/conv1d/cuda_kernel.rs
@@ -73,7 +73,7 @@ where
     Self: HasCudaKernel<E>,
     CudaBlas: Gemm<E>,
 {
-    fn alloc<S: Shape>(&self, shape: S) -> Result<Tensor<S, E, Self>, Self::Err> {
+    fn alloc<S: Shape>(&self, shape: S) -> Result<Tensor<S, E, Self>, Error> {
         let data = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
         Ok(self.build_tensor(shape, shape.strides(), data))
     }
@@ -83,7 +83,7 @@ where
         img: &Tensor<L, E, Self>,
         fil: &Tensor<R, E, Self>,
         out: &mut Tensor<O, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         if !self.dev.has_func(Self::MOD, Self::FNS[0]) {
             self.dev.load_ptx(PTX_SRC.into(), Self::MOD, Self::FNS)?;
         }
@@ -151,7 +151,7 @@ where
         grad_rhs: &mut Self::Vec,
         _: &impl Tensorlike<O, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let patches_item_numel = op.chan_out * op.kernel * op.l_in;
         let patches_numel = op.batch * patches_item_numel;
         let filters_numel =

--- a/dfdx-core/src/tensor_ops/conv2d/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/conv2d/cpu_kernel.rs
@@ -48,7 +48,7 @@ impl Cpu {
         filters: &[E],
         out: &mut [E],
         buf: &mut [E],
-    ) -> Result<(), CpuError>
+    ) -> Result<(), Error>
     where
         Self: MatMulImpl<E>,
     {
@@ -105,7 +105,7 @@ impl Cpu {
         grad_filters_tr: &mut [E],
         grad_out: &[E],
         buf: &mut [E],
-    ) -> Result<(), CpuError>
+    ) -> Result<(), Error>
     where
         Self: MatMulImpl<E>,
     {
@@ -175,7 +175,7 @@ impl<E: Dtype> Conv2DKernel<E> for Cpu
 where
     Self: MatMulImpl<E>,
 {
-    fn alloc<S: Shape>(&self, s: S) -> Result<Tensor<S, E, Self>, Self::Err> {
+    fn alloc<S: Shape>(&self, s: S) -> Result<Tensor<S, E, Self>, Error> {
         self.try_zeros_like(&s)
     }
 
@@ -185,7 +185,7 @@ where
         lhs: &Tensor<L, E, Self>,
         rhs: &Tensor<R, E, Self>,
         out: &mut Tensor<O, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let patches = (op.chan_in, op.kernel, op.kernel, op.h_out, op.w_out);
         let mut patches = self.try_alloc_zeros::<E>(patches.num_elements())?;
         let [lstride, ostride] = match L::NUM_DIMS {
@@ -217,7 +217,7 @@ where
         grad_rhs: &mut Self::Vec,
         out: &impl Tensorlike<O, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let f_tr_shape = [
             op.groups,
             op.chan_in / op.groups,

--- a/dfdx-core/src/tensor_ops/conv2d/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/conv2d/cuda_kernel.rs
@@ -4,7 +4,7 @@ use cudarc::driver::{DeviceRepr, LaunchAsync, ValidAsZeroBits};
 use crate::{
     dtypes::*,
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor, Tensorlike},
+    tensor::{launch_cfg, Cuda, Error, Tensor, Tensorlike},
 };
 
 use std::sync::Arc;

--- a/dfdx-core/src/tensor_ops/conv2d/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/conv2d/cuda_kernel.rs
@@ -73,7 +73,7 @@ where
     Self: HasCudaKernel<E>,
     CudaBlas: Gemm<E>,
 {
-    fn alloc<S: Shape>(&self, shape: S) -> Result<Tensor<S, E, Self>, Self::Err> {
+    fn alloc<S: Shape>(&self, shape: S) -> Result<Tensor<S, E, Self>, Error> {
         let data = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
         Ok(self.build_tensor(shape, shape.strides(), data))
     }
@@ -83,7 +83,7 @@ where
         img: &Tensor<L, E, Self>,
         fil: &Tensor<R, E, Self>,
         out: &mut Tensor<O, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         if !self.dev.has_func(Self::MOD, Self::FNS[0]) {
             self.dev.load_ptx(PTX_SRC.into(), Self::MOD, Self::FNS)?;
         }
@@ -152,7 +152,7 @@ where
         grad_rhs: &mut Self::Vec,
         _: &impl Tensorlike<O, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let patches_item_numel = op.chan_out * op.kernel * op.kernel * op.h_in * op.w_in;
         let patches_numel = op.batch * patches_item_numel;
         let filters_numel = op.groups

--- a/dfdx-core/src/tensor_ops/conv2d/cudnn_kernel.rs
+++ b/dfdx-core/src/tensor_ops/conv2d/cudnn_kernel.rs
@@ -4,7 +4,7 @@ use cudarc::driver::DeviceSlice;
 use crate::{
     dtypes::*,
     shapes::*,
-    tensor::{Cuda, Tensor, Tensorlike},
+    tensor::{Cuda, Error, Tensor, Tensorlike},
 };
 
 use std::sync::Arc;

--- a/dfdx-core/src/tensor_ops/conv2d/cudnn_kernel.rs
+++ b/dfdx-core/src/tensor_ops/conv2d/cudnn_kernel.rs
@@ -29,7 +29,7 @@ impl<E: Dtype + CudnnDataType> super::Conv2DKernel<E> for Cuda
 where
     Self: HasCudnnKernel<E>,
 {
-    fn alloc<S: Shape>(&self, shape: S) -> Result<Tensor<S, E, Self>, Self::Err> {
+    fn alloc<S: Shape>(&self, shape: S) -> Result<Tensor<S, E, Self>, Error> {
         let data = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
         Ok(self.build_tensor(shape, shape.strides(), data))
     }
@@ -39,7 +39,7 @@ where
         lhs: &Tensor<L, E, Self>,
         rhs: &Tensor<R, E, Self>,
         out: &mut Tensor<O, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let mut conv = self.cudnn.create_conv2d::<E>(
             [op.padding as i32, op.padding as i32],
             [op.stride as i32, op.stride as i32],
@@ -97,7 +97,7 @@ where
         grad_rhs: &mut Self::Vec,
         out: &impl Tensorlike<O, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let mut conv = self.cudnn.create_conv2d::<E>(
             [op.padding as i32, op.padding as i32],
             [op.stride as i32, op.stride as i32],

--- a/dfdx-core/src/tensor_ops/convtrans2d/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/convtrans2d/cpu_kernel.rs
@@ -1,6 +1,6 @@
 use crate::prelude::Tensorlike;
 use crate::shapes::{Dtype, Shape};
-use crate::tensor::{cpu::*, Tensor, ZerosTensor};
+use crate::tensor::{cpu::*, Error, Tensor, ZerosTensor};
 use crate::tensor_ops::matmul::cpu_kernel::MatMulImpl;
 
 use std::sync::Arc;
@@ -27,7 +27,7 @@ impl Cpu {
         filters_tr: &[E],
         out: &mut [E],
         buf: &mut [E],
-    ) -> Result<(), CpuError>
+    ) -> Result<(), Error>
     where
         Self: MatMulImpl<E>,
     {
@@ -107,7 +107,7 @@ impl Cpu {
         grad_filters: &mut [E],
         grad_out: &[E],
         buf: &mut [E],
-    ) -> Result<(), CpuError>
+    ) -> Result<(), Error>
     where
         Self: MatMulImpl<E>,
     {
@@ -179,7 +179,7 @@ impl<E: Dtype> ConvTrans2DKernel<E> for Cpu
 where
     Self: MatMulImpl<E>,
 {
-    fn alloc<S: Shape>(&self, s: S) -> Result<Tensor<S, E, Self>, Self::Err> {
+    fn alloc<S: Shape>(&self, s: S) -> Result<Tensor<S, E, Self>, Error> {
         self.try_zeros_like(&s)
     }
 
@@ -189,7 +189,7 @@ where
         lhs: &Tensor<L, E, Self>,
         rhs: &Tensor<R, E, Self>,
         out: &mut Tensor<O, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let patches = (op.chan_in, op.kernel, op.kernel, op.h_out, op.w_out);
         let mut patches = self.try_alloc_zeros::<E>(patches.num_elements())?;
         let f_tr_shape = [
@@ -242,7 +242,7 @@ where
         grad_rhs: &mut Self::Vec,
         out: &impl Tensorlike<O, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let patches_shape = [op.chan_out, op.kernel, op.kernel, op.h_in, op.w_in];
         let mut patches = self.try_alloc_zeros::<E>(patches_shape.num_elements())?;
 

--- a/dfdx-core/src/tensor_ops/convtrans2d/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/convtrans2d/cuda_kernel.rs
@@ -69,7 +69,7 @@ where
     Self: HasCudaKernel<E>,
     CudaBlas: Gemm<E>,
 {
-    fn alloc<S: Shape>(&self, shape: S) -> Result<Tensor<S, E, Self>, Self::Err> {
+    fn alloc<S: Shape>(&self, shape: S) -> Result<Tensor<S, E, Self>, Error> {
         let data = unsafe { self.alloc_empty::<E>(shape.num_elements()) }?;
         Ok(self.build_tensor(shape, shape.strides(), data))
     }
@@ -80,7 +80,7 @@ where
         lhs: &Tensor<L, E, Self>,
         rhs: &Tensor<R, E, Self>,
         out: &mut Tensor<O, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         if !self.dev.has_func(Self::MOD, Self::FNS[0]) {
             self.dev.load_ptx(PTX_SRC.into(), Self::MOD, Self::FNS)?;
         }
@@ -160,7 +160,7 @@ where
         grad_rhs: &mut Self::Vec,
         _: &impl Tensorlike<O, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let patches_numel = op.batch * op.chan_out * op.kernel * op.kernel * op.h_in * op.w_in;
 
         let mut patches = unsafe { self.get_workspace::<E>(patches_numel) }?;

--- a/dfdx-core/src/tensor_ops/convtrans2d/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/convtrans2d/cuda_kernel.rs
@@ -4,7 +4,7 @@ use cudarc::driver::{DeviceRepr, LaunchAsync, ValidAsZeroBits};
 use crate::{
     dtypes::*,
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor, Tensorlike},
+    tensor::{launch_cfg, Cuda, Error, Tensor, Tensorlike},
 };
 
 use std::sync::Arc;

--- a/dfdx-core/src/tensor_ops/cos/mod.rs
+++ b/dfdx-core/src/tensor_ops/cos/mod.rs
@@ -33,7 +33,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<CosKernelOp, E>, T: Tape<E, D>> Tensor<S
         self.try_cos().unwrap()
     }
     /// See [cos]
-    pub fn try_cos(self) -> Result<Self, D::Err> {
+    pub fn try_cos(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(CosKernelOp, self)
     }
 }

--- a/dfdx-core/src/tensor_ops/div/mod.rs
+++ b/dfdx-core/src/tensor_ops/div/mod.rs
@@ -47,9 +47,9 @@ where
 }
 
 /// Fallible version of [std::ops::Div]. See [div]
-pub trait TryDiv<Rhs = Self>: HasErr {
+pub trait TryDiv<Rhs = Self> {
     type Output;
-    fn try_div(self, rhs: Rhs) -> Result<Self::Output, Self::Err>;
+    fn try_div(self, rhs: Rhs) -> Result<Self::Output, Error>;
 }
 
 impl<S: Shape, E: Dtype, D, LhsTape: Tape<E, D>, R> TryDiv<Tensor<S, E, D, R>>
@@ -60,7 +60,7 @@ where
 {
     type Output = Self;
     /// See [div]
-    fn try_div(self, rhs: Tensor<S, E, D, R>) -> Result<Self, Self::Err> {
+    fn try_div(self, rhs: Tensor<S, E, D, R>) -> Result<Self, Error> {
         try_binary_op(BinaryDivKernelOp, self, rhs)
     }
 }
@@ -71,7 +71,7 @@ where
 {
     type Output = Self;
     /// See [div]
-    fn try_div(self, rhs: Rhs) -> Result<Self, Self::Err> {
+    fn try_div(self, rhs: Rhs) -> Result<Self, Error> {
         let rhs: f64 = rhs.into();
         let scalar = E::from_f64(rhs).unwrap();
         try_unary_op(ScalarDivKernelOp { scalar }, self)

--- a/dfdx-core/src/tensor_ops/dropout/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/dropout/cpu_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::{Dtype, Shape},
-    tensor::{unique_id, Cpu, Tensor},
+    tensor::{unique_id, Cpu, Error, Tensor},
 };
 
 use num_traits::Float;
@@ -12,7 +12,7 @@ impl<E: Float + Dtype> super::DropoutKernel<E> for Cpu {
         &self,
         op: super::DropoutKernelOp,
         inp: &Tensor<S, E, Self>,
-    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         let mut rng = StdRng::seed_from_u64(op.seed);
         let dist = Bernoulli::new(op.prob).unwrap();
         let mut out = Tensor {
@@ -39,7 +39,7 @@ impl<E: Float + Dtype> super::DropoutKernel<E> for Cpu {
         inp: &Tensor<S, E, Self>,
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let mut rng = StdRng::seed_from_u64(op.seed);
         let dist = Bernoulli::new(op.prob).unwrap();
         debug_assert_eq!(grad_inp.len(), grad_out.len());

--- a/dfdx-core/src/tensor_ops/dropout/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/dropout/cuda_kernel.rs
@@ -48,7 +48,7 @@ where
         &self,
         op: super::DropoutKernelOp,
         inp: &Tensor<S, E, Self>,
-    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         let mask = {
             let mut rng = StdRng::seed_from_u64(op.seed);
             let dist = Bernoulli::new(op.prob).unwrap();
@@ -78,7 +78,7 @@ where
         inp: &Tensor<S, E, Self>,
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let mask = {
             let mut rng = StdRng::seed_from_u64(op.seed);
             let dist = Bernoulli::new(op.prob).unwrap();

--- a/dfdx-core/src/tensor_ops/dropout/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/dropout/cuda_kernel.rs
@@ -1,7 +1,7 @@
 use crate::{
     dtypes::*,
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Tensor},
 };
 
 use std::vec::Vec;

--- a/dfdx-core/src/tensor_ops/exp/mod.rs
+++ b/dfdx-core/src/tensor_ops/exp/mod.rs
@@ -33,7 +33,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<ExpKernelOp, E>, T: Tape<E, D>> Tensor<S
         self.try_exp().unwrap()
     }
     /// See [exp]
-    pub fn try_exp(self) -> Result<Self, D::Err> {
+    pub fn try_exp(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(ExpKernelOp, self)
     }
 }

--- a/dfdx-core/src/tensor_ops/fast_gelu/mod.rs
+++ b/dfdx-core/src/tensor_ops/fast_gelu/mod.rs
@@ -48,7 +48,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<FastGeLUKernelOp, E>, T: Tape<E, D>> Ten
         self.try_fast_gelu().unwrap()
     }
     /// See [fast_gelu]
-    pub fn try_fast_gelu(self) -> Result<Self, D::Err> {
+    pub fn try_fast_gelu(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(FastGeLUKernelOp, self)
     }
 
@@ -60,7 +60,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<FastGeLUKernelOp, E>, T: Tape<E, D>> Ten
 
     /// Use [Tensor::try_fast_gelu] instead
     #[deprecated(since = "0.12.0", note = "Use `Tensor::try_fast_gelu` instead")]
-    pub fn try_gelu(self) -> Result<Self, D::Err> {
+    pub fn try_gelu(self) -> Result<Self, crate::tensor::Error> {
         self.try_fast_gelu()
     }
 }

--- a/dfdx-core/src/tensor_ops/huber_error/mod.rs
+++ b/dfdx-core/src/tensor_ops/huber_error/mod.rs
@@ -50,7 +50,7 @@ impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Tensor<S, E, D, T> {
         self,
         rhs: Tensor<S, E, D, R>,
         delta: impl Into<f64>,
-    ) -> Result<Self, D::Err>
+    ) -> Result<Self, crate::tensor::Error>
     where
         T: Merge<R>,
     {

--- a/dfdx-core/src/tensor_ops/ln/mod.rs
+++ b/dfdx-core/src/tensor_ops/ln/mod.rs
@@ -33,7 +33,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<LnKernelOp, E>, T: Tape<E, D>> Tensor<S,
         self.try_ln().unwrap()
     }
     /// See [ln]
-    pub fn try_ln(self) -> Result<Self, D::Err> {
+    pub fn try_ln(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(LnKernelOp, self)
     }
 }

--- a/dfdx-core/src/tensor_ops/log_softmax.rs
+++ b/dfdx-core/src/tensor_ops/log_softmax.rs
@@ -38,7 +38,7 @@ impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Tensor<S, E, D, T> {
         self.try_log_softmax::<Ax>().unwrap()
     }
     /// See [log_softmax()]
-    pub fn try_log_softmax<Ax: Axes>(self) -> Result<Self, D::Err>
+    pub fn try_log_softmax<Ax: Axes>(self) -> Result<Self, crate::tensor::Error>
     where
         S: ReduceShape<Ax>,
     {

--- a/dfdx-core/src/tensor_ops/logsumexp_to.rs
+++ b/dfdx-core/src/tensor_ops/logsumexp_to.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{shapes::*, tensor::*};
 
 /// Reduction along multiple axes using [LogSumExp](https://en.wikipedia.org/wiki/LogSumExp).
-pub trait LogSumExpTo: HasErr + HasShape {
+pub trait LogSumExpTo: Sized + HasShape {
     /// [LogSumExp](https://en.wikipedia.org/wiki/LogSumExp) reduction.
     ///
     /// **Pytorch equivalent**: `t.exp().sum(Axes).log()`
@@ -31,13 +31,13 @@ pub trait LogSumExpTo: HasErr + HasShape {
         self.try_logsumexp().unwrap()
     }
     /// Fallible version of [LogSumExpTo::logsumexp]
-    fn try_logsumexp<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_logsumexp<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: ReduceShapeTo<Dst, Ax>;
 }
 
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> LogSumExpTo for Tensor<S, E, D, T> {
-    fn try_logsumexp<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_logsumexp<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: ReduceShapeTo<Dst, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/matmul/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/matmul/cpu_kernel.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::needless_return)]
 
 use crate::shapes::*;
-use crate::tensor::{Cpu, Tensor, ZerosTensor};
+use crate::tensor::{Cpu, Error, Tensor, ZerosTensor};
 
 use std::sync::Arc;
 
@@ -236,7 +236,7 @@ where
         &self,
         lhs: &Tensor<(M, K), E, Self>,
         rhs: &Tensor<(K, N), E, Self>,
-    ) -> Result<Tensor<(M, N), E, Self>, Self::Err> {
+    ) -> Result<Tensor<(M, N), E, Self>, Error> {
         let (m, k) = lhs.shape;
         let n = rhs.shape.1;
         let mut out = self.try_zeros_like(&(m, n))?;
@@ -259,7 +259,7 @@ where
         rhs: &Tensor<(K, N), E, Self>,
         grad_rhs: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let (m, k) = lhs.shape;
         let n = rhs.shape.1;
         let strides = (m, n).strides();
@@ -295,7 +295,7 @@ where
         &self,
         lhs: &Tensor<(B, M, K), E, Self>,
         rhs: &Tensor<(K, N), E, Self>,
-    ) -> Result<Tensor<(B, M, N), E, Self>, Self::Err> {
+    ) -> Result<Tensor<(B, M, N), E, Self>, Error> {
         let (batch, m, k) = lhs.shape;
         let n = rhs.shape.1;
         let mut out = self.try_zeros_like(&(batch, m, n))?;
@@ -321,7 +321,7 @@ where
         rhs: &Tensor<(K, N), E, Self>,
         grad_rhs: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let (batch, m, k) = lhs.shape;
         let n = rhs.shape.1;
         let strides = (batch, m, n).strides();
@@ -359,7 +359,7 @@ where
         &self,
         lhs: &Tensor<(B, M, K), E, Self>,
         rhs: &Tensor<(B, K, N), E, Self>,
-    ) -> Result<Tensor<(B, M, N), E, Self>, Self::Err> {
+    ) -> Result<Tensor<(B, M, N), E, Self>, Error> {
         let (b, m, k) = lhs.shape;
         let n = rhs.shape.2;
         let mut out = self.try_zeros_like(&(b, m, n))?;
@@ -387,7 +387,7 @@ where
         rhs: &Tensor<(B, K, N), E, Self>,
         grad_rhs: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let (b, m, k) = lhs.shape;
         let n = rhs.shape.2;
         let strides = (b, m, n).strides();
@@ -425,7 +425,7 @@ where
         &self,
         lhs: &Tensor<(B, S, M, K), E, Self>,
         rhs: &Tensor<(B, S, K, N), E, Self>,
-    ) -> Result<Tensor<(B, S, M, N), E, Self>, Self::Err> {
+    ) -> Result<Tensor<(B, S, M, N), E, Self>, Error> {
         let (b, s, m, k) = lhs.shape;
         let n = rhs.shape.3;
         let mut out = self.try_zeros_like(&(b, s, m, n))?;
@@ -453,7 +453,7 @@ where
         rhs: &Tensor<(B, S, K, N), E, Self>,
         grad_rhs: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let (b, s, m, k) = lhs.shape;
         let n = rhs.shape.3;
         let strides = (b, s, m, n).strides();

--- a/dfdx-core/src/tensor_ops/matmul/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/matmul/cuda_kernel.rs
@@ -1,7 +1,7 @@
 use crate::{
     dtypes::*,
     shapes::*,
-    tensor::{cuda::Cuda, Tensor},
+    tensor::{cuda::Cuda, Error, Tensor},
 };
 
 use cudarc::{

--- a/dfdx-core/src/tensor_ops/matmul/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/matmul/cuda_kernel.rs
@@ -245,7 +245,7 @@ where
         &self,
         lhs: &Tensor<(M, K), E, Self>,
         rhs: &Tensor<(K, N), E, Self>,
-    ) -> Result<Tensor<(M, N), E, Self>, Self::Err> {
+    ) -> Result<Tensor<(M, N), E, Self>, Error> {
         let (m, _) = lhs.shape;
         let (k, n) = rhs.shape;
         let shape = (m, n);
@@ -275,7 +275,7 @@ where
         rhs: &Tensor<(K, N), E, Self>,
         grad_rhs: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let (m, _) = lhs.shape;
         let (k, n) = rhs.shape;
         let strides = (m, n).strides();
@@ -320,7 +320,7 @@ where
         &self,
         lhs: &Tensor<(B, M, K), E, Self>,
         rhs: &Tensor<(K, N), E, Self>,
-    ) -> Result<Tensor<(B, M, N), E, Self>, Self::Err> {
+    ) -> Result<Tensor<(B, M, N), E, Self>, Error> {
         let (batch, m, _) = lhs.shape;
         let (k, n) = rhs.shape;
         let shape = (batch, m, n);
@@ -347,7 +347,7 @@ where
         rhs: &Tensor<(K, N), E, Self>,
         grad_rhs: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let (batch, m, _) = lhs.shape;
         let (k, n) = rhs.shape;
         let strides = (batch, m, n).strides();
@@ -396,7 +396,7 @@ where
         &self,
         lhs: &Tensor<(B, M, K), E, Self>,
         rhs: &Tensor<(B, K, N), E, Self>,
-    ) -> Result<Tensor<(B, M, N), E, Self>, Self::Err> {
+    ) -> Result<Tensor<(B, M, N), E, Self>, Error> {
         assert_ne!(lhs.strides[0], 0);
         assert_ne!(rhs.strides[0], 0);
         let (batch, m, _) = lhs.shape;
@@ -425,7 +425,7 @@ where
         rhs: &Tensor<(B, K, N), E, Self>,
         grad_rhs: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let (batch, m, _) = lhs.shape;
         let (_, k, n) = rhs.shape;
         let strides = (batch, m, n).strides();
@@ -470,7 +470,7 @@ where
         &self,
         lhs: &Tensor<(B, S, M, K), E, Self>,
         rhs: &Tensor<(B, S, K, N), E, Self>,
-    ) -> Result<Tensor<(B, S, M, N), E, Self>, Self::Err> {
+    ) -> Result<Tensor<(B, S, M, N), E, Self>, Error> {
         assert_ne!(lhs.strides[0], 0);
         assert_ne!(rhs.strides[0], 0);
         assert_ne!(lhs.strides[1], 0);
@@ -527,7 +527,7 @@ where
         rhs: &Tensor<(B, S, K, N), E, Self>,
         grad_rhs: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let (batch, seq, m, _) = lhs.shape;
         let (_, _, k, n) = rhs.shape;
         let strides = (batch, seq, m, n).strides();

--- a/dfdx-core/src/tensor_ops/max_to/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/max_to/cpu_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::{Axes, Dtype, HasAxes, ReduceShapeTo, Shape},
-    tensor::{Cpu, Tensor, ZerosTensor},
+    tensor::{Cpu, Error, Tensor, ZerosTensor},
     tensor_ops::utilities::reduction_utils::index_for_reductions,
 };
 
@@ -11,7 +11,7 @@ impl<E: Dtype + Float> super::MaxReduceKernel<E> for Cpu {
         &self,
         dst: Dst,
         inp: &Tensor<Src, E, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, E, Self>, Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {
@@ -44,7 +44,7 @@ impl<E: Dtype + Float> super::MaxReduceKernel<E> for Cpu {
         grad_inp: &mut Self::Vec,
         out: &Tensor<Dst, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/max_to/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/max_to/cuda_kernel.rs
@@ -51,7 +51,7 @@ where
         &self,
         dst: Dst,
         inp: &Tensor<Src, E, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, E, Self>, Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {
@@ -103,7 +103,7 @@ where
         grad_inp: &mut Self::Vec,
         out: &Tensor<Dst, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/max_to/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/max_to/cuda_kernel.rs
@@ -1,7 +1,7 @@
 use crate::{
     dtypes::*,
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Tensor},
     tensor_ops::reduction_utils::*,
 };
 

--- a/dfdx-core/src/tensor_ops/max_to/mod.rs
+++ b/dfdx-core/src/tensor_ops/max_to/mod.rs
@@ -10,7 +10,7 @@ pub trait MaxReduceKernel<E: Dtype>: Storage<E> {
         &self,
         dst: Dst,
         inp: &Tensor<Src, E, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, E, Self>, Error>
     where
         Src: ReduceShapeTo<Dst, Ax>;
     fn backward<Src: Shape, Dst: Shape, Ax: Axes>(
@@ -19,13 +19,13 @@ pub trait MaxReduceKernel<E: Dtype>: Storage<E> {
         grad_inp: &mut Self::Vec,
         out: &Tensor<Dst, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: ReduceShapeTo<Dst, Ax>;
 }
 
 /// Reduction along multiple axes using `max`.
-pub trait MaxTo: HasErr + HasShape {
+pub trait MaxTo: Sized + HasShape {
     /// Max reduction. **Pytorch equivalent**: `t.amax(Ax)`
     ///
     /// **NOTE** This evenly distributes gradients between all equal maximum values, instead
@@ -55,13 +55,13 @@ pub trait MaxTo: HasErr + HasShape {
         self.try_max().unwrap()
     }
     /// Fallible version of [MaxTo::max]
-    fn try_max<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_max<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: ReduceShapeTo<Dst, Ax>;
 }
 
 impl<S: Shape, E: Dtype, D: MaxReduceKernel<E>, T: Tape<E, D>> MaxTo for Tensor<S, E, D, T> {
-    fn try_max<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_max<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: ReduceShapeTo<Dst, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/maximum/mod.rs
+++ b/dfdx-core/src/tensor_ops/maximum/mod.rs
@@ -39,7 +39,10 @@ impl<S: Shape, E: Dtype, D: Device<E>, LTape: Tape<E, D>> Tensor<S, E, D, LTape>
     }
 
     /// See [maximum]
-    pub fn try_maximum<R: Default>(self, rhs: Tensor<S, E, D, R>) -> Result<Self, D::Err>
+    pub fn try_maximum<R: Default>(
+        self,
+        rhs: Tensor<S, E, D, R>,
+    ) -> Result<Self, crate::tensor::Error>
     where
         LTape: Merge<R>,
     {

--- a/dfdx-core/src/tensor_ops/mean_to.rs
+++ b/dfdx-core/src/tensor_ops/mean_to.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{shapes::*, tensor::*};
 
 /// Reduction along multiple axes using `mean`.
-pub trait MeanTo: HasErr + HasShape {
+pub trait MeanTo: Sized + HasShape {
     /// Mean reduction. **Pytorch equivalent**: `t.mean(Axes)`
     ///
     /// Example:
@@ -29,13 +29,13 @@ pub trait MeanTo: HasErr + HasShape {
         self.try_mean().unwrap()
     }
     /// Fallible version of [MeanTo::mean]
-    fn try_mean<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_mean<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: HasAxes<Ax> + ReduceShapeTo<Dst, Ax>;
 }
 
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> MeanTo for Tensor<S, E, D, T> {
-    fn try_mean<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_mean<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: HasAxes<Ax> + ReduceShapeTo<Dst, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/min_to/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/min_to/cpu_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::{Axes, Dtype, HasAxes, ReduceShapeTo, Shape},
-    tensor::{Cpu, Tensor, ZerosTensor},
+    tensor::{Cpu, Error, Tensor, ZerosTensor},
     tensor_ops::utilities::reduction_utils::index_for_reductions,
 };
 
@@ -11,7 +11,7 @@ impl<E: Dtype + Float> super::MinReduceKernel<E> for Cpu {
         &self,
         dst: Dst,
         inp: &Tensor<Src, E, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, E, Self>, Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {
@@ -44,7 +44,7 @@ impl<E: Dtype + Float> super::MinReduceKernel<E> for Cpu {
         grad_inp: &mut Self::Vec,
         out: &Tensor<Dst, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/min_to/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/min_to/cuda_kernel.rs
@@ -51,7 +51,7 @@ where
         &self,
         dst: Dst,
         inp: &Tensor<Src, E, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, E, Self>, Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {
@@ -103,7 +103,7 @@ where
         grad_inp: &mut Self::Vec,
         out: &Tensor<Dst, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/min_to/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/min_to/cuda_kernel.rs
@@ -1,7 +1,7 @@
 use crate::{
     dtypes::*,
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Tensor},
     tensor_ops::reduction_utils::*,
 };
 

--- a/dfdx-core/src/tensor_ops/min_to/mod.rs
+++ b/dfdx-core/src/tensor_ops/min_to/mod.rs
@@ -10,7 +10,7 @@ pub trait MinReduceKernel<E: Dtype>: Storage<E> {
         &self,
         dst: Dst,
         inp: &Tensor<Src, E, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, E, Self>, Error>
     where
         Src: ReduceShapeTo<Dst, Ax>;
     fn backward<Src: Shape, Dst: Shape, Ax: Axes>(
@@ -19,13 +19,13 @@ pub trait MinReduceKernel<E: Dtype>: Storage<E> {
         grad_inp: &mut Self::Vec,
         out: &Tensor<Dst, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: ReduceShapeTo<Dst, Ax>;
 }
 
 /// Reduction along multiple axes using `min`.
-pub trait MinTo: HasErr + HasShape {
+pub trait MinTo: Sized + HasShape {
     /// Min reduction. **Pytorch equivalent**: `t.amin(Ax)`
     ///
     /// **NOTE** This evenly distributes gradients between all equal maximum values, instead
@@ -55,13 +55,13 @@ pub trait MinTo: HasErr + HasShape {
         self.try_min().unwrap()
     }
     /// Fallible version of [MinTo::min]
-    fn try_min<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_min<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: ReduceShapeTo<Dst, Ax>;
 }
 
 impl<S: Shape, E: Dtype, D: MinReduceKernel<E>, T: Tape<E, D>> MinTo for Tensor<S, E, D, T> {
-    fn try_min<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_min<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: ReduceShapeTo<Dst, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/minimum/mod.rs
+++ b/dfdx-core/src/tensor_ops/minimum/mod.rs
@@ -39,7 +39,10 @@ impl<S: Shape, E: Dtype, D: Device<E>, LTape: Tape<E, D>> Tensor<S, E, D, LTape>
     }
 
     /// See [minimum]
-    pub fn try_minimum<R: Default>(self, rhs: Tensor<S, E, D, R>) -> Result<Self, D::Err>
+    pub fn try_minimum<R: Default>(
+        self,
+        rhs: Tensor<S, E, D, R>,
+    ) -> Result<Self, crate::tensor::Error>
     where
         LTape: Merge<R>,
     {

--- a/dfdx-core/src/tensor_ops/mul/mod.rs
+++ b/dfdx-core/src/tensor_ops/mul/mod.rs
@@ -46,9 +46,9 @@ where
 }
 
 /// Fallible version of [std::ops::Mul]. See [mul].
-pub trait TryMul<Rhs = Self>: HasErr {
+pub trait TryMul<Rhs = Self> {
     type Output;
-    fn try_mul(self, rhs: Rhs) -> Result<Self::Output, Self::Err>;
+    fn try_mul(self, rhs: Rhs) -> Result<Self::Output, Error>;
 }
 
 impl<S: Shape, E: Dtype, D: BinaryKernel<BinaryMulKernelOp, E>, LhsTape: Tape<E, D>, R>
@@ -57,7 +57,7 @@ where
     LhsTape: Merge<R>,
 {
     type Output = Self;
-    fn try_mul(self, rhs: Tensor<S, E, D, R>) -> Result<Self, Self::Err> {
+    fn try_mul(self, rhs: Tensor<S, E, D, R>) -> Result<Self, Error> {
         try_binary_op(BinaryMulKernelOp, self, rhs)
     }
 }
@@ -67,7 +67,7 @@ where
     D: UnaryKernel<ScalarMulKernelOp<E>, E>,
 {
     type Output = Self;
-    fn try_mul(self, rhs: Rhs) -> Result<Self, Self::Err> {
+    fn try_mul(self, rhs: Rhs) -> Result<Self, Error> {
         let rhs: f64 = rhs.into();
         let scalar: E = E::from_f64(rhs).unwrap();
         try_unary_op(ScalarMulKernelOp { scalar }, self)

--- a/dfdx-core/src/tensor_ops/nans_to/mod.rs
+++ b/dfdx-core/src/tensor_ops/nans_to/mod.rs
@@ -35,7 +35,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<NansToKernelOp<E>, E>, T: Tape<E, D>> Te
         self.try_nans_to(value).unwrap()
     }
     /// See [nans_to]
-    pub fn try_nans_to(self, value: impl Into<f64>) -> Result<Self, D::Err> {
+    pub fn try_nans_to(self, value: impl Into<f64>) -> Result<Self, crate::tensor::Error> {
         let value = E::from_f64(value.into()).unwrap();
         try_unary_op(NansToKernelOp(value), self)
     }

--- a/dfdx-core/src/tensor_ops/negate/mod.rs
+++ b/dfdx-core/src/tensor_ops/negate/mod.rs
@@ -30,7 +30,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<NegateKernelOp, E>, T: Tape<E, D>> Tenso
     pub fn negate(self) -> Self {
         self.try_negate().unwrap()
     }
-    pub fn try_negate(self) -> Result<Self, D::Err> {
+    pub fn try_negate(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(NegateKernelOp, self)
     }
 }

--- a/dfdx-core/src/tensor_ops/normalize.rs
+++ b/dfdx-core/src/tensor_ops/normalize.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::{Axes, Dtype, ReduceShape, Shape},
-    tensor::{HasErr, Tape, Tensor},
+    tensor::{Error, Tape, Tensor},
 };
 
 use super::{BroadcastTo, Device, MeanTo, TryAdd, TryDiv, TrySub};
@@ -32,10 +32,7 @@ impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Tensor<S, E, D, T> {
     }
 
     /// See [normalize]
-    pub fn try_normalize<Ax: Axes>(
-        self,
-        epsilon: impl Into<f64>,
-    ) -> Result<Self, <Self as HasErr>::Err>
+    pub fn try_normalize<Ax: Axes>(self, epsilon: impl Into<f64>) -> Result<Self, Error>
     where
         S: ReduceShape<Ax>,
     {

--- a/dfdx-core/src/tensor_ops/permute_to.rs
+++ b/dfdx-core/src/tensor_ops/permute_to.rs
@@ -21,7 +21,7 @@ use crate::{shapes::*, tensor::*};
 /// let b: Tensor<Rank2<3, 2>, f32, _> = a.permute::<_, Axes2<1, 0>>();
 /// assert_eq!(b.array(), [[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]]);
 /// ```
-pub trait PermuteTo: HasErr + HasShape {
+pub trait PermuteTo: Sized + HasShape {
     /// Permutes the tensor.
     fn permute<Dst: Shape, Ax: Axes>(self) -> Self::WithShape<Dst>
     where
@@ -30,13 +30,13 @@ pub trait PermuteTo: HasErr + HasShape {
         self.try_permute().unwrap()
     }
     /// Fallible version of [PermuteTo::permute]
-    fn try_permute<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_permute<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: PermuteShapeTo<Dst, Ax>;
 }
 
 impl<S: Shape, E, D: Storage<E>, T: Tape<E, D>> PermuteTo for Tensor<S, E, D, T> {
-    fn try_permute<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_permute<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: PermuteShapeTo<Dst, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/pool2d/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/pool2d/cpu_kernel.rs
@@ -59,7 +59,7 @@ impl super::Pool2DKind {
 }
 
 impl<E: Float + Dtype> super::Pool2DKernel<E> for Cpu {
-    fn alloc<S: Shape>(&self, s: S) -> Result<Tensor<S, E, Self>, Self::Err> {
+    fn alloc<S: Shape>(&self, s: S) -> Result<Tensor<S, E, Self>, Error> {
         self.try_zeros_like(&s)
     }
     fn forward<I: Shape, O: Shape>(
@@ -67,7 +67,7 @@ impl<E: Float + Dtype> super::Pool2DKernel<E> for Cpu {
         op: super::Pool2DOp,
         inp: &Tensor<I, E, Self>,
         out: &mut Tensor<O, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let istr = make_4d::<I>(inp.strides);
         let ostr = make_4d::<O>(out.strides);
 
@@ -106,7 +106,7 @@ impl<E: Float + Dtype> super::Pool2DKernel<E> for Cpu {
         grad_inp: &mut Self::Vec,
         out: &Tensor<O, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let istr = make_4d::<I>(inp.strides);
         let ostr = make_4d::<O>(out.strides);
 

--- a/dfdx-core/src/tensor_ops/pool2d/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/pool2d/cuda_kernel.rs
@@ -51,7 +51,7 @@ impl<E: Dtype> super::Pool2DKernel<E> for Cuda
 where
     Self: HasCudaKernel<E>,
 {
-    fn alloc<S: Shape>(&self, s: S) -> Result<Tensor<S, E, Self>, Self::Err> {
+    fn alloc<S: Shape>(&self, s: S) -> Result<Tensor<S, E, Self>, Error> {
         let data = unsafe { self.alloc_empty::<E>(s.num_elements()) }?;
         Ok(self.build_tensor(s, s.strides(), data))
     }
@@ -60,7 +60,7 @@ where
         op: super::Pool2DOp,
         inp: &Tensor<I, E, Self>,
         out: &mut Tensor<O, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         if !self.dev.has_func(Self::FWD, Self::FWD) {
             self.dev
                 .load_ptx(PTX_SRC.into(), Self::FWD, &[Self::FWD, Self::BWD])?;
@@ -87,7 +87,7 @@ where
         grad_inp: &mut Self::Vec,
         out: &Tensor<O, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let inp_strides = self.dev.htod_copy(make_4d::<I>(inp.strides).into())?;
         let out_strides = self.dev.htod_copy(make_4d::<O>(out.strides).into())?;
         let bwd_fn = self.dev.get_func(Self::FWD, Self::BWD).unwrap();

--- a/dfdx-core/src/tensor_ops/pool2d/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/pool2d/cuda_kernel.rs
@@ -1,7 +1,7 @@
 use crate::{
     dtypes::*,
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Tensor},
 };
 
 use std::sync::Arc;

--- a/dfdx-core/src/tensor_ops/pow/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/pow/cuda_kernel.rs
@@ -41,7 +41,7 @@ where
         &self,
         op: super::PowiKernelOp,
         inp: Cow<Tensor<S, E, Self>>,
-    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         self.forward(super::PowfKernelOp(E::from_i32(op.0).unwrap()), inp)
     }
 
@@ -52,7 +52,7 @@ where
         grad_inp: &mut Self::Vec,
         out: &impl Tensorlike<S, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         self.backward(
             super::PowfKernelOp(E::from_i32(op.0).unwrap()),
             inp,

--- a/dfdx-core/src/tensor_ops/pow/mod.rs
+++ b/dfdx-core/src/tensor_ops/pow/mod.rs
@@ -34,7 +34,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<PowfKernelOp<E>, E>, T: Tape<E, D>> Tens
         self.try_powf(exponent).unwrap()
     }
     /// See [powf]
-    pub fn try_powf(self, exponent: impl Into<f64>) -> Result<Self, D::Err> {
+    pub fn try_powf(self, exponent: impl Into<f64>) -> Result<Self, crate::tensor::Error> {
         let exponent = E::from_f64(exponent.into()).unwrap();
         try_unary_op(PowfKernelOp(exponent), self)
     }
@@ -60,7 +60,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<PowiKernelOp, E>, T: Tape<E, D>> Tensor<
         self.try_powi(exponent).unwrap()
     }
     /// See [powi]
-    pub fn try_powi(self, exponent: i32) -> Result<Self, D::Err> {
+    pub fn try_powi(self, exponent: i32) -> Result<Self, crate::tensor::Error> {
         try_unary_op(PowiKernelOp(exponent), self)
     }
 }

--- a/dfdx-core/src/tensor_ops/realize_to.rs
+++ b/dfdx-core/src/tensor_ops/realize_to.rs
@@ -13,7 +13,7 @@ use crate::{shapes::*, tensor::*};
 ///     Err(old) => println!("Shape could not be realized, returned the original tensor"),
 /// }
 /// ```
-pub trait RealizeTo: HasErr + HasShape {
+pub trait RealizeTo: Sized + HasShape {
     /// Realizes the concrete shape of the tensor as another compatable shape,
     /// or returns the original tensor if the new shape's dimensions are incompatable.
     fn realize<Dst: Shape<Concrete = <<Self as HasShape>::Shape as Shape>::Concrete>>(

--- a/dfdx-core/src/tensor_ops/recip/mod.rs
+++ b/dfdx-core/src/tensor_ops/recip/mod.rs
@@ -31,7 +31,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<RecipKernelOp, E>, T: Tape<E, D>> Tensor
         self.try_recip().unwrap()
     }
     /// See [recip]
-    pub fn try_recip(self) -> Result<Self, D::Err> {
+    pub fn try_recip(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(RecipKernelOp, self)
     }
 }

--- a/dfdx-core/src/tensor_ops/relu/mod.rs
+++ b/dfdx-core/src/tensor_ops/relu/mod.rs
@@ -34,7 +34,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<ReLUKernelOp, E>, T: Tape<E, D>> Tensor<
         self.try_relu().unwrap()
     }
     /// See [relu]
-    pub fn try_relu(self) -> Result<Self, D::Err> {
+    pub fn try_relu(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(ReLUKernelOp, self)
     }
 }

--- a/dfdx-core/src/tensor_ops/reshape_to/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/reshape_to/cpu_kernel.rs
@@ -1,7 +1,7 @@
 use crate::shapes::{Dtype, Shape};
 use crate::tensor::{
     cpu::{LendingIterator, NdIndex},
-    Cpu, Tensor, ZerosTensor,
+    Cpu, Error, Tensor, ZerosTensor,
 };
 
 impl<E: Dtype> super::ReshapeKernel<E> for Cpu {
@@ -9,7 +9,7 @@ impl<E: Dtype> super::ReshapeKernel<E> for Cpu {
         &self,
         dst: &Dst,
         inp: &Tensor<Src, E, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err> {
+    ) -> Result<Tensor<Dst, E, Self>, Error> {
         let mut out = self.try_zeros_like(dst)?;
         let mut inp_iter = inp.iter();
         let mut out_iter = out.iter_mut();
@@ -24,7 +24,7 @@ impl<E: Dtype> super::ReshapeKernel<E> for Cpu {
         inp: &Tensor<Src, E, Self>,
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let mut inp_idx = NdIndex::new(inp.shape, inp.strides);
         let mut out_idx = NdIndex::new(*dst, dst.strides());
         while let Some((i, o)) = inp_idx.next().zip(out_idx.next()) {

--- a/dfdx-core/src/tensor_ops/reshape_to/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/reshape_to/cuda_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Tensor},
 };
 use cudarc::{
     driver::{DeviceSlice, LaunchAsync},

--- a/dfdx-core/src/tensor_ops/reshape_to/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/reshape_to/cuda_kernel.rs
@@ -15,7 +15,7 @@ impl<E: Dtype + CudaTypeName> super::ReshapeKernel<E> for Cuda {
         &self,
         dst: &Dst,
         inp: &Tensor<Src, E, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err> {
+    ) -> Result<Tensor<Dst, E, Self>, Error> {
         let module = std::format!("reshape_fwd_{}", E::NAME);
         if !self.dev.has_func(&module, "reshape_fwd") {
             let src = FWD_KERNEL.replace("$T", E::NAME);
@@ -62,7 +62,7 @@ impl<E: Dtype + CudaTypeName> super::ReshapeKernel<E> for Cuda {
         inp: &Tensor<Src, E, Self>,
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let module = std::format!("reshape_bwd_{}", E::NAME);
         if !self.dev.has_func(&module, "reshape_bwd") {
             let src = BWD_KERNEL.replace("$T", E::NAME);

--- a/dfdx-core/src/tensor_ops/rmsprop/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/rmsprop/cpu_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     dtypes::{Dtype, NotMixedPrecision},
-    tensor::cpu::Cpu,
+    tensor::{cpu::Cpu, Error},
 };
 
 use super::{RMSpropConfig, RMSpropKernel, WeightDecay};
@@ -15,7 +15,7 @@ impl RMSpropKernel<crate::dtypes::AMP<crate::dtypes::f16>> for Cpu {
         square_avg: &mut Self::Vec,
         grad_avg: &mut Self::Vec,
         grad: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let alpha = cfg.alpha as f32;
         let eps = cfg.eps as f32;
         let lr = cfg.lr as f32;
@@ -80,7 +80,7 @@ impl<E: num_traits::Float + Dtype + NotMixedPrecision> RMSpropKernel<E> for Cpu 
         square_avg: &mut Self::Vec,
         grad_avg: &mut Self::Vec,
         grad: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let alpha = E::from_f64(cfg.alpha).unwrap();
         let eps = E::from_f64(cfg.eps).unwrap();
         let lr = E::from_f64(cfg.lr).unwrap();

--- a/dfdx-core/src/tensor_ops/rmsprop/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/rmsprop/cuda_kernel.rs
@@ -82,7 +82,7 @@ where
         square_avg: &mut Self::Vec,
         grad_avg: &mut Self::Vec,
         grad: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         if !self.dev.has_func(Self::MOD, Self::FWD) {
             self.dev.load_ptx(PTX_SRC.into(), Self::MOD, &[Self::FWD])?;
         }

--- a/dfdx-core/src/tensor_ops/rmsprop/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/rmsprop/cuda_kernel.rs
@@ -1,7 +1,7 @@
 use super::RMSpropConfig;
 use crate::{
     dtypes::*,
-    tensor::{launch_cfg, Cuda},
+    tensor::{launch_cfg, Cuda, Error},
     tensor_ops::optim::*,
 };
 

--- a/dfdx-core/src/tensor_ops/rmsprop/mod.rs
+++ b/dfdx-core/src/tensor_ops/rmsprop/mod.rs
@@ -55,7 +55,7 @@ pub trait RMSpropKernel<E: Dtype>: Storage<E> {
         square_avg: &mut Self::Vec,
         grad_avg: &mut Self::Vec,
         grad: &Self::Vec,
-    ) -> Result<(), Self::Err>;
+    ) -> Result<(), Error>;
 }
 
 impl RMSpropConfig {
@@ -67,7 +67,7 @@ impl RMSpropConfig {
         square_avg: &mut D::Vec,
         grad_avg: &mut D::Vec,
         grad: &D::Vec,
-    ) -> Result<(), D::Err> {
+    ) -> Result<(), crate::tensor::Error> {
         param.device.rmsprop_kernel(
             self,
             std::sync::Arc::make_mut(&mut param.data),

--- a/dfdx-core/src/tensor_ops/roll/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/roll/cpu_kernel.rs
@@ -10,7 +10,7 @@ impl<E: Dtype> super::RollKernel<E> for Cpu {
         &self,
         op: super::RollOp,
         inp: &Tensor<S, E, Self>,
-    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         let dims = inp.shape.concrete();
         let strides = inp.shape.strides();
         let mut data = self.try_alloc_zeros::<E>(inp.shape.num_elements())?;
@@ -39,7 +39,7 @@ impl<E: Dtype> super::RollKernel<E> for Cpu {
         inp: &Tensor<S, E, Self>,
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let dims = inp.shape.concrete();
         let strides = inp.shape.strides();
         let mut idx = NdIndex::new(inp.shape, inp.strides);

--- a/dfdx-core/src/tensor_ops/roll/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/roll/cuda_kernel.rs
@@ -32,7 +32,7 @@ where
         &self,
         op: super::RollOp,
         inp: &Tensor<S, E, Self>,
-    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         if !self.dev.has_func(Self::FNS[0], Self::FNS[0]) {
             self.dev.load_ptx(PTX_SRC.into(), Self::FNS[0], Self::FNS)?;
         }
@@ -66,7 +66,7 @@ where
         inp: &Tensor<S, E, Self>,
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let numel = inp.shape.num_elements();
         let strides = inp.shape.strides();
 

--- a/dfdx-core/src/tensor_ops/roll/mod.rs
+++ b/dfdx-core/src/tensor_ops/roll/mod.rs
@@ -19,14 +19,14 @@ pub trait RollKernel<E: Dtype>: Storage<E> {
         &self,
         op: RollOp,
         inp: &Tensor<S, E, Self>,
-    ) -> Result<Tensor<S, E, Self>, Self::Err>;
+    ) -> Result<Tensor<S, E, Self>, Error>;
     fn backward<S: Shape>(
         &self,
         op: RollOp,
         inp: &Tensor<S, E, Self>,
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err>;
+    ) -> Result<(), Error>;
 }
 
 /// Shifts data along an axis by a specified amount.
@@ -47,7 +47,7 @@ pub trait RollKernel<E: Dtype>: Storage<E> {
 /// let r = t.roll::<Axis<3>>(1);
 /// assert_eq!(r.array(), [4.0, 1.0, 2.0, 3.0]);
 /// ```
-pub trait Roll: HasShape + HasErr {
+pub trait Roll: Sized + HasShape {
     /// Shifts data along an axis by a specified amount.
     fn roll<Ax: Axes<Array = [isize; 1]>>(self, amount: usize) -> Self
     where
@@ -57,13 +57,16 @@ pub trait Roll: HasShape + HasErr {
     }
 
     /// Shifts data along an axis by a specified amount.
-    fn try_roll<Ax: Axes<Array = [isize; 1]>>(self, amount: usize) -> Result<Self, Self::Err>
+    fn try_roll<Ax: Axes<Array = [isize; 1]>>(self, amount: usize) -> Result<Self, Error>
     where
         Self::Shape: HasAxes<Ax>;
 }
 
 impl<S: Shape, E: Dtype, D: RollKernel<E>, T: Tape<E, D>> Roll for Tensor<S, E, D, T> {
-    fn try_roll<Ax: Axes<Array = [isize; 1]>>(self, amount: usize) -> Result<Self, D::Err>
+    fn try_roll<Ax: Axes<Array = [isize; 1]>>(
+        self,
+        amount: usize,
+    ) -> Result<Self, crate::tensor::Error>
     where
         S: HasAxes<Ax>,
     {

--- a/dfdx-core/src/tensor_ops/select_and_gather/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/select_and_gather/cpu_kernel.rs
@@ -3,7 +3,7 @@
 use crate::shapes::{Axes, Dtype, RemoveDimTo, ReplaceDimTo, Shape};
 use crate::tensor::{
     cpu::{index_to_i, LendingIterator, NdIndex},
-    Cpu, Storage, Tensor, ZerosTensor,
+    Cpu, Error, Storage, Tensor, ZerosTensor,
 };
 
 impl<E: Dtype> super::ReplaceDimKernel<E> for Cpu {
@@ -11,7 +11,7 @@ impl<E: Dtype> super::ReplaceDimKernel<E> for Cpu {
         &self,
         inp: &Tensor<Src, E, Self>,
         idx: &Tensor<Idx, usize, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, E, Self>, Error>
     where
         Src: ReplaceDimTo<Dst, Idx>,
     {
@@ -53,7 +53,7 @@ impl<E: Dtype> super::ReplaceDimKernel<E> for Cpu {
         idx: &Tensor<Idx, usize, Self>,
         out: &Tensor<Dst, E, Self>,
         grad_out: &<Self as Storage<E>>::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: ReplaceDimTo<Dst, Idx>,
     {
@@ -87,7 +87,7 @@ impl<E: Dtype> super::RemoveDimKernel<E> for Cpu {
         &self,
         inp: &Tensor<Src, E, Self>,
         idx: &Tensor<Idx, usize, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, E, Self>, Error>
     where
         Src: RemoveDimTo<Dst, Idx>,
     {
@@ -126,7 +126,7 @@ impl<E: Dtype> super::RemoveDimKernel<E> for Cpu {
         idx: &Tensor<Idx, usize, Self>,
         out: &Tensor<Dst, E, Self>,
         grad_out: &<Self as Storage<E>>::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: RemoveDimTo<Dst, Idx>,
     {

--- a/dfdx-core/src/tensor_ops/select_and_gather/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/select_and_gather/cuda_kernel.rs
@@ -16,7 +16,7 @@ macro_rules! impl_cuda_kernels {
                 &self,
                 inp: &Tensor<Src, $TypeName, Self>,
                 idx: &Tensor<Idx, usize, Self>,
-            ) -> Result<Tensor<Dst, $TypeName, Self>, Self::Err>
+            ) -> Result<Tensor<Dst, $TypeName, Self>, Error>
             where
                 Src: ReplaceDimTo<Dst, Idx>,
             {
@@ -65,7 +65,7 @@ macro_rules! impl_cuda_kernels {
                 idx: &Tensor<Idx, usize, Self>,
                 _: &Tensor<Dst, $TypeName, Self>,
                 grad_out: &<Self as Storage<$TypeName>>::Vec,
-            ) -> Result<(), Self::Err>
+            ) -> Result<(), Error>
             where
                 Src: ReplaceDimTo<Dst, Idx>,
             {
@@ -101,7 +101,7 @@ macro_rules! impl_cuda_kernels {
                 &self,
                 inp: &Tensor<Src, $TypeName, Self>,
                 idx: &Tensor<Idx, usize, Self>,
-            ) -> Result<Tensor<Dst, $TypeName, Self>, Self::Err>
+            ) -> Result<Tensor<Dst, $TypeName, Self>, Error>
             where
                 Src: RemoveDimTo<Dst, Idx>,
             {
@@ -153,7 +153,7 @@ macro_rules! impl_cuda_kernels {
                 idx: &Tensor<Idx, usize, Self>,
                 out: &Tensor<Dst, $TypeName, Self>,
                 grad_out: &<Self as Storage<$TypeName>>::Vec,
-            ) -> Result<(), Self::Err>
+            ) -> Result<(), Error>
             where
                 Src: RemoveDimTo<Dst, Idx>,
             {

--- a/dfdx-core/src/tensor_ops/select_and_gather/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/select_and_gather/cuda_kernel.rs
@@ -2,7 +2,7 @@
 use crate::{
     dtypes::*,
     shapes::{RemoveDimTo, ReplaceDimTo, Shape},
-    tensor::{launch_cfg, Cuda, Storage, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Storage, Tensor},
 };
 use cudarc::driver::{DeviceSlice, LaunchAsync};
 

--- a/dfdx-core/src/tensor_ops/select_and_gather/mod.rs
+++ b/dfdx-core/src/tensor_ops/select_and_gather/mod.rs
@@ -12,7 +12,7 @@ pub trait ReplaceDimKernel<E: Dtype>: Storage<E> + Storage<usize> {
         &self,
         inp: &Tensor<Src, E, Self>,
         idx: &Tensor<Idx, usize, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, E, Self>, Error>
     where
         Src: ReplaceDimTo<Dst, Idx>;
     fn backward<Src: Shape, Dst: Shape, Idx: Shape>(
@@ -22,7 +22,7 @@ pub trait ReplaceDimKernel<E: Dtype>: Storage<E> + Storage<usize> {
         idx: &Tensor<Idx, usize, Self>,
         out: &Tensor<Dst, E, Self>,
         grad_out: &<Self as Storage<E>>::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: ReplaceDimTo<Dst, Idx>;
 }
@@ -32,7 +32,7 @@ pub trait RemoveDimKernel<E: Dtype>: Storage<E> + Storage<usize> {
         &self,
         inp: &Tensor<Src, E, Self>,
         idx: &Tensor<Idx, usize, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, E, Self>, Error>
     where
         Src: RemoveDimTo<Dst, Idx>;
     fn backward<Src: Shape, Dst: Shape, Idx: Shape>(
@@ -42,7 +42,7 @@ pub trait RemoveDimKernel<E: Dtype>: Storage<E> + Storage<usize> {
         idx: &Tensor<Idx, usize, Self>,
         out: &Tensor<Dst, E, Self>,
         grad_out: &<Self as Storage<E>>::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: RemoveDimTo<Dst, Idx>;
 }
@@ -73,7 +73,7 @@ pub trait RemoveDimKernel<E: Dtype>: Storage<E> + Storage<usize> {
 /// let idx: Tensor<Rank1<3>, usize, _> = dev.tensor([0, 2, 4]);
 /// let _: Tensor<Rank1<3>, f32, _> = a.select(idx);
 ///```
-pub trait SelectTo<E, D: Storage<E> + Storage<usize>>: HasErr + HasShape {
+pub trait SelectTo<E, D: Storage<E> + Storage<usize>>: Sized + HasShape {
     /// Select values given indices.
     fn select<Dst: Shape, Idx: Shape>(self, idx: Tensor<Idx, usize, D>) -> Self::WithShape<Dst>
     where
@@ -86,7 +86,7 @@ pub trait SelectTo<E, D: Storage<E> + Storage<usize>>: HasErr + HasShape {
     fn try_select<Dst: Shape, Idx: Shape>(
         self,
         idx: Tensor<Idx, usize, D>,
-    ) -> Result<Self::WithShape<Dst>, Self::Err>
+    ) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: RemoveDimTo<Dst, Idx>;
 }
@@ -97,7 +97,7 @@ impl<Src: Shape, E: Dtype, D: RemoveDimKernel<E>, T: Tape<E, D>> SelectTo<E, D>
     fn try_select<Dst: Shape, Idx: Shape>(
         self,
         idx: Tensor<Idx, usize, D>,
-    ) -> Result<Self::WithShape<Dst>, Self::Err>
+    ) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: RemoveDimTo<Dst, Idx>,
     {
@@ -146,7 +146,7 @@ impl<Src: Shape, E: Dtype, D: RemoveDimKernel<E>, T: Tape<E, D>> SelectTo<E, D>
 /// let idx: Tensor<Rank2<3, 2>, usize, _> = dev.tensor([[0, 1], [2, 3], [4, 4]]);
 /// let _: Tensor<Rank2<3, 2>, f32, _> = a.gather(idx);
 ///```
-pub trait GatherTo<E, D: Storage<E> + Storage<usize>>: HasErr + HasShape {
+pub trait GatherTo<E, D: Storage<E> + Storage<usize>>: Sized + HasShape {
     /// Gather values given indices.
     fn gather<Dst: Shape, Idx: Shape>(self, idx: Tensor<Idx, usize, D>) -> Self::WithShape<Dst>
     where
@@ -158,7 +158,7 @@ pub trait GatherTo<E, D: Storage<E> + Storage<usize>>: HasErr + HasShape {
     fn try_gather<Dst: Shape, Idx: Shape>(
         self,
         idx: Tensor<Idx, usize, D>,
-    ) -> Result<Self::WithShape<Dst>, Self::Err>
+    ) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: ReplaceDimTo<Dst, Idx>;
 }
@@ -169,7 +169,7 @@ impl<Src: Shape, E: Dtype, D: ReplaceDimKernel<E>, T: Tape<E, D>> GatherTo<E, D>
     fn try_gather<Dst: Shape, Idx: Shape>(
         self,
         idx: Tensor<Idx, usize, D>,
-    ) -> Result<Self::WithShape<Dst>, Self::Err>
+    ) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: ReplaceDimTo<Dst, Idx>,
     {

--- a/dfdx-core/src/tensor_ops/sgd/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/sgd/cpu_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     dtypes::{Dtype, NotMixedPrecision},
-    tensor::cpu::*,
+    tensor::{cpu::*, Error},
 };
 
 use super::{Momentum, SgdConfig, SgdKernel, WeightDecay};
@@ -13,7 +13,7 @@ impl SgdKernel<crate::dtypes::AMP<crate::dtypes::f16>> for Cpu {
         param: &mut Self::Vec,
         velocity: &mut Self::Vec,
         grad: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let lr = cfg.lr as f32;
 
         for ((p, g), v) in param
@@ -62,7 +62,7 @@ impl<E: Dtype + NotMixedPrecision> SgdKernel<E> for Cpu {
         param: &mut Self::Vec,
         velocity: &mut Self::Vec,
         grad: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let lr = E::from_f64(cfg.lr).unwrap();
 
         for ((p, mut g), v) in param

--- a/dfdx-core/src/tensor_ops/sgd/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/sgd/cuda_kernel.rs
@@ -2,7 +2,7 @@ use super::SgdConfig;
 
 use crate::{
     dtypes::*,
-    tensor::{launch_cfg, Cuda},
+    tensor::{launch_cfg, Cuda, Error},
     tensor_ops::optim::*,
 };
 

--- a/dfdx-core/src/tensor_ops/sgd/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/sgd/cuda_kernel.rs
@@ -71,7 +71,7 @@ where
         param: &mut Self::Vec,
         velocity: &mut Self::Vec,
         grad: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         if !self.dev.has_func(Self::MOD, Self::FWD) {
             self.dev.load_ptx(PTX_SRC.into(), Self::MOD, &[Self::FWD])?;
         }

--- a/dfdx-core/src/tensor_ops/sgd/mod.rs
+++ b/dfdx-core/src/tensor_ops/sgd/mod.rs
@@ -5,7 +5,7 @@ mod cuda_kernel;
 
 use crate::{
     shapes::{Dtype, Shape},
-    tensor::{Storage, Tensor},
+    tensor::{Error, Storage, Tensor},
 };
 
 use super::optim::{Momentum, WeightDecay};
@@ -90,7 +90,7 @@ pub trait SgdKernel<E: Dtype>: Storage<E> {
         param: &mut Self::Vec,
         velocity: &mut Self::Vec,
         grad: &Self::Vec,
-    ) -> Result<(), Self::Err>;
+    ) -> Result<(), Error>;
 }
 
 impl SgdConfig {
@@ -100,7 +100,7 @@ impl SgdConfig {
         param: &mut Tensor<S, E, D>,
         velocity: &mut D::Vec,
         grad: &D::Vec,
-    ) -> Result<(), D::Err> {
+    ) -> Result<(), crate::tensor::Error> {
         param.device.sgd_kernel(
             self,
             std::sync::Arc::make_mut(&mut param.data),

--- a/dfdx-core/src/tensor_ops/sigmoid/mod.rs
+++ b/dfdx-core/src/tensor_ops/sigmoid/mod.rs
@@ -33,7 +33,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<SigmoidKernelOp, E>, T: Tape<E, D>> Tens
         self.try_sigmoid().unwrap()
     }
     /// See [sigmoid]
-    pub fn try_sigmoid(self) -> Result<Self, D::Err> {
+    pub fn try_sigmoid(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(SigmoidKernelOp, self)
     }
 }

--- a/dfdx-core/src/tensor_ops/sin/mod.rs
+++ b/dfdx-core/src/tensor_ops/sin/mod.rs
@@ -33,7 +33,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<SinKernelOp, E>, T: Tape<E, D>> Tensor<S
         self.try_sin().unwrap()
     }
     /// See [sin]
-    pub fn try_sin(self) -> Result<Self, D::Err> {
+    pub fn try_sin(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(SinKernelOp, self)
     }
 }

--- a/dfdx-core/src/tensor_ops/slice/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/slice/cpu_kernel.rs
@@ -7,7 +7,7 @@ impl<E: Unit> SliceKernel<E> for Cpu {
         &self,
         inp: &Tensor<Src, E, Self>,
         slice: &Slice,
-    ) -> Result<Tensor<Src::Sliced, E, Self>, Self::Err> {
+    ) -> Result<Tensor<Src::Sliced, E, Self>, Error> {
         let dst = inp.shape.slice(slice).unwrap();
         let mut out = self.try_zeros_like(&dst)?;
 
@@ -31,7 +31,7 @@ impl<E: Unit> SliceKernel<E> for Cpu {
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
         slice: &Slice,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let dst = inp.shape.slice(slice).unwrap();
 
         let mut inp_idx = NdIndex::new(dst, inp.strides);

--- a/dfdx-core/src/tensor_ops/slice/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/slice/cuda_kernel.rs
@@ -56,7 +56,7 @@ where
         &self,
         inp: &Tensor<Src, E, Self>,
         slice: &Slice,
-    ) -> Result<Tensor<Src::Sliced, E, Self>, Self::Err> {
+    ) -> Result<Tensor<Src::Sliced, E, Self>, Error> {
         if !self.dev.has_func(Self::MOD, Self::FNS[0]) {
             self.dev.load_ptx(PTX_SRC.into(), Self::MOD, Self::FNS)?;
         }
@@ -94,7 +94,7 @@ where
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
         slice: &Slice,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         if !self.dev.has_func(Self::MOD, Self::FNS[1]) {
             self.dev.load_ptx(PTX_SRC.into(), Self::MOD, Self::FNS)?;
         }

--- a/dfdx-core/src/tensor_ops/slice/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/slice/cuda_kernel.rs
@@ -2,7 +2,7 @@ use crate::{
     dtypes::*,
     prelude::cpu::NdIndex,
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Tensor},
 };
 use cudarc::driver::{CudaSlice, LaunchAsync};
 

--- a/dfdx-core/src/tensor_ops/slice/mod.rs
+++ b/dfdx-core/src/tensor_ops/slice/mod.rs
@@ -9,7 +9,7 @@ pub trait SliceKernel<E: Unit>: Storage<E> {
         &self,
         inp: &Tensor<Src, E, Self>,
         slice: &Slice,
-    ) -> Result<Tensor<Src::Sliced, E, Self>, Self::Err>;
+    ) -> Result<Tensor<Src::Sliced, E, Self>, Error>;
 
     fn backward<Src: Shape + SliceShape<Slice>, Slice>(
         &self,
@@ -17,7 +17,7 @@ pub trait SliceKernel<E: Unit>: Storage<E> {
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
         slice: &Slice,
-    ) -> Result<(), Self::Err>;
+    ) -> Result<(), Error>;
 }
 
 /// Slices all dimensions of a tensor, with the starting and ending indices of each dimension
@@ -53,7 +53,10 @@ pub fn slice<S: SliceShape<Slice>, E: Unit, D: SliceKernel<E>, T: Tape<E, D>, Sl
 
 impl<S: Shape, E: Unit, D: SliceKernel<E>, T: Tape<E, D>> Tensor<S, E, D, T> {
     /// Fallible version of [Tensor::slice]
-    pub fn try_slice<Slice>(self, slice: Slice) -> Result<Tensor<S::Sliced, E, D, T>, D::Err>
+    pub fn try_slice<Slice>(
+        self,
+        slice: Slice,
+    ) -> Result<Tensor<S::Sliced, E, D, T>, crate::tensor::Error>
     where
         S: SliceShape<Slice>,
         Slice: 'static,

--- a/dfdx-core/src/tensor_ops/softmax.rs
+++ b/dfdx-core/src/tensor_ops/softmax.rs
@@ -33,7 +33,7 @@ impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Tensor<S, E, D, T> {
         self.try_softmax::<Ax>().unwrap()
     }
     /// See [softmax()]
-    pub fn try_softmax<Ax: Axes>(self) -> Result<Self, D::Err>
+    pub fn try_softmax<Ax: Axes>(self) -> Result<Self, crate::tensor::Error>
     where
         S: ReduceShape<Ax>,
     {

--- a/dfdx-core/src/tensor_ops/sqrt/mod.rs
+++ b/dfdx-core/src/tensor_ops/sqrt/mod.rs
@@ -33,7 +33,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<SqrtKernelOp, E>, T: Tape<E, D>> Tensor<
         self.try_sqrt().unwrap()
     }
     /// See [sqrt]
-    pub fn try_sqrt(self) -> Result<Self, D::Err> {
+    pub fn try_sqrt(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(SqrtKernelOp, self)
     }
 }

--- a/dfdx-core/src/tensor_ops/square/mod.rs
+++ b/dfdx-core/src/tensor_ops/square/mod.rs
@@ -33,7 +33,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<SquareKernelOp, E>, T: Tape<E, D>> Tenso
         self.try_square().unwrap()
     }
     /// See [square]
-    pub fn try_square(self) -> Result<Self, D::Err> {
+    pub fn try_square(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(SquareKernelOp, self)
     }
 }

--- a/dfdx-core/src/tensor_ops/stack/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/stack/cpu_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::*,
-    tensor::{unique_id, Cpu, Tensor},
+    tensor::{unique_id, Cpu, Error, Tensor},
 };
 
 use std::vec::Vec;
@@ -10,7 +10,7 @@ impl<E: Dtype> super::StackKernel<E> for Cpu {
         &self,
         num: Num,
         inp: &[Tensor<S, E, Self>],
-    ) -> Result<Tensor<S::Larger, E, Self>, Self::Err>
+    ) -> Result<Tensor<S::Larger, E, Self>, Error>
     where
         S: super::AddDim<Num>,
     {
@@ -52,7 +52,7 @@ impl<E: Dtype> super::StackKernel<E> for Cpu {
         &self,
         mut grad_inp: Vec<&mut Self::Vec>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let mut offset = 0;
         for item in grad_inp.drain(..) {
             for gi in item.iter_mut() {

--- a/dfdx-core/src/tensor_ops/stack/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/stack/cuda_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Tensor},
 };
 use cudarc::{
     driver::{DeviceSlice, LaunchAsync},

--- a/dfdx-core/src/tensor_ops/stack/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/stack/cuda_kernel.rs
@@ -14,7 +14,7 @@ impl<E: Dtype + CudaTypeName> super::StackKernel<E> for Cuda {
         &self,
         num: Num,
         inps: &[Tensor<S, E, Self>],
-    ) -> Result<Tensor<S::Larger, E, Self>, Self::Err>
+    ) -> Result<Tensor<S::Larger, E, Self>, Error>
     where
         S: super::AddDim<Num>,
     {
@@ -54,7 +54,7 @@ impl<E: Dtype + CudaTypeName> super::StackKernel<E> for Cuda {
         &self,
         mut grad_inp: Vec<&mut Self::Vec>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let module_name = std::format!("stack_bwd_{}", E::NAME);
         if !self.dev.has_func(&module_name, "stack_bwd") {
             let src = BWD_KERNEL.replace("$Ty", E::NAME);

--- a/dfdx-core/src/tensor_ops/stddev_to.rs
+++ b/dfdx-core/src/tensor_ops/stddev_to.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{shapes::*, tensor::*};
 
 /// Reduction along multiple axes using standard deviation.
-pub trait StddevTo<E: Dtype>: HasErr + HasShape {
+pub trait StddevTo<E: Dtype>: Sized + HasShape {
     /// Standard deviation reduction.
     ///
     /// **Pytorch equivalent**: `t.std(Axes, unbiased=False)`
@@ -25,7 +25,7 @@ pub trait StddevTo<E: Dtype>: HasErr + HasShape {
     fn try_stddev<Dst: Shape, Ax: Axes>(
         self,
         epsilon: impl Into<f64>,
-    ) -> Result<Self::WithShape<Dst>, Self::Err>
+    ) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: HasAxes<Ax> + ReduceShapeTo<Dst, Ax>;
 }
@@ -34,7 +34,7 @@ impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> StddevTo<E> for Tensor<S, 
     fn try_stddev<Dst: Shape, Ax: Axes>(
         self,
         epsilon: impl Into<f64>,
-    ) -> Result<Self::WithShape<Dst>, Self::Err>
+    ) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: HasAxes<Ax> + ReduceShapeTo<Dst, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/sub/mod.rs
+++ b/dfdx-core/src/tensor_ops/sub/mod.rs
@@ -47,9 +47,9 @@ where
 }
 
 /// Fallible version of [std::ops::Sub]. See [sub]
-pub trait TrySub<Rhs = Self>: HasErr {
+pub trait TrySub<Rhs = Self> {
     type Output;
-    fn try_sub(self, rhs: Rhs) -> Result<Self::Output, Self::Err>;
+    fn try_sub(self, rhs: Rhs) -> Result<Self::Output, Error>;
 }
 
 impl<S: Shape, E: Dtype, D: BinaryKernel<BinarySubKernelOp, E>, LTape: Tape<E, D>, R>
@@ -58,7 +58,7 @@ where
     LTape: Merge<R>,
 {
     type Output = Self;
-    fn try_sub(self, rhs: Tensor<S, E, D, R>) -> Result<Self, Self::Err> {
+    fn try_sub(self, rhs: Tensor<S, E, D, R>) -> Result<Self, Error> {
         try_binary_op(BinarySubKernelOp, self, rhs)
     }
 }
@@ -68,7 +68,7 @@ where
     D: UnaryKernel<ScalarSubKernelOp<E>, E>,
 {
     type Output = Self;
-    fn try_sub(self, rhs: Rhs) -> Result<Self, Self::Err> {
+    fn try_sub(self, rhs: Rhs) -> Result<Self, Error> {
         let rhs: f64 = rhs.into();
         let scalar = E::from_f64(rhs).unwrap();
         try_unary_op(ScalarSubKernelOp { scalar }, self)

--- a/dfdx-core/src/tensor_ops/sum_to/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/sum_to/cpu_kernel.rs
@@ -1,7 +1,7 @@
 use crate::{
     dtypes::{Dtype, NotMixedPrecision},
     shapes::{Axes, HasAxes, ReduceShapeTo, Shape},
-    tensor::{Cpu, Tensor, Tensorlike, ZerosTensor},
+    tensor::{Cpu, Error, Tensor, Tensorlike, ZerosTensor},
     tensor_ops::utilities::reduction_utils::index_for_reductions,
 };
 
@@ -11,7 +11,7 @@ impl super::SumKernel<crate::dtypes::AMP<crate::dtypes::f16>> for Cpu {
         &self,
         dst: Dst,
         inp: &Tensor<Src, crate::dtypes::AMP<crate::dtypes::f16>, Self>,
-    ) -> Result<Tensor<Dst, crate::dtypes::AMP<crate::dtypes::f16>, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, crate::dtypes::AMP<crate::dtypes::f16>, Self>, Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {
@@ -46,7 +46,7 @@ impl super::SumKernel<crate::dtypes::AMP<crate::dtypes::f16>> for Cpu {
         inp: &impl Tensorlike<Src, crate::dtypes::AMP<crate::dtypes::f16>, Self>,
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {
@@ -75,7 +75,7 @@ impl<E: Dtype + NotMixedPrecision> super::SumKernel<E> for Cpu {
         &self,
         dst: Dst,
         inp: &Tensor<Src, E, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, E, Self>, Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {
@@ -108,7 +108,7 @@ impl<E: Dtype + NotMixedPrecision> super::SumKernel<E> for Cpu {
         inp: &impl Tensorlike<Src, E, Self>,
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/sum_to/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/sum_to/cuda_kernel.rs
@@ -46,7 +46,7 @@ where
         &self,
         dst: Dst,
         inp: &Tensor<Src, E, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, E, Self>, Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {
@@ -99,7 +99,7 @@ where
         inp: &impl Tensorlike<Src, E, Self>,
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: ReduceShapeTo<Dst, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/sum_to/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/sum_to/cuda_kernel.rs
@@ -1,7 +1,7 @@
 use crate::{
     dtypes::*,
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor, Tensorlike},
+    tensor::{launch_cfg, Cuda, Error, Tensor, Tensorlike},
     tensor_ops::reduction_utils::*,
 };
 

--- a/dfdx-core/src/tensor_ops/sum_to/mod.rs
+++ b/dfdx-core/src/tensor_ops/sum_to/mod.rs
@@ -10,7 +10,7 @@ pub trait SumKernel<E: Dtype>: Storage<E> {
         &self,
         dst: Dst,
         inp: &Tensor<Src, E, Self>,
-    ) -> Result<Tensor<Dst, E, Self>, Self::Err>
+    ) -> Result<Tensor<Dst, E, Self>, Error>
     where
         Src: ReduceShapeTo<Dst, Ax>;
     fn backward<Src: Shape, Dst: Shape, Ax: Axes>(
@@ -19,13 +19,13 @@ pub trait SumKernel<E: Dtype>: Storage<E> {
         inp: &impl Tensorlike<Src, E, Self>,
         grad_inp: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err>
+    ) -> Result<(), Error>
     where
         Src: ReduceShapeTo<Dst, Ax>;
 }
 
 /// Reduction along multiple axes using `sum`.
-pub trait SumTo: HasErr + HasShape {
+pub trait SumTo: Sized + HasShape {
     /// Sum reduction. **Pytorch equivalent**: `t.sum(Ax)`
     ///
     /// Example reducing a single axis:
@@ -52,13 +52,13 @@ pub trait SumTo: HasErr + HasShape {
         self.try_sum().unwrap()
     }
     /// Fallible version of [SumTo::sum]
-    fn try_sum<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_sum<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: ReduceShapeTo<Dst, Ax>;
 }
 
 impl<S: Shape, E: Dtype, D: SumKernel<E>, T: Tape<E, D>> SumTo for Tensor<S, E, D, T> {
-    fn try_sum<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_sum<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: ReduceShapeTo<Dst, Ax>,
     {

--- a/dfdx-core/src/tensor_ops/tanh/mod.rs
+++ b/dfdx-core/src/tensor_ops/tanh/mod.rs
@@ -33,7 +33,7 @@ impl<S: Shape, E: Dtype, D: UnaryKernel<TanhKernelOp, E>, T: Tape<E, D>> Tensor<
         self.try_tanh().unwrap()
     }
     /// See [tanh]
-    pub fn try_tanh(self) -> Result<Self, D::Err> {
+    pub fn try_tanh(self) -> Result<Self, crate::tensor::Error> {
         try_unary_op(TanhKernelOp, self)
     }
 }

--- a/dfdx-core/src/tensor_ops/to_dtype/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/to_dtype/cpu_kernel.rs
@@ -1,10 +1,10 @@
 use num_traits::AsPrimitive;
 use std::{sync::Arc, vec::Vec};
 
-use crate::prelude::{cpu::CachableVec, Cpu, Shape, Tensor, Unit};
+use crate::prelude::{cpu::CachableVec, Cpu, Error, Shape, Tensor, Unit};
 
 impl<E1: Unit + AsPrimitive<E2>, E2: Unit> super::ToDtypeKernel<E1, E2> for Cpu {
-    fn forward<S: Shape>(inp: Tensor<S, E1, Self>) -> Result<Tensor<S, E2, Self>, Self::Err> {
+    fn forward<S: Shape>(inp: Tensor<S, E1, Self>) -> Result<Tensor<S, E2, Self>, Error> {
         let data: &[E1] = inp.data.as_ref();
         let data: Vec<E2> = data.iter().map(|x| (*x).as_()).collect();
         let data = CachableVec {

--- a/dfdx-core/src/tensor_ops/to_dtype/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/to_dtype/cuda_kernel.rs
@@ -22,7 +22,7 @@ extern \"C\" __global__ void kernel(const size_t n, const $Src *inp, $Dst *out) 
 }";
 
 impl<E1: Unit + CudaTypeName, E2: Unit + CudaTypeName> super::ToDtypeKernel<E1, E2> for Cuda {
-    fn forward<S: Shape>(inp: Tensor<S, E1, Self>) -> Result<Tensor<S, E2, Self>, Self::Err> {
+    fn forward<S: Shape>(inp: Tensor<S, E1, Self>) -> Result<Tensor<S, E2, Self>, Error> {
         let module = std::format!("convert_{}_to_{}", E1::NAME, E2::NAME);
         let cuda = &inp.device;
 

--- a/dfdx-core/src/tensor_ops/to_dtype/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/to_dtype/cuda_kernel.rs
@@ -1,6 +1,6 @@
 use crate::{
     shapes::{Shape, Unit},
-    tensor::{launch_cfg, Cuda, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Tensor},
 };
 use cudarc::{
     driver::{DeviceSlice, LaunchAsync},

--- a/dfdx-core/src/tensor_ops/to_dtype/mod.rs
+++ b/dfdx-core/src/tensor_ops/to_dtype/mod.rs
@@ -2,10 +2,10 @@ mod cpu_kernel;
 #[cfg(feature = "cuda")]
 mod cuda_kernel;
 
-use crate::prelude::{Shape, Storage, Tensor, Unit};
+use crate::prelude::{Error, Shape, Storage, Tensor, Unit};
 
 pub trait ToDtypeKernel<E1: Unit, E2: Unit>: Storage<E1> + Storage<E2> {
-    fn forward<S: Shape>(inp: Tensor<S, E1, Self>) -> Result<Tensor<S, E2, Self>, Self::Err>;
+    fn forward<S: Shape>(inp: Tensor<S, E1, Self>) -> Result<Tensor<S, E2, Self>, Error>;
 }
 
 /// Copies the elements of a tensor, converting its data to a different dtype.
@@ -29,7 +29,7 @@ pub fn to_dtype<E2: Unit, S: Shape, E1: Unit, D: ToDtypeKernel<E1, E2>>(
 }
 
 impl<S: Shape, E: Unit, D: Storage<E>> Tensor<S, E, D> {
-    pub fn try_to_dtype<E2: Unit>(self) -> Result<Tensor<S, E2, D>, D::Err>
+    pub fn try_to_dtype<E2: Unit>(self) -> Result<Tensor<S, E2, D>, crate::tensor::Error>
     where
         D: ToDtypeKernel<E, E2>,
     {

--- a/dfdx-core/src/tensor_ops/tri.rs
+++ b/dfdx-core/src/tensor_ops/tri.rs
@@ -1,5 +1,5 @@
 use crate::shapes::{Dtype, Shape};
-use crate::tensor::{HasErr, Tape, Tensor, TriangleTensor};
+use crate::tensor::{Error, Tape, Tensor, TriangleTensor};
 
 use super::TryMul;
 
@@ -11,7 +11,7 @@ pub fn lower_tri<S: Shape, E: Dtype, D: TriangleTensor<E>, T: Tape<E, D>>(
     diagonal: impl Into<Option<isize>>,
 ) -> Tensor<S, E, D, T>
 where
-    Tensor<S, E, D, T>: TryMul<Tensor<S, E, D>, Output = Tensor<S, E, D, T>> + HasErr<Err = D::Err>,
+    Tensor<S, E, D, T>: TryMul<Tensor<S, E, D>, Output = Tensor<S, E, D, T>>,
 {
     t.lower_tri(diagonal)
 }
@@ -24,20 +24,17 @@ pub fn upper_tri<S: Shape, E: Dtype, D: TriangleTensor<E>, T: Tape<E, D>>(
     diagonal: impl Into<Option<isize>>,
 ) -> Tensor<S, E, D, T>
 where
-    Tensor<S, E, D, T>: TryMul<Tensor<S, E, D>, Output = Tensor<S, E, D, T>> + HasErr<Err = D::Err>,
+    Tensor<S, E, D, T>: TryMul<Tensor<S, E, D>, Output = Tensor<S, E, D, T>>,
 {
     t.upper_tri(diagonal)
 }
 
 impl<S: Shape, E: Dtype, D: TriangleTensor<E>, T: Tape<E, D>> Tensor<S, E, D, T>
 where
-    Self: TryMul<Tensor<S, E, D>, Output = Self> + HasErr<Err = D::Err>,
+    Self: TryMul<Tensor<S, E, D>, Output = Self>,
 {
     /// See [lower_tri]
-    pub fn try_lower_tri(
-        self,
-        diagonal: impl Into<Option<isize>>,
-    ) -> Result<Self, <Self as HasErr>::Err> {
+    pub fn try_lower_tri(self, diagonal: impl Into<Option<isize>>) -> Result<Self, Error> {
         let out = self
             .device
             .try_lower_tri_like(&self.shape, E::ONE, diagonal)?;
@@ -50,10 +47,7 @@ where
     }
 
     /// See [upper_tri]
-    pub fn try_upper_tri(
-        self,
-        diagonal: impl Into<Option<isize>>,
-    ) -> Result<Self, <Self as HasErr>::Err> {
+    pub fn try_upper_tri(self, diagonal: impl Into<Option<isize>>) -> Result<Self, Error> {
         let out = self
             .device
             .try_upper_tri_like(&self.shape, E::ONE, diagonal)?;

--- a/dfdx-core/src/tensor_ops/upscale2d/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/upscale2d/cpu_kernel.rs
@@ -1,5 +1,5 @@
 use crate::shapes::*;
-use crate::tensor::{Cpu, Tensor};
+use crate::tensor::{Cpu, Error, Tensor};
 
 use std::sync::Arc;
 
@@ -23,7 +23,7 @@ impl<E: Float + Unit + std::ops::AddAssign + std::ops::DivAssign>
         op: super::Upscale2DOp,
         inp: &Tensor<I, E, Self>,
         out: &mut Tensor<O, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let istr = make_4d::<I>(inp.strides);
         let ostr = make_4d::<O>(out.strides);
 
@@ -56,7 +56,7 @@ impl<E: Float + Unit + std::ops::AddAssign + std::ops::DivAssign>
         grad_inp: &mut Self::Vec,
         out: &Tensor<O, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let istr = make_4d::<I>(inp.strides);
         let ostr = make_4d::<O>(out.strides);
 
@@ -87,7 +87,7 @@ impl<E: Float + Dtype> super::Upscale2DKernel<E, Bilinear> for Cpu {
         op: super::Upscale2DOp,
         inp: &Tensor<I, E, Self>,
         out: &mut Tensor<O, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let istr = make_4d::<I>(inp.strides);
         let ostr = make_4d::<O>(out.strides);
 
@@ -138,7 +138,7 @@ impl<E: Float + Dtype> super::Upscale2DKernel<E, Bilinear> for Cpu {
         grad_inp: &mut Self::Vec,
         out: &Tensor<O, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let istr = make_4d::<I>(inp.strides);
         let ostr = make_4d::<O>(out.strides);
 

--- a/dfdx-core/src/tensor_ops/upscale2d/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/upscale2d/cuda_kernel.rs
@@ -71,7 +71,7 @@ where
         op: super::Upscale2DOp,
         inp: &Tensor<I, E, Self>,
         out: &mut Tensor<O, E, Self>,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         if !self.dev.has_func(Self::FWD, Self::FWD) {
             self.dev
                 .load_ptx(PTX_SRC.into(), Self::FWD, &[Self::FWD, Self::BWD])?;
@@ -96,7 +96,7 @@ where
         grad_inp: &mut Self::Vec,
         out: &Tensor<O, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let strides = self.dev.htod_copy(make_4d::<I>(inp.strides).into())?;
         let bwd_fn = self.dev.get_func(Self::FWD, Self::BWD).unwrap();
         let cfg = launch_cfg::<128>(out.shape().num_elements() as u32);

--- a/dfdx-core/src/tensor_ops/upscale2d/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/upscale2d/cuda_kernel.rs
@@ -1,7 +1,7 @@
 use crate::{
     dtypes::*,
     shapes::*,
-    tensor::{launch_cfg, Cuda, Tensor},
+    tensor::{launch_cfg, Cuda, Error, Tensor},
 };
 
 use std::sync::Arc;

--- a/dfdx-core/src/tensor_ops/utilities/cpu_kernels.rs
+++ b/dfdx-core/src/tensor_ops/utilities/cpu_kernels.rs
@@ -5,7 +5,7 @@ use crate::{
     shapes::{Dtype, Shape},
     tensor::{
         cpu::{Cpu, LendingIterator, NdIndex},
-        unique_id, Tensor, Tensorlike, ZerosTensor,
+        unique_id, Error, Tensor, Tensorlike, ZerosTensor,
     },
 };
 
@@ -51,7 +51,7 @@ impl<E: Dtype, Op: UnaryDerivative<E>> UnaryKernel<Op, E> for Cpu {
         &self,
         op: Op,
         inp: Cow<Tensor<S, E, Self>>,
-    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         let mut out = match inp {
             Cow::Borrowed(inp) => {
                 // allocate a new data buffer
@@ -84,7 +84,7 @@ impl<E: Dtype, Op: UnaryDerivative<E>> UnaryKernel<Op, E> for Cpu {
         grad_inp: &mut Self::Vec,
         out: &impl Tensorlike<S, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         match (inp.data(), out.data()) {
             (None, None) => {
                 let df = op.const_df();
@@ -115,7 +115,7 @@ impl<E: Dtype, Op: BinaryDerivative<E>> BinaryKernel<Op, E> for Cpu {
         op: Op,
         lhs: Cow<Tensor<S, E, Self>>,
         rhs: Cow<Tensor<S, E, Self>>,
-    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         match (lhs, rhs) {
             (Cow::Borrowed(lhs), Cow::Borrowed(rhs)) => {
                 let mut out = self.try_zeros_like(&lhs.shape)?;
@@ -169,7 +169,7 @@ impl<E: Dtype, Op: BinaryDerivative<E>> BinaryKernel<Op, E> for Cpu {
         rhs: &impl Tensorlike<S, E, Self>,
         grad_rhs: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         match (lhs.data(), rhs.data()) {
             (Some(lhs_buf), Some(rhs_buf)) => {
                 let mut lhs_idx = NdIndex::new(*lhs.shape(), lhs.strides());

--- a/dfdx-core/src/tensor_ops/utilities/cuda_kernels.rs
+++ b/dfdx-core/src/tensor_ops/utilities/cuda_kernels.rs
@@ -67,7 +67,7 @@ impl<E: Dtype, K: UnaryOpCudaKernel<E> + DeviceRepr> UnaryKernel<K, E> for Cuda 
         &self,
         op: K,
         inp: Cow<Tensor<S, E, Self>>,
-    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         if !self.dev.has_func(K::MODULE_NAME, K::FWD_FN_NAME) {
             self.dev
                 .load_ptx(K::PTX_SRC.into(), K::MODULE_NAME, &K::ALL_FN_NAMES)?;
@@ -103,7 +103,7 @@ impl<E: Dtype, K: UnaryOpCudaKernel<E> + DeviceRepr> UnaryKernel<K, E> for Cuda 
         grad_inp: &mut Self::Vec,
         out: &impl Tensorlike<S, E, Self>,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let bwd_fn = self.dev.get_func(K::MODULE_NAME, K::BWD_FN_NAME).unwrap();
         match (inp.data(), out.data()) {
             (None, None) => {
@@ -219,7 +219,7 @@ impl<E: Dtype, K: BinaryOpCudaKernel<E> + DeviceRepr + Clone> BinaryKernel<K, E>
         op: K,
         lhs: Cow<Tensor<S, E, Self>>,
         rhs: Cow<Tensor<S, E, Self>>,
-    ) -> Result<Tensor<S, E, Self>, Self::Err> {
+    ) -> Result<Tensor<S, E, Self>, Error> {
         if !self.dev.has_func(K::MODULE_NAME, K::FWD_FN_NAME) {
             self.dev
                 .load_ptx(K::PTX_SRC.into(), K::MODULE_NAME, &K::ALL_FN_NAMES)?;
@@ -326,7 +326,7 @@ impl<E: Dtype, K: BinaryOpCudaKernel<E> + DeviceRepr + Clone> BinaryKernel<K, E>
         rhs: &impl Tensorlike<S, E, Self>,
         grad_rhs: &mut Self::Vec,
         grad_out: &Self::Vec,
-    ) -> Result<(), Self::Err> {
+    ) -> Result<(), Error> {
         let bwd_lhs_fn = self
             .dev
             .get_func(K::MODULE_NAME, K::BWD_LHS_FN_NAME)

--- a/dfdx-core/src/tensor_ops/var_to.rs
+++ b/dfdx-core/src/tensor_ops/var_to.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{shapes::*, tensor::*};
 
 /// Reduction alogn multiple axes using variance
-pub trait VarTo: HasErr + HasShape {
+pub trait VarTo: Sized + HasShape {
     /// Result [Tensor] has smaller number of dimensions.
     ///
     /// **Pytorch equivalent**: `t.var(Axes, unbiased=False)`
@@ -22,13 +22,13 @@ pub trait VarTo: HasErr + HasShape {
         self.try_var().unwrap()
     }
     /// Fallible version of [VarTo::var]
-    fn try_var<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_var<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: HasAxes<Ax> + ReduceShapeTo<Dst, Ax>;
 }
 
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> VarTo for Tensor<S, E, D, T> {
-    fn try_var<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Self::Err>
+    fn try_var<Dst: Shape, Ax: Axes>(self) -> Result<Self::WithShape<Dst>, Error>
     where
         Self::Shape: HasAxes<Ax> + ReduceShapeTo<Dst, Ax>,
     {

--- a/dfdx/examples/advanced-train-loop.rs
+++ b/dfdx/examples/advanced-train-loop.rs
@@ -12,7 +12,7 @@ fn classification_train<
     Lbl,
     // Our model just needs to implement these two things! ModuleMut for forward
     // and TensorCollection for optimizer/alloc_grads/zero_grads
-    Model: Module<Inp::Traced, Error = crate::tensor::Error> + ZeroGrads<E, D> + UpdateParams<E, D>,
+    Model: Module<Inp::Traced> + ZeroGrads<E, D> + UpdateParams<E, D>,
     // optimizer, pretty straight forward
     Opt: Optimizer<Model, E, D>,
     // our data will just be any iterator over these items. easy!
@@ -22,7 +22,7 @@ fn classification_train<
     Criterion: FnMut(Model::Output, Lbl) -> Loss,
     // the Loss needs to be able to call backward, and we also use
     // this generic as an output
-    Loss: Backward<E, D, Err = crate::tensor::Error> + AsArray<Array = E>,
+    Loss: Backward<E, D> + AsArray<Array = E>,
     // Dtype & Device to tie everything together
     E: Dtype,
     D: Device<E>,
@@ -32,7 +32,7 @@ fn classification_train<
     mut criterion: Criterion,
     data: Data,
     batch_accum: usize,
-) -> Result<(), crate::tensor::Error> {
+) -> Result<(), Error> {
     let mut grads = model.try_alloc_grads()?;
     for (i, (inp, lbl)) in data.enumerate() {
         let y = model.try_forward_mut(inp.traced(grads))?;

--- a/dfdx/examples/advanced-train-loop.rs
+++ b/dfdx/examples/advanced-train-loop.rs
@@ -12,7 +12,7 @@ fn classification_train<
     Lbl,
     // Our model just needs to implement these two things! ModuleMut for forward
     // and TensorCollection for optimizer/alloc_grads/zero_grads
-    Model: Module<Inp::Traced, Error = D::Err> + ZeroGrads<E, D> + UpdateParams<E, D>,
+    Model: Module<Inp::Traced, Error = crate::tensor::Error> + ZeroGrads<E, D> + UpdateParams<E, D>,
     // optimizer, pretty straight forward
     Opt: Optimizer<Model, E, D>,
     // our data will just be any iterator over these items. easy!
@@ -22,7 +22,7 @@ fn classification_train<
     Criterion: FnMut(Model::Output, Lbl) -> Loss,
     // the Loss needs to be able to call backward, and we also use
     // this generic as an output
-    Loss: Backward<E, D, Err = D::Err> + AsArray<Array = E>,
+    Loss: Backward<E, D, Err = crate::tensor::Error> + AsArray<Array = E>,
     // Dtype & Device to tie everything together
     E: Dtype,
     D: Device<E>,
@@ -32,7 +32,7 @@ fn classification_train<
     mut criterion: Criterion,
     data: Data,
     batch_accum: usize,
-) -> Result<(), D::Err> {
+) -> Result<(), crate::tensor::Error> {
     let mut grads = model.try_alloc_grads()?;
     for (i, (inp, lbl)) in data.enumerate() {
         let y = model.try_forward_mut(inp.traced(grads))?;

--- a/dfdx/src/nn/layers/abs.rs
+++ b/dfdx/src/nn/layers/abs.rs
@@ -7,8 +7,7 @@ impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> crate::nn::Module<Tensor<S
     for Abs
 {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_abs()
     }
 }

--- a/dfdx/src/nn/layers/bias1d.rs
+++ b/dfdx/src/nn/layers/bias1d.rs
@@ -28,7 +28,7 @@ pub type Bias1DConstConfig<const I: usize> = Bias1DConfig<Const<I>>;
 
 impl<I: Dim, E: Dtype, D: Device<E>> BuildOnDevice<E, D> for Bias1DConfig<I> {
     type Built = Bias1D<I, E, D>;
-    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, D::Err> {
+    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, crate::tensor::Error> {
         Ok(Bias1D {
             bias: device.try_zeros_like(&(self.0,))?,
         })
@@ -44,7 +44,7 @@ pub struct Bias1D<I: Dim, Elem: Dtype, Dev: Device<Elem>> {
 }
 
 impl<I: Dim, E: Dtype, D: Device<E>> ResetParams<E, D> for Bias1D<I, E, D> {
-    fn try_reset_params(&mut self) -> Result<(), D::Err> {
+    fn try_reset_params(&mut self) -> Result<(), crate::tensor::Error> {
         self.bias.try_fill_with_zeros()
     }
 }
@@ -53,8 +53,7 @@ impl<I: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<(I,), E, D, T>
     for Bias1D<I, E, D>
 {
     type Output = Tensor<(I,), E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<(I,), E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<(I,), E, D, T>) -> Result<Self::Output, Error> {
         x.try_add(self.bias.clone())
     }
 }
@@ -63,8 +62,7 @@ impl<Batch: Dim, I: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<(B
     for Bias1D<I, E, D>
 {
     type Output = Tensor<(Batch, I), E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<(Batch, I), E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<(Batch, I), E, D, T>) -> Result<Self::Output, Error> {
         self.bias.retaped::<T>().broadcast_like(&x).try_add(x)
     }
 }
@@ -73,11 +71,7 @@ impl<Batch: Dim, Seq: Dim, I: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>>
     Module<Tensor<(Batch, Seq, I), E, D, T>> for Bias1D<I, E, D>
 {
     type Output = Tensor<(Batch, Seq, I), E, D, T>;
-    type Error = D::Err;
-    fn try_forward(
-        &self,
-        x: Tensor<(Batch, Seq, I), E, D, T>,
-    ) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<(Batch, Seq, I), E, D, T>) -> Result<Self::Output, Error> {
         self.bias.retaped::<T>().broadcast_like(&x).try_add(x)
     }
 }

--- a/dfdx/src/nn/layers/bias2d.rs
+++ b/dfdx/src/nn/layers/bias2d.rs
@@ -28,7 +28,7 @@ pub type Bias2DConstConfig<const C: usize> = Bias2DConfig<Const<C>>;
 
 impl<C: Dim, E: Dtype, D: Device<E>> BuildOnDevice<E, D> for Bias2DConfig<C> {
     type Built = Bias2D<C, E, D>;
-    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, D::Err> {
+    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, crate::tensor::Error> {
         Ok(Bias2D {
             bias: device.try_zeros_like(&(self.0,))?,
         })
@@ -44,7 +44,7 @@ pub struct Bias2D<C: Dim, Elem: Dtype, Dev: Device<Elem>> {
 }
 
 impl<C: Dim, E: Dtype, D: Device<E>> ResetParams<E, D> for Bias2D<C, E, D> {
-    fn try_reset_params(&mut self) -> Result<(), D::Err> {
+    fn try_reset_params(&mut self) -> Result<(), crate::tensor::Error> {
         self.bias.try_fill_with_zeros()
     }
 }
@@ -53,8 +53,7 @@ impl<C: Dim, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>>
     Module<Tensor<(C, H, W), E, D, T>> for Bias2D<C, E, D>
 {
     type Output = Tensor<(C, H, W), E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<(C, H, W), E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<(C, H, W), E, D, T>) -> Result<Self::Output, Error> {
         self.bias.retaped::<T>().broadcast_like(&x).try_add(x)
     }
 }
@@ -63,8 +62,7 @@ impl<B: Dim, C: Dim, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>>
     Module<Tensor<(B, C, H, W), E, D, T>> for Bias2D<C, E, D>
 {
     type Output = Tensor<(B, C, H, W), E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<(B, C, H, W), E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<(B, C, H, W), E, D, T>) -> Result<Self::Output, Error> {
         self.bias.retaped::<T>().broadcast_like(&x).try_add(x)
     }
 }

--- a/dfdx/src/nn/layers/conv1d.rs
+++ b/dfdx/src/nn/layers/conv1d.rs
@@ -62,7 +62,7 @@ where
     <I as std::ops::Div<G>>::Output: Dim,
 {
     type Built = Conv1D<I, O, K, S, P, L, G, E, D>;
-    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, <D>::Err> {
+    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, crate::tensor::Error> {
         assert_eq!(self.in_chan.size() % self.groups.size(), 0);
         assert_eq!(self.out_chan.size() % self.groups.size(), 0);
         let i_over_g = self.in_chan / self.groups;
@@ -119,7 +119,7 @@ where
     E: Dtype + num_traits::Float + rand_distr::uniform::SampleUniform,
     D: Device<E>,
 {
-    fn try_reset_params(&mut self) -> Result<(), D::Err> {
+    fn try_reset_params(&mut self) -> Result<(), crate::tensor::Error> {
         let (_, i_over_g, k) = self.weight.shape();
         let scale = (1.0 / (k.size() * i_over_g.size()) as f64).sqrt();
         let b = E::from_f64(scale).unwrap();
@@ -143,14 +143,7 @@ where
         L,
         G,
     >>::Convolved;
-    type Error = <(Img, Tensor<(O, <I as std::ops::Div<G>>::Output, K), E, D>) as TryConv1D<
-        S,
-        P,
-        L,
-        G,
-    >>::Error;
-
-    fn try_forward(&self, x: Img) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Img) -> Result<Self::Output, Error> {
         (x, self.weight.clone()).try_conv1d(self.stride, self.padding, self.dilation, self.groups)
     }
 }

--- a/dfdx/src/nn/layers/conv2d.rs
+++ b/dfdx/src/nn/layers/conv2d.rs
@@ -78,7 +78,7 @@ where
     <I as std::ops::Div<G>>::Output: Dim,
 {
     type Built = Conv2D<I, O, K, S, P, L, G, E, D>;
-    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, <D>::Err> {
+    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, crate::tensor::Error> {
         assert_eq!(self.in_chan.size() % self.groups.size(), 0);
         assert_eq!(self.out_chan.size() % self.groups.size(), 0);
         let i_over_g = self.in_chan / self.groups;
@@ -141,7 +141,7 @@ where
     E: Dtype + num_traits::Float + rand_distr::uniform::SampleUniform,
     D: Device<E>,
 {
-    fn try_reset_params(&mut self) -> Result<(), D::Err> {
+    fn try_reset_params(&mut self) -> Result<(), crate::tensor::Error> {
         let (_, i_over_g, k, _) = self.weight.shape();
         let scale = E::from_f64(1.0 / (k.size() * k.size() * i_over_g.size()) as f64).unwrap();
         let b = scale.sqrt();
@@ -166,12 +166,7 @@ where
         Img,
         Tensor<(O, <I as std::ops::Div<G>>::Output, K, K), E, D>,
     ) as TryConv2D<S, P, L, G>>::Convolved;
-    type Error = <(
-        Img,
-        Tensor<(O, <I as std::ops::Div<G>>::Output, K, K), E, D>,
-    ) as TryConv2D<S, P, L, G>>::Error;
-
-    fn try_forward(&self, x: Img) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Img) -> Result<Self::Output, Error> {
         (x, self.weight.clone()).try_conv2d(self.stride, self.padding, self.dilation, self.groups)
     }
 }

--- a/dfdx/src/nn/layers/conv_trans2d.rs
+++ b/dfdx/src/nn/layers/conv_trans2d.rs
@@ -60,7 +60,7 @@ where
     <O as std::ops::Div<G>>::Output: Dim,
 {
     type Built = ConvTrans2D<I, O, K, S, P, L, G, E, D>;
-    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, <D>::Err> {
+    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, crate::tensor::Error> {
         assert_eq!(self.in_chan.size() % self.groups.size(), 0);
         assert_eq!(self.out_chan.size() % self.groups.size(), 0);
         let o_over_g = self.out_chan / self.groups;
@@ -119,7 +119,7 @@ where
     E: Dtype + num_traits::Float + rand_distr::uniform::SampleUniform,
     D: Device<E>,
 {
-    fn try_reset_params(&mut self) -> Result<(), D::Err> {
+    fn try_reset_params(&mut self) -> Result<(), crate::tensor::Error> {
         let (_, o_over_g, k, _) = self.weight.shape();
         let b = (1.0 / (k.size() * k.size() * o_over_g.size()) as f64).sqrt();
         let b = E::from_f64(b).unwrap();
@@ -144,12 +144,7 @@ where
         Img,
         Tensor<(I, <O as std::ops::Div<G>>::Output, K, K), E, D>,
     ) as TryConvTrans2D<S, P, L, G>>::Convolved;
-    type Error = <(
-        Img,
-        Tensor<(I, <O as std::ops::Div<G>>::Output, K, K), E, D>,
-    ) as TryConvTrans2D<S, P, L, G>>::Error;
-
-    fn try_forward(&self, x: Img) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Img) -> Result<Self::Output, Error> {
         (x, self.weight.clone()).try_convtrans2d(
             self.stride,
             self.padding,

--- a/dfdx/src/nn/layers/cos.rs
+++ b/dfdx/src/nn/layers/cos.rs
@@ -5,8 +5,7 @@ use crate::prelude::*;
 pub struct Cos;
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for Cos {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_cos()
     }
 }

--- a/dfdx/src/nn/layers/dropout.rs
+++ b/dfdx/src/nn/layers/dropout.rs
@@ -23,10 +23,9 @@ impl<const N: usize, S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Ten
     for DropoutOneIn<N>
 {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
 
     /// Does nothing
-    fn try_forward(&self, input: Tensor<S, E, D, T>) -> Result<Self::Output, D::Err> {
+    fn try_forward(&self, input: Tensor<S, E, D, T>) -> Result<Self::Output, crate::tensor::Error> {
         assert!(
             !T::OWNS_TAPE,
             "DropoutOneIn::try_forward input must not be traced."
@@ -35,7 +34,7 @@ impl<const N: usize, S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Ten
     }
 
     /// Applies dropout to the input tensor.
-    fn try_forward_mut(&mut self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward_mut(&mut self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         assert!(
             T::OWNS_TAPE,
             "DropoutOneIn::try_forward_mut input must be traced."
@@ -70,10 +69,9 @@ impl Default for Dropout {
 
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for Dropout {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
 
     /// Does nothing
-    fn try_forward(&self, input: Tensor<S, E, D, T>) -> Result<Self::Output, D::Err> {
+    fn try_forward(&self, input: Tensor<S, E, D, T>) -> Result<Self::Output, crate::tensor::Error> {
         assert!(
             !T::OWNS_TAPE,
             "Dropout::try_forward input must not be traced."
@@ -82,7 +80,7 @@ impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>>
     }
 
     /// Applies dropout to the input tensor.
-    fn try_forward_mut(&mut self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward_mut(&mut self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         assert!(
             T::OWNS_TAPE,
             "Dropout::try_forward_mut input must be traced."

--- a/dfdx/src/nn/layers/exp.rs
+++ b/dfdx/src/nn/layers/exp.rs
@@ -5,8 +5,7 @@ use crate::prelude::*;
 pub struct Exp;
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for Exp {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_exp()
     }
 }

--- a/dfdx/src/nn/layers/flatten2d.rs
+++ b/dfdx/src/nn/layers/flatten2d.rs
@@ -14,9 +14,11 @@ where
     <<C as Mul<H>>::Output as Mul<W>>::Output: Dim,
 {
     type Output = Tensor<(<<C as Mul<H>>::Output as Mul<W>>::Output,), E, D, T>;
-    type Error = D::Err;
 
-    fn try_forward(&self, input: Tensor<(C, H, W), E, D, T>) -> Result<Self::Output, D::Err> {
+    fn try_forward(
+        &self,
+        input: Tensor<(C, H, W), E, D, T>,
+    ) -> Result<Self::Output, crate::tensor::Error> {
         let (c, h, w) = *input.shape();
         let dst = (c * h * w,);
         input.try_reshape_like(&dst)
@@ -31,12 +33,11 @@ where
     <<C as Mul<H>>::Output as Mul<W>>::Output: Dim,
 {
     type Output = Tensor<(Batch, <<C as Mul<H>>::Output as Mul<W>>::Output), E, D, T>;
-    type Error = D::Err;
 
     fn try_forward(
         &self,
         input: Tensor<(Batch, C, H, W), E, D, T>,
-    ) -> Result<Self::Output, D::Err> {
+    ) -> Result<Self::Output, crate::tensor::Error> {
         let (batch, c, h, w) = *input.shape();
         let dst = (batch, c * h * w);
         input.try_reshape_like(&dst)

--- a/dfdx/src/nn/layers/gelu.rs
+++ b/dfdx/src/nn/layers/gelu.rs
@@ -5,8 +5,7 @@ use crate::prelude::*;
 pub struct FastGeLU;
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for FastGeLU {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_fast_gelu()
     }
 }
@@ -16,8 +15,7 @@ impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>>
 pub struct AccurateGeLU;
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for AccurateGeLU {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_accurate_gelu()
     }
 }

--- a/dfdx/src/nn/layers/generalized_add.rs
+++ b/dfdx/src/nn/layers/generalized_add.rs
@@ -34,27 +34,25 @@ impl<E: Dtype, D: Device<E>, T: BuildOnDevice<E, D>, U: BuildOnDevice<E, D>> Bui
     for GeneralizedAdd<T, U>
 {
     type Built = GeneralizedAdd<T::Built, U::Built>;
-    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, <D>::Err> {
+    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, crate::tensor::Error> {
         let t = self.t.try_build_on_device(device)?;
         let u = self.u.try_build_on_device(device)?;
         Ok(GeneralizedAdd { t, u })
     }
 }
 
-impl<X: WithEmptyTape, T: Module<X>, U: Module<X, Error = T::Error>> Module<X>
-    for GeneralizedAdd<T, U>
+impl<X: WithEmptyTape, T: Module<X>, U: Module<X>> Module<X> for GeneralizedAdd<T, U>
 where
-    T::Output: TryAdd<U::Output, Err = T::Error>,
+    T::Output: TryAdd<U::Output>,
 {
     type Output = <T::Output as TryAdd<U::Output>>::Output;
-    type Error = T::Error;
-    fn try_forward(&self, x: X) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: X) -> Result<Self::Output, Error> {
         let t = self.t.try_forward(x.with_empty_tape())?;
         let u = self.u.try_forward(x)?;
         t.try_add(u)
     }
 
-    fn try_forward_mut(&mut self, x: X) -> Result<Self::Output, Self::Error> {
+    fn try_forward_mut(&mut self, x: X) -> Result<Self::Output, Error> {
         let t = self.t.try_forward_mut(x.with_empty_tape())?;
         let u = self.u.try_forward_mut(x)?;
         t.try_add(u)

--- a/dfdx/src/nn/layers/generalized_mul.rs
+++ b/dfdx/src/nn/layers/generalized_mul.rs
@@ -33,27 +33,25 @@ impl<E: Dtype, D: Device<E>, T: BuildOnDevice<E, D>, U: BuildOnDevice<E, D>> Bui
     for GeneralizedMul<T, U>
 {
     type Built = GeneralizedMul<T::Built, U::Built>;
-    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, <D>::Err> {
+    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, crate::tensor::Error> {
         let t = self.t.try_build_on_device(device)?;
         let u = self.u.try_build_on_device(device)?;
         Ok(GeneralizedMul { t, u })
     }
 }
 
-impl<X: WithEmptyTape, T: Module<X>, U: Module<X, Error = T::Error>> Module<X>
-    for GeneralizedMul<T, U>
+impl<X: WithEmptyTape, T: Module<X>, U: Module<X>> Module<X> for GeneralizedMul<T, U>
 where
-    T::Output: TryMul<U::Output, Err = T::Error>,
+    T::Output: TryMul<U::Output>,
 {
     type Output = <T::Output as TryMul<U::Output>>::Output;
-    type Error = T::Error;
-    fn try_forward(&self, x: X) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: X) -> Result<Self::Output, Error> {
         let t = self.t.try_forward(x.with_empty_tape())?;
         let u = self.u.try_forward(x)?;
         t.try_mul(u)
     }
 
-    fn try_forward_mut(&mut self, x: X) -> Result<Self::Output, Self::Error> {
+    fn try_forward_mut(&mut self, x: X) -> Result<Self::Output, Error> {
         let t = self.t.try_forward_mut(x.with_empty_tape())?;
         let u = self.u.try_forward_mut(x)?;
         t.try_mul(u)

--- a/dfdx/src/nn/layers/leaky_relu.rs
+++ b/dfdx/src/nn/layers/leaky_relu.rs
@@ -12,8 +12,7 @@ impl Default for LeakyReLU {
 
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for LeakyReLU {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_prelu(E::from_f64(self.0).unwrap())
     }
 }

--- a/dfdx/src/nn/layers/ln.rs
+++ b/dfdx/src/nn/layers/ln.rs
@@ -5,8 +5,7 @@ use crate::prelude::*;
 pub struct Ln;
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for Ln {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_ln()
     }
 }

--- a/dfdx/src/nn/layers/log_softmax.rs
+++ b/dfdx/src/nn/layers/log_softmax.rs
@@ -5,8 +5,7 @@ use crate::prelude::*;
 pub struct LogSoftmax;
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for LogSoftmax {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_log_softmax()
     }
 }

--- a/dfdx/src/nn/layers/multi_head_attention.rs
+++ b/dfdx/src/nn/layers/multi_head_attention.rs
@@ -64,7 +64,6 @@ where
     T: Tape<E, D>,
 {
     type Output = Tensor<(S1, M), E, D, T>;
-    type Error = D::Err;
 
     /// Encoder-Decoder style self attention where one set of tensors is used for values and keys, and another is used for queries
     fn try_forward(
@@ -74,7 +73,7 @@ where
             Tensor<(S2, M), E, D>,
             Tensor<(S2, M), E, D>,
         ),
-    ) -> Result<Self::Output, D::Err> {
+    ) -> Result<Self::Output, crate::tensor::Error> {
         assert_eq!(k.shape().0, v.shape().0);
         let (s1, m) = *q.shape();
         let s2 = k.shape().0;
@@ -101,7 +100,6 @@ where
     T: Tape<E, D>,
 {
     type Output = Tensor<(B, S1, M), E, D, T>;
-    type Error = D::Err;
 
     /// Batched Encoder-Decoder style self attention where one set of tensors is used for values and keys, and another is used for queries
     fn try_forward(
@@ -111,7 +109,7 @@ where
             Tensor<(B, S2, M), E, D>,
             Tensor<(B, S2, M), E, D>,
         ),
-    ) -> Result<Self::Output, D::Err> {
+    ) -> Result<Self::Output, crate::tensor::Error> {
         assert_eq!(q.shape().0, k.shape().0);
         assert_eq!(q.shape().0, v.shape().0);
         assert_eq!(k.shape().1, v.shape().1);
@@ -153,12 +151,11 @@ where
     E: Dtype,
     D: Device<E>,
     Src: SplitTape,
-    Self: Module<(Src, Src::NoTape, Src::NoTape), Output = Src, Error = D::Err>,
+    Self: Module<(Src, Src::NoTape, Src::NoTape), Output = Src>,
 {
     type Output = Src;
-    type Error = D::Err;
 
-    fn try_forward(&self, src: Src) -> Result<Self::Output, D::Err> {
+    fn try_forward(&self, src: Src) -> Result<Self::Output, crate::tensor::Error> {
         let (src, tape) = src.split_tape();
         self.try_forward((src.clone().put_tape(tape), src.clone(), src))
     }

--- a/dfdx/src/nn/layers/pool_2d_avg.rs
+++ b/dfdx/src/nn/layers/pool_2d_avg.rs
@@ -32,9 +32,8 @@ impl<K: Dim, S: Dim, P: Dim, L: Dim, Img: TryPool2D<K, S, P, L>> Module<Img>
     for AvgPool2D<K, S, P, L>
 {
     type Output = Img::Pooled;
-    type Error = Img::Error;
 
-    fn try_forward(&self, x: Img) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Img) -> Result<Self::Output, Error> {
         x.try_pool2d(
             crate::tensor_ops::Pool2DKind::Avg,
             self.kernel_size,

--- a/dfdx/src/nn/layers/pool_2d_max.rs
+++ b/dfdx/src/nn/layers/pool_2d_max.rs
@@ -32,9 +32,7 @@ impl<K: Dim, S: Dim, P: Dim, L: Dim, Img: TryPool2D<K, S, P, L>> Module<Img>
     for MaxPool2D<K, S, P, L>
 {
     type Output = Img::Pooled;
-    type Error = Img::Error;
-
-    fn try_forward(&self, x: Img) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Img) -> Result<Self::Output, Error> {
         x.try_pool2d(
             crate::tensor_ops::Pool2DKind::Max,
             self.kernel_size,

--- a/dfdx/src/nn/layers/pool_2d_min.rs
+++ b/dfdx/src/nn/layers/pool_2d_min.rs
@@ -32,9 +32,7 @@ impl<K: Dim, S: Dim, P: Dim, L: Dim, Img: TryPool2D<K, S, P, L>> Module<Img>
     for MinPool2D<K, S, P, L>
 {
     type Output = Img::Pooled;
-    type Error = Img::Error;
-
-    fn try_forward(&self, x: Img) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Img) -> Result<Self::Output, Error> {
         x.try_pool2d(
             crate::tensor_ops::Pool2DKind::Min,
             self.kernel_size,

--- a/dfdx/src/nn/layers/pool_global_avg.rs
+++ b/dfdx/src/nn/layers/pool_global_avg.rs
@@ -23,9 +23,10 @@ impl<C: Dim, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>>
     Module<Tensor<(C, H, W), E, D, T>> for AvgPoolGlobal
 {
     type Output = Tensor<(C,), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, input: Tensor<(C, H, W), E, D, T>) -> Result<Self::Output, D::Err> {
+    fn try_forward(
+        &self,
+        input: Tensor<(C, H, W), E, D, T>,
+    ) -> Result<Self::Output, crate::tensor::Error> {
         input.try_mean()
     }
 }
@@ -34,9 +35,10 @@ impl<B: Dim, C: Dim, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>>
     Module<Tensor<(B, C, H, W), E, D, T>> for AvgPoolGlobal
 {
     type Output = Tensor<(B, C), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, input: Tensor<(B, C, H, W), E, D, T>) -> Result<Self::Output, D::Err> {
+    fn try_forward(
+        &self,
+        input: Tensor<(B, C, H, W), E, D, T>,
+    ) -> Result<Self::Output, crate::tensor::Error> {
         input.try_mean()
     }
 }

--- a/dfdx/src/nn/layers/pool_global_max.rs
+++ b/dfdx/src/nn/layers/pool_global_max.rs
@@ -23,9 +23,10 @@ impl<C: Dim, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>>
     Module<Tensor<(C, H, W), E, D, T>> for MaxPoolGlobal
 {
     type Output = Tensor<(C,), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, input: Tensor<(C, H, W), E, D, T>) -> Result<Self::Output, D::Err> {
+    fn try_forward(
+        &self,
+        input: Tensor<(C, H, W), E, D, T>,
+    ) -> Result<Self::Output, crate::tensor::Error> {
         input.try_max()
     }
 }
@@ -34,9 +35,10 @@ impl<B: Dim, C: Dim, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>>
     Module<Tensor<(B, C, H, W), E, D, T>> for MaxPoolGlobal
 {
     type Output = Tensor<(B, C), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, input: Tensor<(B, C, H, W), E, D, T>) -> Result<Self::Output, D::Err> {
+    fn try_forward(
+        &self,
+        input: Tensor<(B, C, H, W), E, D, T>,
+    ) -> Result<Self::Output, crate::tensor::Error> {
         input.try_max()
     }
 }

--- a/dfdx/src/nn/layers/pool_global_min.rs
+++ b/dfdx/src/nn/layers/pool_global_min.rs
@@ -23,9 +23,10 @@ impl<C: Dim, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>>
     Module<Tensor<(C, H, W), E, D, T>> for MinPoolGlobal
 {
     type Output = Tensor<(C,), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, input: Tensor<(C, H, W), E, D, T>) -> Result<Self::Output, D::Err> {
+    fn try_forward(
+        &self,
+        input: Tensor<(C, H, W), E, D, T>,
+    ) -> Result<Self::Output, crate::tensor::Error> {
         input.try_min()
     }
 }
@@ -34,9 +35,10 @@ impl<B: Dim, C: Dim, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>>
     Module<Tensor<(B, C, H, W), E, D, T>> for MinPoolGlobal
 {
     type Output = Tensor<(B, C), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, input: Tensor<(B, C, H, W), E, D, T>) -> Result<Self::Output, D::Err> {
+    fn try_forward(
+        &self,
+        input: Tensor<(B, C, H, W), E, D, T>,
+    ) -> Result<Self::Output, crate::tensor::Error> {
         input.try_min()
     }
 }

--- a/dfdx/src/nn/layers/prelu.rs
+++ b/dfdx/src/nn/layers/prelu.rs
@@ -12,7 +12,7 @@ impl Default for PReLUConfig {
 
 impl<E: Dtype, D: Device<E>> BuildOnDevice<E, D> for PReLUConfig {
     type Built = PReLU<E, D>;
-    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, <D>::Err> {
+    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, crate::tensor::Error> {
         let a = device.try_tensor(E::from_f64(self.0).unwrap())?;
         Ok(PReLU { a })
     }
@@ -28,16 +28,14 @@ pub struct PReLU<Elem: Dtype, Dev: Device<Elem>> {
 
 impl<E: Dtype, D: Device<E>> ResetParams<E, D> for PReLU<E, D> {
     /// Does nothing.
-    fn try_reset_params(&mut self) -> Result<(), D::Err> {
+    fn try_reset_params(&mut self) -> Result<(), crate::tensor::Error> {
         Ok(())
     }
 }
 
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for PReLU<E, D> {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         let a = self.a.retaped::<T>().broadcast_like(&x);
         x.try_prelu(a)
     }

--- a/dfdx/src/nn/layers/prelu1d.rs
+++ b/dfdx/src/nn/layers/prelu1d.rs
@@ -18,7 +18,7 @@ impl<C: Dim + Default> Default for PReLU1DConfig<C> {
 
 impl<C: Dim, E: Dtype, D: Device<E>> BuildOnDevice<E, D> for PReLU1DConfig<C> {
     type Built = PReLU1D<C, E, D>;
-    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, <D>::Err> {
+    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, crate::tensor::Error> {
         let a = device.try_ones_like(&(self.c,))?.try_mul(self.a)?;
         Ok(PReLU1D { a })
     }
@@ -34,7 +34,7 @@ pub struct PReLU1D<C: Dim, Elem: Dtype, Dev: Device<Elem>> {
 
 impl<C: Dim, E: Dtype, D: Device<E>> ResetParams<E, D> for PReLU1D<C, E, D> {
     /// Does nothing.
-    fn try_reset_params(&mut self) -> Result<(), D::Err> {
+    fn try_reset_params(&mut self) -> Result<(), crate::tensor::Error> {
         Ok(())
     }
 }
@@ -43,9 +43,7 @@ impl<C: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<(C,), E, D, T>
     for PReLU1D<C, E, D>
 {
     type Output = Tensor<(C,), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, x: Tensor<(C,), E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<(C,), E, D, T>) -> Result<Self::Output, Error> {
         x.try_prelu(self.a.clone())
     }
 }
@@ -54,9 +52,7 @@ impl<B: Dim, C: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<(B, C)
     for PReLU1D<C, E, D>
 {
     type Output = Tensor<(B, C), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, x: Tensor<(B, C), E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<(B, C), E, D, T>) -> Result<Self::Output, Error> {
         let a = self.a.retaped::<T>().broadcast_like(&x);
         x.try_prelu(a)
     }
@@ -66,9 +62,7 @@ impl<B: Dim, C: Dim, H: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>>
     Module<Tensor<(B, C, H), E, D, T>> for PReLU1D<C, E, D>
 {
     type Output = Tensor<(B, C, H), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, x: Tensor<(B, C, H), E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<(B, C, H), E, D, T>) -> Result<Self::Output, Error> {
         let a = self.a.retaped::<T>().broadcast_like(&x);
         x.try_prelu(a)
     }
@@ -78,9 +72,7 @@ impl<B: Dim, C: Dim, H: Dim, W: Dim, E: Dtype, D: Device<E>, T: Tape<E, D>>
     Module<Tensor<(B, C, H, W), E, D, T>> for PReLU1D<C, E, D>
 {
     type Output = Tensor<(B, C, H, W), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, x: Tensor<(B, C, H, W), E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<(B, C, H, W), E, D, T>) -> Result<Self::Output, Error> {
         let a = self.a.retaped::<T>().broadcast_like(&x);
         x.try_prelu(a)
     }

--- a/dfdx/src/nn/layers/relu.rs
+++ b/dfdx/src/nn/layers/relu.rs
@@ -5,8 +5,7 @@ use crate::prelude::*;
 pub struct ReLU;
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for ReLU {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_relu()
     }
 }

--- a/dfdx/src/nn/layers/reshape.rs
+++ b/dfdx/src/nn/layers/reshape.rs
@@ -18,8 +18,7 @@ impl<Src: Shape, Dst: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tenso
     for Reshape<Dst>
 {
     type Output = Tensor<Dst, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<Src, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<Src, E, D, T>) -> Result<Self::Output, Error> {
         x.try_reshape_like(&self.0)
     }
 }

--- a/dfdx/src/nn/layers/residual_add.rs
+++ b/dfdx/src/nn/layers/residual_add.rs
@@ -27,10 +27,9 @@ pub struct ResidualAdd<T>(
     pub T,
 );
 
-// TODO derive this
 impl<E: Dtype, D: Device<E>, T: BuildOnDevice<E, D>> BuildOnDevice<E, D> for ResidualAdd<T> {
     type Built = ResidualAdd<T::Built>;
-    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, <D>::Err> {
+    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, crate::tensor::Error> {
         let t = self.0.try_build_on_device(device)?;
         Ok(ResidualAdd(t))
     }
@@ -38,15 +37,14 @@ impl<E: Dtype, D: Device<E>, T: BuildOnDevice<E, D>> BuildOnDevice<E, D> for Res
 
 impl<X: WithEmptyTape, T: Module<X>> Module<X> for ResidualAdd<T>
 where
-    T::Output: TryAdd<X, Err = T::Error>,
+    T::Output: TryAdd<X>,
 {
     type Output = <T::Output as TryAdd<X>>::Output;
-    type Error = T::Error;
-    fn try_forward(&self, x: X) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: X) -> Result<Self::Output, Error> {
         let t = self.0.try_forward(x.with_empty_tape())?;
         t.try_add(x)
     }
-    fn try_forward_mut(&mut self, x: X) -> Result<Self::Output, Self::Error> {
+    fn try_forward_mut(&mut self, x: X) -> Result<Self::Output, Error> {
         let t = self.0.try_forward_mut(x.with_empty_tape())?;
         t.try_add(x)
     }

--- a/dfdx/src/nn/layers/residual_mul.rs
+++ b/dfdx/src/nn/layers/residual_mul.rs
@@ -26,10 +26,9 @@ pub struct ResidualMul<T>(
     pub T,
 );
 
-// TODO derive this
 impl<E: Dtype, D: Device<E>, T: BuildOnDevice<E, D>> BuildOnDevice<E, D> for ResidualMul<T> {
     type Built = ResidualMul<T::Built>;
-    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, <D>::Err> {
+    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, crate::tensor::Error> {
         let t = self.0.try_build_on_device(device)?;
         Ok(ResidualMul(t))
     }
@@ -37,15 +36,14 @@ impl<E: Dtype, D: Device<E>, T: BuildOnDevice<E, D>> BuildOnDevice<E, D> for Res
 
 impl<X: WithEmptyTape, T: Module<X>> Module<X> for ResidualMul<T>
 where
-    T::Output: TryMul<X, Err = T::Error>,
+    T::Output: TryMul<X>,
 {
     type Output = <T::Output as TryMul<X>>::Output;
-    type Error = T::Error;
-    fn try_forward(&self, x: X) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: X) -> Result<Self::Output, Error> {
         let t = self.0.try_forward(x.with_empty_tape())?;
         t.try_mul(x)
     }
-    fn try_forward_mut(&mut self, x: X) -> Result<Self::Output, Self::Error> {
+    fn try_forward_mut(&mut self, x: X) -> Result<Self::Output, Error> {
         let t = self.0.try_forward_mut(x.with_empty_tape())?;
         t.try_mul(x)
     }

--- a/dfdx/src/nn/layers/sigmoid.rs
+++ b/dfdx/src/nn/layers/sigmoid.rs
@@ -5,8 +5,7 @@ use crate::prelude::*;
 pub struct Sigmoid;
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for Sigmoid {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_sigmoid()
     }
 }

--- a/dfdx/src/nn/layers/sin.rs
+++ b/dfdx/src/nn/layers/sin.rs
@@ -5,8 +5,7 @@ use crate::prelude::*;
 pub struct Sin;
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for Sin {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_sin()
     }
 }

--- a/dfdx/src/nn/layers/softmax.rs
+++ b/dfdx/src/nn/layers/softmax.rs
@@ -5,8 +5,7 @@ use crate::prelude::*;
 pub struct Softmax;
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for Softmax {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_softmax()
     }
 }

--- a/dfdx/src/nn/layers/split_into.rs
+++ b/dfdx/src/nn/layers/split_into.rs
@@ -33,7 +33,7 @@ pub struct SplitInto<T>(
 
 impl<E: Dtype, D: Device<E>, T: BuildOnDevice<E, D>> BuildOnDevice<E, D> for SplitInto<T> {
     type Built = SplitInto<T::Built>;
-    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, <D>::Err> {
+    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, crate::tensor::Error> {
         let t = self.0.try_build_on_device(device)?;
         Ok(SplitInto(t))
     }
@@ -44,29 +44,26 @@ macro_rules! tuple_impls {
         impl<
             Input: WithEmptyTape,
             $head: Module<Input>,
-            $($tails : Module<Input, Error = $head::Error>,)+
+            $($tails : Module<Input>,)+
         > Module<Input> for SplitInto<($head, $($tails,)+)> {
             type Output = (
                 $head::Output,
                 $($tails::Output),+
             );
-            type Error = $head::Error;
 
             #[allow(non_snake_case)]
-            fn try_forward(&self, x: Input) -> Result<Self::Output, $head::Error> {
+            fn try_forward(&self, x: Input) -> Result<Self::Output, Error> {
                 let ($head, $($tails,)+) = &self.0;
                 let ($($tails,)+) = ($($tails.try_forward(x.with_empty_tape())?,)+);
                 let $head = $head.try_forward(x)?;
-
                 Ok(($head, $($tails,)+))
             }
 
             #[allow(non_snake_case)]
-            fn try_forward_mut(&mut self, x: Input) -> Result<Self::Output, $head::Error> {
+            fn try_forward_mut(&mut self, x: Input) -> Result<Self::Output, Error> {
                 let ($head, $($tails,)+) = &mut self.0;
                 let ($($tails,)+) = ($($tails.try_forward_mut(x.with_empty_tape())?,)+);
                 let $head = $head.try_forward_mut(x)?;
-
                 Ok(($head, $($tails,)+))
             }
         }

--- a/dfdx/src/nn/layers/sqrt.rs
+++ b/dfdx/src/nn/layers/sqrt.rs
@@ -6,8 +6,7 @@ pub struct Sqrt;
 
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for Sqrt {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_sqrt()
     }
 }

--- a/dfdx/src/nn/layers/square.rs
+++ b/dfdx/src/nn/layers/square.rs
@@ -5,8 +5,7 @@ use crate::prelude::*;
 pub struct Square;
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for Square {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_square()
     }
 }

--- a/dfdx/src/nn/layers/tanh.rs
+++ b/dfdx/src/nn/layers/tanh.rs
@@ -5,8 +5,7 @@ use crate::prelude::*;
 pub struct Tanh;
 impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for Tanh {
     type Output = Tensor<S, E, D, T>;
-    type Error = D::Err;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
         x.try_tanh()
     }
 }

--- a/dfdx/src/nn/layers/upscale2d.rs
+++ b/dfdx/src/nn/layers/upscale2d.rs
@@ -18,9 +18,7 @@ impl<H: Dim, W: Dim, M: UpscaleMethod, Img: GenericUpscale2D<M>> Module<Img>
     for Upscale2D<H, W, M>
 {
     type Output = Img::Output<H, W>;
-    type Error = Img::Err;
-
-    fn try_forward(&self, x: Img) -> Result<Self::Output, Img::Err> {
+    fn try_forward(&self, x: Img) -> Result<Self::Output, Error> {
         x.generic_upscale2d_like(self.method, self.out_height, self.out_width)
     }
 }
@@ -45,9 +43,7 @@ where
     D: Device<E> + Upscale2DKernel<E, M>,
 {
     type Output = Tensor<(C, H::Output, W::Output), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, x: Tensor<(C, H, W), E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<(C, H, W), E, D, T>) -> Result<Self::Output, Error> {
         let (_c, h, w) = *x.shape();
         let h = h * self.height_factor;
         let w = w * self.width_factor;
@@ -66,9 +62,7 @@ where
     T: 'static + Tape<E, D>,
 {
     type Output = Tensor<(B, C, H::Output, W::Output), E, D, T>;
-    type Error = D::Err;
-
-    fn try_forward(&self, x: Tensor<(B, C, H, W), E, D, T>) -> Result<Self::Output, Self::Error> {
+    fn try_forward(&self, x: Tensor<(B, C, H, W), E, D, T>) -> Result<Self::Output, Error> {
         let (_b, _c, h, w) = *x.shape();
         let h = h * self.height_factor;
         let w = w * self.width_factor;

--- a/dfdx/src/nn/optim/adam.rs
+++ b/dfdx/src/nn/optim/adam.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::{
     shapes::{Dtype, Shape},
-    tensor::{Gradients, Storage, Tensor, Tensorlike, UniqueId},
+    tensor::{Error, Gradients, Storage, Tensor, Tensorlike, UniqueId},
     tensor_ops::{AdamConfig, Device},
 };
 
@@ -55,7 +55,7 @@ impl<M, E: Dtype, D: Device<E>> crate::nn::Optimizer<M, E, D> for Adam<M, E, D> 
         t: &mut Tensor<S, E, D>,
         gradients: &Gradients<E, D>,
         missing_params: &mut Vec<UniqueId>,
-    ) -> Result<(), D::Err> {
+    ) -> Result<(), crate::tensor::Error> {
         let g = gradients.get_ref_checked(t);
         match g {
             None => missing_params.push(t.id()),
@@ -68,11 +68,7 @@ impl<M, E: Dtype, D: Device<E>> crate::nn::Optimizer<M, E, D> for Adam<M, E, D> 
         Ok(())
     }
 
-    fn update(
-        &mut self,
-        module: &mut M,
-        gradients: &Gradients<E, D>,
-    ) -> Result<(), crate::nn::OptimizerUpdateError<<D>::Err>>
+    fn update(&mut self, module: &mut M, gradients: &Gradients<E, D>) -> Result<(), Error>
     where
         M: crate::nn::UpdateParams<E, D>,
     {
@@ -80,15 +76,11 @@ impl<M, E: Dtype, D: Device<E>> crate::nn::Optimizer<M, E, D> for Adam<M, E, D> 
 
         // NOTE: the rest of this is identical to default implementation of update.
         let mut missing_tensors = Vec::new();
-        module
-            .try_update_params(self, gradients, &mut missing_tensors)
-            .map_err(crate::nn::OptimizerUpdateError::DeviceError)?;
+        module.try_update_params(self, gradients, &mut missing_tensors)?;
         if missing_tensors.is_empty() {
             Ok(())
         } else {
-            Err(crate::nn::OptimizerUpdateError::UnusedTensors(
-                missing_tensors,
-            ))
+            Err(Error::UnusedTensors(missing_tensors))
         }
     }
 }

--- a/dfdx/src/nn/optim/mod.rs
+++ b/dfdx/src/nn/optim/mod.rs
@@ -39,5 +39,5 @@ pub use adam::Adam;
 pub use rmsprop::RMSprop;
 pub use sgd::Sgd;
 // re-exports
-pub use super::{Optimizer, OptimizerUpdateError};
+pub use super::Optimizer;
 pub use crate::tensor_ops::{AdamConfig, Momentum, RMSpropConfig, SgdConfig, WeightDecay};

--- a/dfdx/src/nn/optim/sgd.rs
+++ b/dfdx/src/nn/optim/sgd.rs
@@ -51,7 +51,7 @@ impl<M, E: Dtype, D: Device<E>> crate::nn::Optimizer<M, E, D> for Sgd<M, E, D> {
         t: &mut Tensor<S, E, D>,
         gradients: &Gradients<E, D>,
         missing_params: &mut Vec<UniqueId>,
-    ) -> Result<(), D::Err> {
+    ) -> Result<(), crate::tensor::Error> {
         let g = gradients.get_ref_checked(t);
         match g {
             None => missing_params.push(t.id()),


### PR DESCRIPTION
This makes it a lot easier to write neural network modules, since you don't have to constraint the Module::Error to be the same across all sub modules anymore.

In general it makes it easier to work with dfdx since there is a single dfdx::tensor::Error type for errors.