### PR TITLE
Add missing backtick (`) in crate-level documentation

### DIFF
--- a/dfdx/src/lib.rs
+++ b/dfdx/src/lib.rs
@@ -224,7 +224,7 @@
 //! | Optimizer | dfdx | pytorch |
 //! | --- | --- | --- |
 //! | SGD | [nn::optim::Sgd] | `torch.optim.SGD` |
-//! | Adam | [nn::optim::Adam] | torch.optim.Adam` |
+//! | Adam | [nn::optim::Adam] | `torch.optim.Adam` |
 //! | AdamW | [nn::optim::Adam] with [nn::optim::WeightDecay::Decoupled] | `torch.optim.AdamW` |
 //! | RMSprop | [nn::optim::RMSprop] | `torch.optim.RMSprop` |
 //!


### PR DESCRIPTION
There was an open code block in the "Optimizers and Gradients" section, this PR closes it.