### PR TITLE
Input Wrapper

### DIFF
--- a/dfdx-derives/Cargo.toml
+++ b/dfdx-derives/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["extra-traits"] }
 dfdx-core = { path = "../dfdx-core" }
+heck = "0.4.1"
 
 [features]
 nightly = ["dfdx-core/nightly"]

--- a/dfdx-derives/src/lib.rs
+++ b/dfdx-derives/src/lib.rs
@@ -1167,10 +1167,10 @@ pub fn input_wrapper(
         );
         quote! {
             #[doc = #doc1]
-            #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, crate::prelude::CustomModule)]
+            #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, ::dfdx::CustomModule)]
             pub struct FromTuple;
             #[doc = #doc2]
-            #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, crate::prelude::CustomModule)]
+            #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, ::dfdx::prelude::CustomModule)]
             pub struct IntoTuple;
         }
     };
@@ -1235,16 +1235,16 @@ pub fn input_wrapper(
         let doc2 = format!("Module to convert a [`{}`] into a tuple.", wrapper_ident,);
         quote! {
             #[doc = #doc1]
-            impl<#(#wrapper_generic_names), *> crate::prelude::Module<(#(#field_ty_names), *)> for FromTuple {
+            impl<#(#wrapper_generic_names), *> ::dfdx::prelude::Module<(#(#field_ty_names), *)> for FromTuple {
                 type Output = #wrapper_ident<#(#wrapper_generic_names), *>;
-                fn try_forward(&self, x: (#(#field_ty_names), *)) -> Result<Self::Output, crate::prelude::Error> {
+                fn try_forward(&self, x: (#(#field_ty_names), *)) -> Result<Self::Output, ::dfdx::prelude::Error> {
                     Ok(x.into())
                 }
             }
             #[doc = #doc2]
-            impl<#(#wrapper_generic_names), *> crate::prelude::Module<#wrapper_ident<#(#wrapper_generic_names), *>> for IntoTuple {
+            impl<#(#wrapper_generic_names), *> ::dfdx::prelude::Module<#wrapper_ident<#(#wrapper_generic_names), *>> for IntoTuple {
                 type Output = (#(#field_ty_names), *);
-                fn try_forward(&self, x: #wrapper_ident<#(#wrapper_generic_names), *>) -> Result<Self::Output, crate::prelude::Error> {
+                fn try_forward(&self, x: #wrapper_ident<#(#wrapper_generic_names), *>) -> Result<Self::Output, ::dfdx::prelude::Error> {
                     Ok(x.into())
                 }
             }
@@ -1295,7 +1295,7 @@ pub fn input_wrapper(
                     );
                 }
                 contains_ident = true;
-                quote!(<M as crate::prelude::Module<#ty>>::Output)
+                quote!(<M as ::dfdx::prelude::Module<#ty>>::Output)
             } else {
                 quote!(#ty_ident)
             }
@@ -1334,15 +1334,15 @@ pub fn input_wrapper(
 
         let field_access_module = quote! {
             #[doc = #doc]
-            impl<M: crate::prelude::Module<#ty>, #(#wrapper_generic_names), *> crate::prelude::Module<#wrapper_ident<#(#wrapper_generic_names), *>> for crate::prelude::On<#on_acccess, M> {
+            impl<M: ::dfdx::prelude::Module<#ty>, #(#wrapper_generic_names), *> ::dfdx::prelude::Module<#wrapper_ident<#(#wrapper_generic_names), *>> for ::dfdx::prelude::On<#on_acccess, M> {
                 type Output = #wrapper_ident<#(#output_generics), *>;
-                fn try_forward(&self, x: #wrapper_ident<#(#wrapper_generic_names), *>) -> Result<Self::Output, crate::prelude::Error> {
+                fn try_forward(&self, x: #wrapper_ident<#(#wrapper_generic_names), *>) -> Result<Self::Output, ::dfdx::prelude::Error> {
                     #(#field_extraction)*
                     let #forward = self.t.try_forward(#forward)?;
                     let x = #field_replacement;
                     Ok(x)
                 }
-                fn try_forward_mut(&mut self, x: #wrapper_ident<#(#wrapper_generic_names), *>) -> Result<Self::Output, crate::prelude::Error> {
+                fn try_forward_mut(&mut self, x: #wrapper_ident<#(#wrapper_generic_names), *>) -> Result<Self::Output, ::dfdx::prelude::Error> {
                     #(#field_extraction)*
                     let #forward = self.t.try_forward_mut(#forward)?;
                     let x = #field_replacement;

--- a/dfdx/src/nn/layers/id.rs
+++ b/dfdx/src/nn/layers/id.rs
@@ -1,0 +1,19 @@
+use crate::prelude::*;
+
+/// Forwards the input to the output.
+#[derive(Default, Debug, Clone, Copy, CustomModule)]
+pub struct Id;
+
+impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for Id {
+    type Output = Tensor<S, E, D, T>;
+    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
+        Ok(x)
+    }
+}
+
+pub type Id1 = (Id,);
+pub type Id2 = (Id, Id);
+pub type Id3 = (Id, Id, Id);
+pub type Id4 = (Id, Id, Id, Id);
+pub type Id5 = (Id, Id, Id, Id, Id);
+pub type Id6 = (Id, Id, Id, Id, Id, Id);

--- a/dfdx/src/nn/layers/id.rs
+++ b/dfdx/src/nn/layers/id.rs
@@ -4,9 +4,9 @@ use crate::prelude::*;
 #[derive(Default, Debug, Clone, Copy, CustomModule)]
 pub struct Id;
 
-impl<S: Shape, E: Dtype, D: Device<E>, T: Tape<E, D>> Module<Tensor<S, E, D, T>> for Id {
-    type Output = Tensor<S, E, D, T>;
-    fn try_forward(&self, x: Tensor<S, E, D, T>) -> Result<Self::Output, Error> {
+impl<Input> Module<Input> for Id {
+    type Output = Input;
+    fn try_forward(&self, x: Input) -> Result<Self::Output, Error> {
         Ok(x)
     }
 }

--- a/dfdx/src/nn/layers/mod.rs
+++ b/dfdx/src/nn/layers/mod.rs
@@ -22,7 +22,6 @@ mod gelu;
 mod generalized_add;
 mod generalized_mul;
 pub mod id;
-mod input_into;
 mod layer_norm1d;
 mod leaky_relu;
 mod linear;

--- a/dfdx/src/nn/layers/mod.rs
+++ b/dfdx/src/nn/layers/mod.rs
@@ -1,3 +1,5 @@
+pub mod ops;
+
 mod abs;
 mod add_into;
 mod batch_norm1d;
@@ -19,6 +21,8 @@ mod flatten2d;
 mod gelu;
 mod generalized_add;
 mod generalized_mul;
+pub mod id;
+mod input_into;
 mod layer_norm1d;
 mod leaky_relu;
 mod linear;
@@ -26,6 +30,7 @@ mod ln;
 mod log_softmax;
 mod matmul;
 mod multi_head_attention;
+mod on;
 #[cfg(feature = "nightly")]
 mod pool_2d_avg;
 #[cfg(feature = "nightly")]
@@ -72,6 +77,7 @@ pub use flatten2d::Flatten2D;
 pub use gelu::{AccurateGeLU, FastGeLU};
 pub use generalized_add::GeneralizedAdd;
 pub use generalized_mul::GeneralizedMul;
+pub use id::Id;
 pub use layer_norm1d::{LayerNorm1D, LayerNorm1DConfig, LayerNorm1DConstConfig};
 pub use leaky_relu::LeakyReLU;
 pub use linear::{Linear, LinearConfig, LinearConstConfig};
@@ -79,6 +85,7 @@ pub use ln::Ln;
 pub use log_softmax::LogSoftmax;
 pub use matmul::{MatMul, MatMulConfig, MatMulConstConfig};
 pub use multi_head_attention::{MultiHeadAttention, MultiHeadAttentionConfig};
+pub use on::On;
 #[cfg(feature = "nightly")]
 pub use pool_2d_avg::{AvgPool2D, AvgPool2DConst};
 #[cfg(feature = "nightly")]

--- a/dfdx/src/nn/layers/on.rs
+++ b/dfdx/src/nn/layers/on.rs
@@ -44,7 +44,6 @@ mod tests {
         pub b: B,
     }
 
-
     #[input_wrapper]
     pub struct Split1<Forward, Skip> {
         pub forward: Forward,
@@ -74,7 +73,8 @@ mod tests {
     fn test_residual_add_backward() {
         let dev: TestDevice = Default::default();
 
-        let model = dev.build_module::<f32>(<ResidualAdd1<LinearConstConfig<2, 2>>>::default());
+        let model =
+            dev.build_module::<TestDtype>(<ResidualAdd1<LinearConstConfig<2, 2>>>::default());
 
         let x: Tensor<Rank2<4, 2>, f32, _> = dev.sample_normal();
         let x = x.to_dtype::<TestDtype>();
@@ -115,7 +115,8 @@ mod tests {
     fn test_residual_add_backward2() {
         let dev: TestDevice = Default::default();
 
-        let model = dev.build_module::<f32>(<ResidualAdd2<LinearConstConfig<2, 2>>>::default());
+        let model =
+            dev.build_module::<TestDtype>(<ResidualAdd2<LinearConstConfig<2, 2>>>::default());
 
         let x: Tensor<Rank2<4, 2>, f32, _> = dev.sample_normal();
         let x = x.to_dtype::<TestDtype>();

--- a/dfdx/src/nn/layers/on.rs
+++ b/dfdx/src/nn/layers/on.rs
@@ -1,0 +1,132 @@
+use crate::prelude::*;
+use std::marker::PhantomData;
+
+// TODO: try making a Call module, whih allows calling an arbitrary method on the input.
+
+/// Access the input that is stored in a wrapper structure.
+#[derive(
+    Debug, Default, Clone, ResetParams, ZeroGrads, UpdateParams, LoadSafeTensors, SaveSafeTensors,
+)]
+#[repr(transparent)]
+pub struct On<N, T> {
+    #[module]
+    #[serialize]
+    pub t: T,
+
+    pub _n: PhantomData<N>,
+}
+
+impl<E: Dtype, D: Device<E>, N: Clone + std::fmt::Debug, T: BuildOnDevice<E, D>> BuildOnDevice<E, D>
+    for On<N, T>
+{
+    type Built = On<N, T::Built>;
+    fn try_build_on_device(&self, device: &D) -> Result<Self::Built, Error> {
+        let t = self.t.try_build_on_device(device)?;
+        Ok(On { t, _n: PhantomData })
+    }
+}
+
+// TODO: define On access for standard tuples,
+// so that it's possible to access them with something like:
+// On<tuple::_0, T>
+pub mod tuple {}
+
+// cargo 'test' '--package' 'dfdx' '--lib' '--' 'nn::layers::on::tests' '--nocapture'
+// test based on nn/layers/residual_add.rs
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::*;
+
+    #[input_wrapper]
+    pub struct MyWrapper<A, B> {
+        pub a: A,
+        pub b: B,
+    }
+
+
+    #[input_wrapper]
+    pub struct Split1<Forward, Skip> {
+        pub forward: Forward,
+        pub skip: Skip,
+    }
+
+    #[derive(Default, Clone, Sequential)]
+    pub struct ResidualAdd1<T: Clone + std::fmt::Debug> {
+        // input is Input
+        pub split: SplitInto<(Id, Id)>,
+
+        // input is (Input, Input)
+        pub input_to_wrapper: split1::FromTuple,
+
+        // input is Split1 { Input, Input }
+        pub t: On<split1::forward, T>,
+
+        // input is Split1 { T::Output, Input }
+        pub input_to_tuple: split1::IntoTuple,
+
+        // input is (T::Output, Input)
+        pub add: ops::Add,
+        // input is T::Output = Input
+    }
+
+    #[test]
+    fn test_residual_add_backward() {
+        let dev: TestDevice = Default::default();
+
+        let model = dev.build_module::<f32>(<ResidualAdd1<LinearConstConfig<2, 2>>>::default());
+
+        let x: Tensor<Rank2<4, 2>, f32, _> = dev.sample_normal();
+        let x = x.to_dtype::<TestDtype>();
+        let y = model.forward(x.leaky_trace());
+
+        #[rustfmt::skip]
+        assert_close_to_literal!(y, [[0.25372928, -2.4258814],[1.7892148, -2.6242268],[1.5131638, 0.23407778],[3.4201493, 1.597525]]);
+
+        let g = y.mean().backward();
+        assert_close_to_literal!(g.get(&model.t.t.weight), [[0.475242, -0.075136]; 2]);
+        assert_close_to_literal!(g.get(&model.t.t.bias), [0.5; 2]);
+        assert_close_to_literal!(g.get(&x), [[0.18806472, 0.21419683]; 4]);
+    }
+
+    #[input_wrapper]
+    pub struct Split2<Forward, Skip>(Forward, Skip);
+
+    #[derive(Default, Clone, Sequential)]
+    pub struct ResidualAdd2<T: Clone + std::fmt::Debug> {
+        // input is Input
+        pub split: SplitInto<(Id, Id)>,
+
+        // input is (Input, Input)
+        pub input_to_wrapper: split2::FromTuple,
+
+        // input is Split2 ( Input, Input )
+        pub t: On<split2::_0, T>,
+
+        // input is Split2 ( T::Output, Input )
+        pub input_to_tuple: split2::IntoTuple,
+
+        // input is (T::Output, Input)
+        pub add: ops::Add,
+        // input is T::Output = Input
+    }
+
+    #[test]
+    fn test_residual_add_backward2() {
+        let dev: TestDevice = Default::default();
+
+        let model = dev.build_module::<f32>(<ResidualAdd2<LinearConstConfig<2, 2>>>::default());
+
+        let x: Tensor<Rank2<4, 2>, f32, _> = dev.sample_normal();
+        let x = x.to_dtype::<TestDtype>();
+        let y = model.forward(x.leaky_trace());
+
+        #[rustfmt::skip]
+        assert_close_to_literal!(y, [[0.25372928, -2.4258814],[1.7892148, -2.6242268],[1.5131638, 0.23407778],[3.4201493, 1.597525]]);
+
+        let g = y.mean().backward();
+        assert_close_to_literal!(g.get(&model.t.t.weight), [[0.475242, -0.075136]; 2]);
+        assert_close_to_literal!(g.get(&model.t.t.bias), [0.5; 2]);
+        assert_close_to_literal!(g.get(&x), [[0.18806472, 0.21419683]; 4]);
+    }
+}

--- a/dfdx/src/nn/layers/on.rs
+++ b/dfdx/src/nn/layers/on.rs
@@ -39,12 +39,6 @@ mod tests {
     use crate::tests::*;
 
     #[input_wrapper]
-    pub struct MyWrapper<A, B> {
-        pub a: A,
-        pub b: B,
-    }
-
-    #[input_wrapper]
     pub struct Split1<Forward, Skip> {
         pub forward: Forward,
         pub skip: Skip,
@@ -73,8 +67,20 @@ mod tests {
     fn test_residual_add_backward() {
         let dev: TestDevice = Default::default();
 
-        let model =
-            dev.build_module::<TestDtype>(<ResidualAdd1<LinearConstConfig<2, 2>>>::default());
+        let model = dev.build_module::<f32>(<ResidualAdd1<LinearConstConfig<2, 2>>>::default());
+        let model = DeviceResidualAdd1::<LinearConstConfig<2, 2>, TestDtype, TestDevice> {
+            t: On {
+                t: Linear {
+                    weight: model.t.t.weight.to_dtype::<TestDtype>(),
+                    bias: model.t.t.bias.to_dtype::<TestDtype>(),
+                },
+                _n: Default::default(),
+            },
+            add: Default::default(),
+            input_to_tuple: Default::default(),
+            input_to_wrapper: Default::default(),
+            split: Default::default(),
+        };
 
         let x: Tensor<Rank2<4, 2>, f32, _> = dev.sample_normal();
         let x = x.to_dtype::<TestDtype>();
@@ -115,8 +121,20 @@ mod tests {
     fn test_residual_add_backward2() {
         let dev: TestDevice = Default::default();
 
-        let model =
-            dev.build_module::<TestDtype>(<ResidualAdd2<LinearConstConfig<2, 2>>>::default());
+        let model = dev.build_module::<f32>(<ResidualAdd2<LinearConstConfig<2, 2>>>::default());
+        let model = DeviceResidualAdd2::<LinearConstConfig<2, 2>, TestDtype, TestDevice> {
+            t: On {
+                t: Linear {
+                    weight: model.t.t.weight.to_dtype::<TestDtype>(),
+                    bias: model.t.t.bias.to_dtype::<TestDtype>(),
+                },
+                _n: Default::default(),
+            },
+            add: Default::default(),
+            input_to_tuple: Default::default(),
+            input_to_wrapper: Default::default(),
+            split: Default::default(),
+        };
 
         let x: Tensor<Rank2<4, 2>, f32, _> = dev.sample_normal();
         let x = x.to_dtype::<TestDtype>();

--- a/dfdx/src/nn/layers/on.rs
+++ b/dfdx/src/nn/layers/on.rs
@@ -4,13 +4,12 @@ use std::marker::PhantomData;
 // TODO: try making a Call module, whih allows calling an arbitrary method on the input.
 
 /// Applies module `T` into an input field from a wrapper.
-#[derive(
-    Debug, Default, Clone, ResetParams, ZeroGrads, UpdateParams, LoadSafeTensors, SaveSafeTensors,
-)]
+#[cfg_attr(feature = "safetensors", derive(SaveSafeTensors, LoadSafeTensors))]
+#[derive(Debug, Default, Clone, ResetParams, ZeroGrads, UpdateParams)]
 #[repr(transparent)]
 pub struct On<N, T> {
     #[module]
-    #[serialize]
+    #[cfg_attr(feature = "safetensors", serialize)]
     pub t: T,
 
     pub _n: PhantomData<N>,

--- a/dfdx/src/nn/layers/on.rs
+++ b/dfdx/src/nn/layers/on.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 // TODO: try making a Call module, whih allows calling an arbitrary method on the input.
 
-/// Access the input that is stored in a wrapper structure.
+/// Applies module `T` into an input field from a wrapper.
 #[derive(
     Debug, Default, Clone, ResetParams, ZeroGrads, UpdateParams, LoadSafeTensors, SaveSafeTensors,
 )]
@@ -52,10 +52,10 @@ mod tests {
         // input is (Input, Input)
         pub input_to_wrapper: split1::FromTuple,
 
-        // input is Split1 { Input, Input }
+        // input is Split1<Input, Input>
         pub t: On<split1::forward, T>,
 
-        // input is Split1 { T::Output, Input }
+        // input is Split1<T::Output, Input>
         pub input_to_tuple: split1::IntoTuple,
 
         // input is (T::Output, Input)
@@ -64,7 +64,7 @@ mod tests {
     }
 
     #[test]
-    fn test_residual_add_backward() {
+    fn test_input_wrapper_struct() {
         let dev: TestDevice = Default::default();
 
         let model = dev.build_module::<f32>(<ResidualAdd1<LinearConstConfig<2, 2>>>::default());
@@ -106,10 +106,10 @@ mod tests {
         // input is (Input, Input)
         pub input_to_wrapper: split2::FromTuple,
 
-        // input is Split2 ( Input, Input )
+        // input is Split2<Input, Input>
         pub t: On<split2::_0, T>,
 
-        // input is Split2 ( T::Output, Input )
+        // input is Split2<T::Output, Input>
         pub input_to_tuple: split2::IntoTuple,
 
         // input is (T::Output, Input)
@@ -118,7 +118,7 @@ mod tests {
     }
 
     #[test]
-    fn test_residual_add_backward2() {
+    fn test_input_wrapper_tuple_struct() {
         let dev: TestDevice = Default::default();
 
         let model = dev.build_module::<f32>(<ResidualAdd2<LinearConstConfig<2, 2>>>::default());

--- a/dfdx/src/nn/layers/ops/add.rs
+++ b/dfdx/src/nn/layers/ops/add.rs
@@ -1,0 +1,20 @@
+use crate::prelude::*;
+
+/// Calls [crate::tensor_ops::add()]
+#[derive(Default, Debug, Clone, Copy, crate::nn::CustomModule)]
+pub struct Add;
+
+// TODO: macro for more tuples
+// TODO: lower the requirement, as long as one of the values can be broadcast into the other one
+// TODO: check if this works for constants
+
+impl<Input> Module<(Input, Input)> for Add
+where
+    Input: TryAdd,
+{
+    type Output = <Input as TryAdd>::Output;
+
+    fn try_forward(&self, x: (Input, Input)) -> Result<Self::Output, Error> {
+        x.0.try_add(x.1)
+    }
+}

--- a/dfdx/src/nn/layers/ops/mod.rs
+++ b/dfdx/src/nn/layers/ops/mod.rs
@@ -1,0 +1,3 @@
+mod add;
+
+pub use add::Add;


### PR DESCRIPTION
This is a draft, closes #878.  
Note: If this design ends up being useful, this could be implemented as a separated library (there are only code additions and they don't conflict with anything), but for perhaps feedback, it's better and more straight-forward to currently have this as a draft PR.

- Add `#[input_wrapper]`.
  - Add the heck dep to convert from CamelCase into snake_case.
- Add layers.
  - `Id`, which just forwards the input.
  - `On`, applies some Module into an input wrapper field.
    - Contains a test demonstrating it's usage.
  - `Add`, which calls `try_add` for the inputs.

This is how it gets used:
https://github.com/coreylowman/dfdx/blob/52b62649d38482ceea432027cabed08ceca12f52/dfdx/src/nn/layers/on.rs#L41-L64

This is what gets generated from the above:
<details> 
<summary>rust code</summary>
<p>

```rust
pub struct Split1<Forward, Skip> {
    pub forward: Forward,
    pub skip: Skip,
}
/// Automatically generated by `input_wrapper`. The containing items are visible on your project's documentation.
pub mod split1 {
    use super::Split1;
    /// Indicates the [`Split1::forward`] field.  \nThis field is the `0` value (`0`-based index).
    #[allow(non_camel_case_types)]
    #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
    pub struct forward;

    /// Indicates the [`Split1::skip`] field.  \nThis field is the `1` value (`0`-based index).
    #[allow(non_camel_case_types)]
    #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
    pub struct skip;

    /// Indicates a conversion from a (Forward, Skip) tuple into a `Split1<Forward, Skip>`.
    #[derive(
        Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, crate::prelude::CustomModule,
    )]
    pub struct FromTuple;

    /// Indicates a conversion from a `Split1<Forward, Skip>` into a (Forward, Skip) tuple.
    #[derive(
        Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, crate::prelude::CustomModule,
    )]
    pub struct IntoTuple;

    /// Conversion of a tuple into a [`Split1`].
    impl<Forward, Skip> From<(Forward, Skip)> for Split1<Forward, Skip> {
        fn from(x: (Forward, Skip)) -> Self {
            Split1 {
                forward: x.0,
                skip: x.1,
            }
        }
    }
    /// Conversion of a [`Split1`] into a tuple.
    impl<Forward, Skip> From<Split1<Forward, Skip>> for (Forward, Skip) {
        fn from(x: Split1<Forward, Skip>) -> Self {
            (x.forward, x.skip)
        }
    }
    /// Module to convert a tuple into a [`Split1`].
    impl<Forward, Skip> crate::prelude::Module<(Forward, Skip)> for FromTuple {
        type Output = Split1<Forward, Skip>;
        fn try_forward(&self, x: (Forward, Skip)) -> Result<Self::Output, crate::prelude::Error> {
            Ok(x.into())
        }
    }
    /// Module to convert a [`Split1`] into a tuple.
    impl<Forward, Skip> crate::prelude::Module<Split1<Forward, Skip>> for IntoTuple {
        type Output = (Forward, Skip);
        fn try_forward(
            &self,
            x: Split1<Forward, Skip>,
        ) -> Result<Self::Output, crate::prelude::Error> {
            Ok(x.into())
        }
    }
    /// Module that access [`Split1::forward`] and then applies Module `M` on it.
    impl<M: crate::prelude::Module<Forward>, Forward, Skip>
        crate::prelude::Module<Split1<Forward, Skip>> for crate::prelude::On<forward, M>
    {
        type Output = Split1<<M as crate::prelude::Module<Forward>>::Output, Skip>;
        fn try_forward(
            &self,
            x: Split1<Forward, Skip>,
        ) -> Result<Self::Output, crate::prelude::Error> {
            let x0 = x.forward;
            let x1 = x.skip;
            let x0 = self.t.try_forward(x0)?;
            let x = Split1 {
                forward: x0,
                skip: x1,
            };
            Ok(x)
        }
        fn try_forward_mut(
            &mut self,
            x: Split1<Forward, Skip>,
        ) -> Result<Self::Output, crate::prelude::Error> {
            let x0 = x.forward;
            let x1 = x.skip;
            let x0 = self.t.try_forward_mut(x0)?;
            let x = Split1 {
                forward: x0,
                skip: x1,
            };
            Ok(x)
        }
    }
    /// Module that access [`Split1::skip`] and then applies Module `M` on it.
    impl<M: crate::prelude::Module<Skip>, Forward, Skip>
        crate::prelude::Module<Split1<Forward, Skip>> for crate::prelude::On<skip, M>
    {
        type Output = Split1<Forward, <M as crate::prelude::Module<Skip>>::Output>;
        fn try_forward(
            &self,
            x: Split1<Forward, Skip>,
        ) -> Result<Self::Output, crate::prelude::Error> {
            let x0 = x.forward;
            let x1 = x.skip;
            let x1 = self.t.try_forward(x1)?;
            let x = Split1 {
                forward: x0,
                skip: x1,
            };
            Ok(x)
        }
        fn try_forward_mut(
            &mut self,
            x: Split1<Forward, Skip>,
        ) -> Result<Self::Output, crate::prelude::Error> {
            let x0 = x.forward;
            let x1 = x.skip;
            let x1 = self.t.try_forward_mut(x1)?;
            let x = Split1 {
                forward: x0,
                skip: x1,
            };
            Ok(x)
        }
    }
}
```
</p>
</details>