### PR TITLE
Added `TryUnstack` for tensors.

### DIFF
--- a/dfdx-core/Cargo.toml
+++ b/dfdx-core/Cargo.toml
@@ -35,7 +35,7 @@ num-traits = { workspace = true }
 safetensors = { workspace = true, optional = true }
 memmap2 = { workspace = true, optional = true }
 half = { version = "2.3.1", optional = true, features = ["num-traits", "rand_distr"] }
-gemm = { version = "0.16.14", default-features = false, optional = true, features = ["rayon"] }
+gemm = { version = "0.17.1", default-features = false, optional = true, features = ["rayon"] }
 rayon = { version = "1.7.0", optional = true }
 libm = { workspace = true }
 wgpu = { version = "0.18.0", features = ["glsl", "spirv"], optional = true }

--- a/dfdx-core/src/data/collate.rs
+++ b/dfdx-core/src/data/collate.rs
@@ -55,6 +55,7 @@ impl<A, B> Collate for Vec<(A, B)> {
 impl<'a, A, B> Collate for Vec<&'a (A, B)> {
     type Collated = (Vec<&'a A>, Vec<&'a B>);
     fn collated(self) -> Self::Collated {
+        #[allow(clippy::map_identity)]
         self.into_iter().map(|(a, b)| (a, b)).unzip()
     }
 }

--- a/dfdx-core/src/lib.rs
+++ b/dfdx-core/src/lib.rs
@@ -128,44 +128,6 @@ pub mod prelude {
     pub use crate::tensor_ops::*;
 }
 
-/// Sets a CPU `sse` flag to flush denormal floating point numbers to zero. The opposite of this is [keep_denormals()].
-///
-/// Some resources:
-/// 1. [Effects of Flush-To-Zero mode](https://developer.arm.com/documentation/dui0473/c/neon-and-vfp-programming/the-effects-of-using-flush-to-zero-mode?lang=en)
-/// 2. [When to use Flush-To-Zero mode](https://developer.arm.com/documentation/dui0473/c/neon-and-vfp-programming/when-to-use-flush-to-zero-mode?lang=en)
-pub fn flush_denormals_to_zero() {
-    #[cfg(all(target_arch = "x86", target_feature = "sse"))]
-    {
-        use std::arch::x86::{_MM_FLUSH_ZERO_ON, _MM_SET_FLUSH_ZERO_MODE};
-        unsafe { _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON) }
-    }
-
-    #[cfg(all(target_arch = "x86_64", target_feature = "sse"))]
-    {
-        use std::arch::x86_64::{_MM_FLUSH_ZERO_ON, _MM_SET_FLUSH_ZERO_MODE};
-        unsafe { _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON) }
-    }
-}
-
-/// Sets a CPU flag to keep denormal floating point numbers. The opposite of this is [flush_denormals_to_zero()].
-///
-/// Some resources:
-/// 1. [Effects of Flush-To-Zero mode](https://developer.arm.com/documentation/dui0473/c/neon-and-vfp-programming/the-effects-of-using-flush-to-zero-mode?lang=en)
-/// 2. [When to use Flush-To-Zero mode](https://developer.arm.com/documentation/dui0473/c/neon-and-vfp-programming/when-to-use-flush-to-zero-mode?lang=en)
-pub fn keep_denormals() {
-    #[cfg(all(target_arch = "x86", target_feature = "sse"))]
-    {
-        use std::arch::x86::{_MM_FLUSH_ZERO_OFF, _MM_SET_FLUSH_ZERO_MODE};
-        unsafe { _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF) }
-    }
-
-    #[cfg(all(target_arch = "x86_64", target_feature = "sse"))]
-    {
-        use std::arch::x86_64::{_MM_FLUSH_ZERO_OFF, _MM_SET_FLUSH_ZERO_MODE};
-        unsafe { _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_OFF) }
-    }
-}
-
 #[cfg(test)]
 pub(crate) mod tests {
     pub use num_traits::{Float, NumCast, Zero};

--- a/dfdx-core/src/shapes/shape.rs
+++ b/dfdx-core/src/shapes/shape.rs
@@ -121,17 +121,32 @@ where
 pub trait Array<T>: IntoIterator<Item = T> {
     type Dim: Dim;
     fn dim(&self) -> Self::Dim;
+    fn from_fn<F>(cb: F, len: Self::Dim) -> Self
+    where
+        F: FnMut(usize) -> T;
 }
 impl<T, const N: usize> Array<T> for [T; N] {
     type Dim = Const<N>;
     fn dim(&self) -> Self::Dim {
         Const
     }
+    fn from_fn<F>(cb: F, _len: Self::Dim) -> Self
+    where
+        F: FnMut(usize) -> T,
+    {
+        std::array::from_fn(cb)
+    }
 }
 impl<T> Array<T> for std::vec::Vec<T> {
     type Dim = usize;
     fn dim(&self) -> Self::Dim {
         self.len()
+    }
+    fn from_fn<F>(cb: F, len: Self::Dim) -> Self
+    where
+        F: FnMut(usize) -> T,
+    {
+        (0..len).map(cb).collect()
     }
 }
 

--- a/dfdx-core/src/tensor/gradients.rs
+++ b/dfdx-core/src/tensor/gradients.rs
@@ -153,7 +153,7 @@ impl<E, D: Storage<E>> Gradients<E, D> {
     #[inline]
     pub(crate) fn many_and_ref<L: Shape, R: Shape>(
         &mut self,
-        ls: &Vec<impl Tensorlike<L, E, D>>,
+        ls: &[impl Tensorlike<L, E, D>],
         r: &impl Tensorlike<R, E, D>,
     ) -> (Vec<&mut D::Vec>, &D::Vec) {
         for i in 0..ls.len() {

--- a/dfdx-core/src/tensor_ops/mod.rs
+++ b/dfdx-core/src/tensor_ops/mod.rs
@@ -209,6 +209,7 @@ mod sum_to;
 mod tanh;
 mod to_dtype;
 mod tri;
+mod unstack;
 mod upscale2d;
 mod var_to;
 
@@ -276,6 +277,7 @@ pub use sum_to::SumTo;
 pub use tanh::tanh;
 pub use to_dtype::{to_dtype, ToDtypeKernel};
 pub use tri::{lower_tri, upper_tri};
+pub use unstack::{SubDim, TryUnstack};
 pub use upscale2d::{
     Bilinear, GenericUpscale2D, NearestNeighbor, TryUpscale2D, Upscale2DKernel, UpscaleMethod,
 };

--- a/dfdx-core/src/tensor_ops/unstack/cpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/unstack/cpu_kernel.rs
@@ -1,0 +1,63 @@
+use crate::{
+    prelude::NoneTape,
+    shapes::*,
+    tensor::{unique_id, Cpu, Error, Tensor},
+};
+
+// note: in order to return NoneTape items and not require a tape type information T,
+// each element must be optional.
+impl<E: Dtype> super::UnstackKernel<E> for Cpu {
+    fn forward<S: Shape, OptionalItems>(
+        &self,
+        stack: Tensor<S, E, Self, NoneTape>,
+    ) -> Result<OptionalItems, Error>
+    where
+        S: super::SubDim,
+        OptionalItems: Array<Option<Tensor<S::Tail, E, Self, NoneTape>>, Dim = S::Head>,
+    {
+        let (head, tail) = stack.shape().sub_dim();
+        let stack_data = stack.data.as_slice();
+        let unstack_num_elements = tail.num_elements();
+        Ok(OptionalItems::from_fn(
+            |i| {
+                let mut data = self
+                    .try_alloc_elem(unstack_num_elements, E::default())
+                    // TODO: remove unwrap (needs try_from_fn)
+                    // https://github.com/rust-lang/rust/issues/89379
+                    .unwrap();
+
+                data.copy_from_slice(
+                    &stack_data[i * unstack_num_elements..(i + 1) * unstack_num_elements],
+                );
+
+                Some(Tensor {
+                    id: unique_id(),
+                    data: std::sync::Arc::new(data),
+                    shape: *tail.shape(),
+                    strides: tail.strides(),
+                    device: self.clone(),
+                    tape: NoneTape,
+                })
+            },
+            head,
+        ))
+    }
+    fn backward(
+        &self,
+        grad_stack: &mut Self::Vec,
+        grad_unstack: &Self::Vec,
+        unstack_idx: usize,
+    ) -> Result<(), Error> {
+        let unstack_num_elements = grad_unstack.len();
+        for (i, stacked) in grad_stack
+            .iter_mut()
+            .skip(unstack_idx * unstack_num_elements)
+            .take(unstack_num_elements)
+            .enumerate()
+        {
+            *stacked += grad_unstack[i];
+        }
+
+        Ok(())
+    }
+}

--- a/dfdx-core/src/tensor_ops/unstack/cuda_kernel.rs
+++ b/dfdx-core/src/tensor_ops/unstack/cuda_kernel.rs
@@ -1,0 +1,27 @@
+use crate::{
+    prelude::NoneTape,
+    shapes::*,
+    tensor::{Cuda, Error, Tensor},
+};
+use cudarc::types::CudaTypeName;
+
+impl<E: Dtype + CudaTypeName> super::UnstackKernel<E> for Cuda {
+    fn forward<S: Shape, OptionalItems>(
+        &self,
+        _stack: Tensor<S, E, Self, NoneTape>,
+    ) -> Result<OptionalItems, Error>
+    where
+        S: super::SubDim,
+        OptionalItems: Array<Option<Tensor<S::Tail, E, Self, NoneTape>>, Dim = S::Head>,
+    {
+        todo!()
+    }
+    fn backward(
+        &self,
+        _grad_stack: &mut Self::Vec,
+        _grad_unstack: &Self::Vec,
+        _unstack_idx: usize,
+    ) -> Result<(), Error> {
+        todo!()
+    }
+}

--- a/dfdx-core/src/tensor_ops/unstack/mod.rs
+++ b/dfdx-core/src/tensor_ops/unstack/mod.rs
@@ -1,4 +1,5 @@
 use crate::{shapes::*, tensor::*};
+use std::vec::Vec;
 
 mod cpu_kernel;
 #[cfg(feature = "cuda")]
@@ -21,15 +22,15 @@ mod webgpu_kernel;
 /// # use dfdx_core::prelude::*;
 /// # let dev: Cpu = Default::default();
 /// let stack: Tensor<Rank3<2, 3, 4>, f32, _> = dev.zeros();
-/// let [a, b]: [Tensor<Rank2<3, 4>, f32, _>; 2] = stack.unstack();
+/// let ([a, b], _tape): ([Tensor<Rank2<3, 4>, f32, _>; 2], _) = stack.unstack();
 /// ```
 ///
 /// Unstacking to a vec:
 /// ```rust
 /// # use dfdx_core::prelude::*;
 /// # let dev: Cpu = Default::default();
-/// let stack: Tensor<(usize, Const::<3>, Const::<4>>, f32, _> = dev.zeros_like(&(2, Const, Const));
-/// let unstack: Vec<Tensor<Rank2<3, 4>, f32, _>> = stack.unstack();
+/// let stack: Tensor<(usize, Const::<3>, Const::<4>), f32, _> = dev.zeros_like(&(2, Const, Const));
+/// let (unstack, _tape): (Vec<Tensor<Rank2<3, 4>, f32, _>>, _) = stack.unstack();
 /// ```
 pub trait TryUnstack<Head: Dim>: Sized {
     type Unstacked;

--- a/dfdx-core/src/tensor_ops/unstack/mod.rs
+++ b/dfdx-core/src/tensor_ops/unstack/mod.rs
@@ -1,0 +1,258 @@
+use crate::{shapes::*, tensor::*};
+
+mod cpu_kernel;
+#[cfg(feature = "cuda")]
+mod cuda_kernel;
+
+#[cfg(feature = "webgpu")]
+mod webgpu_kernel;
+
+/// Unstack a tensor along the first dimension into an array or vec of tensors.  
+///
+/// This is the opposite of [crate::prelude::TryStack].
+///
+/// A [Const] dim will be turned into an array of tensors, and
+/// a [usize] dim will be turned into a `Vec` of tensors.
+///
+/// **Pytorch equivalent** `torch.unbind` with `dim=0`.
+///
+/// Unstacking to an array:
+/// ```rust
+/// # use dfdx_core::prelude::*;
+/// # let dev: Cpu = Default::default();
+/// let stack: Tensor<Rank3<2, 3, 4>, f32, _> = dev.zeros();
+/// let [a, b]: [Tensor<Rank2<3, 4>, f32, _>; 2] = stack.unstack();
+/// ```
+///
+/// Unstacking to a vec:
+/// ```rust
+/// # use dfdx_core::prelude::*;
+/// # let dev: Cpu = Default::default();
+/// let stack: Tensor<(usize, Const::<3>, Const::<4>>, f32, _> = dev.zeros_like(&(2, Const, Const));
+/// let unstack: Vec<Tensor<Rank2<3, 4>, f32, _>> = stack.unstack();
+/// ```
+pub trait TryUnstack<Head: Dim>: Sized {
+    type Unstacked;
+
+    /// Unstack a tensor along the first dimension into an array or vec of tensors.  
+    fn unstack(self) -> Self::Unstacked {
+        self.try_unstack().unwrap()
+    }
+    /// Fallible version of [TryUnstack::unstack]
+    fn try_unstack(self) -> Result<Self::Unstacked, Error>;
+}
+
+impl<S: Shape, E: Dtype, D: UnstackKernel<E>, T, const N: usize> TryUnstack<Const<N>>
+    for Tensor<S, E, D, T>
+where
+    S: SubDim<Head = Const<N>>,
+    T: Tape<E, D>,
+{
+    type Unstacked = ([Tensor<S::Tail, E, D, T>; N], T);
+    fn try_unstack(self) -> Result<Self::Unstacked, Error> {
+        try_unstack::<[Option<Tensor<S::Tail, E, D, NoneTape>>; N], _, S, E, D, T>(self)
+    }
+}
+
+impl<S: Shape, E: Dtype, D: UnstackKernel<E>, T> TryUnstack<usize> for Tensor<S, E, D, T>
+where
+    S: SubDim<Head = usize>,
+    T: Tape<E, D>,
+{
+    type Unstacked = (Vec<Tensor<S::Tail, E, D, T>>, T);
+    fn try_unstack(self) -> Result<Self::Unstacked, Error> {
+        try_unstack::<Vec<Option<Tensor<S::Tail, E, D, NoneTape>>>, _, S, E, D, T>(self)
+    }
+}
+
+pub trait SubDim: Shape {
+    type Head: Dim;
+    type Tail: Shape;
+    fn sub_dim(&self) -> (Self::Head, Self::Tail);
+}
+
+impl<D1: Dim> SubDim for (D1,) {
+    type Head = D1;
+    type Tail = ();
+    fn sub_dim(&self) -> (Self::Head, Self::Tail) {
+        (self.0, ())
+    }
+}
+impl<D1: Dim, D2: Dim> SubDim for (D1, D2) {
+    type Head = D1;
+    type Tail = (D2,);
+    fn sub_dim(&self) -> (Self::Head, Self::Tail) {
+        (self.0, (self.1,))
+    }
+}
+impl<D1: Dim, D2: Dim, D3: Dim> SubDim for (D1, D2, D3) {
+    type Head = D1;
+    type Tail = (D2, D3);
+    fn sub_dim(&self) -> (Self::Head, Self::Tail) {
+        (self.0, (self.1, self.2))
+    }
+}
+impl<D1: Dim, D2: Dim, D3: Dim, D4: Dim> SubDim for (D1, D2, D3, D4) {
+    type Head = D1;
+    type Tail = (D2, D3, D4);
+    fn sub_dim(&self) -> (Self::Head, Self::Tail) {
+        (self.0, (self.1, self.2, self.3))
+    }
+}
+impl<D1: Dim, D2: Dim, D3: Dim, D4: Dim, D5: Dim> SubDim for (D1, D2, D3, D4, D5) {
+    type Head = D1;
+    type Tail = (D2, D3, D4, D5);
+    fn sub_dim(&self) -> (Self::Head, Self::Tail) {
+        (self.0, (self.1, self.2, self.3, self.4))
+    }
+}
+impl<D1: Dim, D2: Dim, D3: Dim, D4: Dim, D5: Dim, D6: Dim> SubDim for (D1, D2, D3, D4, D5, D6) {
+    type Head = D1;
+    type Tail = (D2, D3, D4, D5, D6);
+    fn sub_dim(&self) -> (Self::Head, Self::Tail) {
+        (self.0, (self.1, self.2, self.3, self.4, self.5))
+    }
+}
+
+pub trait UnstackKernel<E: Dtype>: Storage<E> {
+    fn forward<S: Shape, OptionalItems>(
+        &self,
+        stack: Tensor<S, E, Self, NoneTape>,
+    ) -> Result<OptionalItems, Error>
+    where
+        S: SubDim,
+        OptionalItems: Array<Option<Tensor<S::Tail, E, Self, NoneTape>>, Dim = S::Head>;
+    fn backward(
+        &self,
+        grad_stack: &mut Self::Vec,
+        grad_unstack: &Self::Vec,
+        unstack_idx: usize,
+    ) -> Result<(), Error>;
+}
+
+fn try_unstack<OptionalItems, Items, S: Shape, E: Dtype, D: UnstackKernel<E>, T>(
+    stack: Tensor<S, E, D, T>,
+) -> Result<(Items, T), crate::tensor::Error>
+where
+    S: SubDim,
+    T: Tape<E, D>,
+    OptionalItems: Array<Option<Tensor<S::Tail, E, D, NoneTape>>, Dim = S::Head>
+        + std::ops::IndexMut<usize, Output = Option<Tensor<S::Tail, E, D, NoneTape>>>,
+    Items: Array<Tensor<S::Tail, E, D, T>, Dim = S::Head>,
+{
+    let device = stack.device.clone();
+    let (head, _tail) = stack.shape().sub_dim();
+    let (stack, stack_tape) = stack.split_tape();
+
+    let stack_ghost = stack.ghost();
+
+    // list of optional tensors (all are Some)
+    let mut unstacks = device.forward::<_, OptionalItems>(stack)?;
+
+    // tensors from unstacks must get tapes inserted into them.
+    // to do this, from_fn is re-utilized, but this time without optionals
+    let unstacks = Items::from_fn(
+        |i| {
+            let unstack = std::mem::take(&mut unstacks[i]).unwrap();
+            let device = device.clone();
+            let stack_ghost = stack_ghost.clone();
+            let unstack_ghost = unstack.ghost();
+            let mut unstack_tape = T::default();
+
+            unstack_tape.add_backward_op(move |grads| {
+                grads.try_alloc_for(&stack_ghost)?;
+                grads.try_alloc_for(&unstack_ghost)?;
+                let (grad_stack, grad_unstack) = grads.mut_and_ref(&stack_ghost, &unstack_ghost);
+                device.backward(grad_stack, grad_unstack, i)
+            });
+            unstack.put_tape(unstack_tape)
+        },
+        head,
+    );
+
+    Ok((unstacks, stack_tape))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{tensor_ops::*, tests::*};
+
+    // note: based on a stack test
+    #[test]
+    fn test_valid_unstacks() {
+        let dev: TestDevice = Default::default();
+
+        {
+            let stack: Tensor<Rank1<3>, TestDtype, _> = dev.sample_normal();
+            let ([_x, _y, _z], _tape): ([Tensor<(), TestDtype, _>; 3], _) = stack.unstack();
+        }
+
+        {
+            let stack: Tensor<Rank2<3, 2>, TestDtype, _> = dev.sample_normal();
+            let ([_x, _y, _z], _tape): ([Tensor<Rank1<2>, TestDtype, _>; 3], _) = stack.unstack();
+        }
+
+        {
+            let stack: Tensor<(usize, Const<2>), TestDtype, _> =
+                dev.sample_normal_like(&(3, Const));
+            let (unstacks, _tape): (Vec<Tensor<Rank1<2>, _, _, _>>, _) = stack.unstack();
+            assert_eq!(unstacks.len(), 3);
+        }
+    }
+
+    // note: based on a stack test
+    #[test]
+    fn test_unstack_backwards() {
+        let dev: TestDevice = Default::default();
+        let stack: Tensor<Rank2<3, 2>, TestDtype, _> = dev.sample_normal();
+
+        let ([x, y, z], _tape): ([Tensor<Rank1<2>, TestDtype, _, _>; 3], _) =
+            stack.leaky_trace().unstack(); // r
+        assert_eq!(stack.array(), [x.array(), y.array(), z.array()]);
+
+        let x1 = x.retaped::<NoneTape>(); // r1
+        let y1 = y.retaped::<NoneTape>(); // r1
+        let z1 = z.retaped::<NoneTape>(); // r1
+        let x1g = x1.leaky_trace().exp().mean().backward(); // g1
+        let y1g = y1.leaky_trace().exp().mean().backward(); // g1
+        let z1g = z1.leaky_trace().exp().mean().backward(); // g1
+
+        let xg = x.exp().mean().backward(); // g
+        let yg = y.exp().mean().backward(); // g
+        let zg = z.exp().mean().backward(); // g
+
+        let x1_grad = x1g.get(&x1).array(); // r_grad
+        let y1_grad = y1g.get(&y1).array(); // r_grad
+        let z1_grad = z1g.get(&z1).array(); // r_grad
+
+        assert_eq!(
+            [x1_grad, [TestDtype::zero(); 2], [TestDtype::zero(); 2]],
+            xg.get(&stack).array()
+        );
+        assert_eq!(
+            [[TestDtype::zero(); 2], y1_grad, [TestDtype::zero(); 2]],
+            yg.get(&stack).array()
+        );
+        assert_eq!(
+            [[TestDtype::zero(); 2], [TestDtype::zero(); 2], z1_grad],
+            zg.get(&stack).array()
+        );
+
+        // extra check
+        let stack_g = stack
+            .leaky_trace()
+            .exp()
+            .mean::<_, Axis<1>>()
+            .sum()
+            .backward();
+        assert_eq!(
+            stack_g.get(&stack).array(),
+            [
+                xg.get(&stack).array()[0],
+                yg.get(&stack).array()[1],
+                zg.get(&stack).array()[2]
+            ]
+        );
+    }
+}

--- a/dfdx-core/src/tensor_ops/unstack/webgpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/unstack/webgpu_kernel.rs
@@ -1,11 +1,14 @@
 use crate::{prelude::NoneTape, shapes::*, tensor::Webgpu};
 use std::vec::Vec;
 
-impl<E: Dtype, Items> super::UnstackKernel<E, Items> for Webgpu {
-    fn forward<S: Shape>(&self, stack: Tensor<S, E, Self, NoneTape>) -> Result<Items, Error>
+impl<E: Dtype> super::UnstackKernel<E> for Webgpu {
+    fn forward<Items, S: Shape, T: Tape<E, Self>>(
+        &self,
+        stack: Tensor<S, E, Self, NoneTape>,
+    ) -> Result<Items, Error>
     where
         S: super::SubDim,
-        Items: Array<Option<Tensor<S::Tail, E, Self, NoneTape>>, Dim = S::Head>,
+        Items: Array<Tensor<S::Tail, E, Self, T>, Dim = S::Head>,
     {
         todo!()
     }

--- a/dfdx-core/src/tensor_ops/unstack/webgpu_kernel.rs
+++ b/dfdx-core/src/tensor_ops/unstack/webgpu_kernel.rs
@@ -1,0 +1,20 @@
+use crate::{prelude::NoneTape, shapes::*, tensor::Webgpu};
+use std::vec::Vec;
+
+impl<E: Dtype, Items> super::UnstackKernel<E, Items> for Webgpu {
+    fn forward<S: Shape>(&self, stack: Tensor<S, E, Self, NoneTape>) -> Result<Items, Error>
+    where
+        S: super::SubDim,
+        Items: Array<Option<Tensor<S::Tail, E, Self, NoneTape>>, Dim = S::Head>,
+    {
+        todo!()
+    }
+    fn backward(
+        &self,
+        grad_stack: &mut Self::Vec,
+        grad_unstack: &Self::Vec,
+        unstack_idx: usize,
+    ) -> Result<(), Error> {
+        todo!()
+    }
+}

--- a/dfdx-core/src/tensor_ops/utilities/device.rs
+++ b/dfdx-core/src/tensor_ops/utilities/device.rs
@@ -21,6 +21,10 @@ pub trait Device<E: Dtype>:
     + super::super::concat_tensor_along::ConcatAlongKernel<E>
     + super::super::concat_tensor_along::ConcatAlongKernel<usize>
 
+    // splits
+    + super::super::unstack::UnstackKernel<E>
+    + super::super::unstack::UnstackKernel<usize>
+
     // optimizers
     + super::super::adam::AdamKernel<E>
     + super::super::sgd::SgdKernel<E>

--- a/dfdx-core/src/tensor_ops/utilities/device.rs
+++ b/dfdx-core/src/tensor_ops/utilities/device.rs
@@ -114,25 +114,49 @@ pub trait Device<E: Dtype>:
     + crate::tensor_ops::axpy::AxpyKernel<E>
 
     // conv1d
-    + super::super::conv1d::Conv1DKernel<E>
+    + NonCudnnCuda<E>
+{
+}
+
+#[cfg(feature = "cudnn")]
+pub trait NonCudnnCuda<E: Dtype> {}
+
+#[cfg(not(feature = "cudnn"))]
+pub trait NonCudnnCuda<E: Dtype>:
+    // conv1d
+    super::super::conv1d::Conv1DKernel<E>
 {
 }
 
 #[cfg(feature = "f16")]
-impl Device<f16> for crate::tensor::Cpu {}
-#[cfg(feature = "f16")]
-impl Device<AMP<f16>> for crate::tensor::Cpu {}
+mod f16_ {
+    use super::*;
+    impl Device<f16> for crate::tensor::Cpu {}
+    impl NonCudnnCuda<f16> for crate::tensor::Cpu {}
+    impl Device<AMP<f16>> for crate::tensor::Cpu {}
+    impl NonCudnnCuda<AMP<f16>> for crate::tensor::Cpu {}
+}
 impl Device<f32> for crate::tensor::Cpu {}
+impl NonCudnnCuda<f32> for crate::tensor::Cpu {}
 impl Device<f64> for crate::tensor::Cpu {}
+impl NonCudnnCuda<f64> for crate::tensor::Cpu {}
 
 #[cfg(all(feature = "cuda", feature = "f16"))]
-impl Device<f16> for crate::tensor::Cuda {}
-#[cfg(all(feature = "cuda", feature = "f16"))]
-impl Device<AMP<f16>> for crate::tensor::Cuda {}
+mod cuda_f16 {
+    use super::*;
+    impl Device<f16> for crate::tensor::Cuda {}
+    impl NonCudnnCuda<f16> for crate::tensor::Cuda {}
+    impl Device<AMP<f16>> for crate::tensor::Cuda {}
+    impl NonCudnnCuda<AMP<f16>> for crate::tensor::Cuda {}
+}
 #[cfg(feature = "cuda")]
-impl Device<f32> for crate::tensor::Cuda {}
-#[cfg(feature = "cuda")]
-impl Device<f64> for crate::tensor::Cuda {}
+mod cuda {
+    use super::*;
+    impl Device<f32> for crate::tensor::Cuda {}
+    impl NonCudnnCuda<f32> for crate::tensor::Cuda {}
+    impl Device<f64> for crate::tensor::Cuda {}
+    impl NonCudnnCuda<f64> for crate::tensor::Cuda {}
+}
 
 // TODO: How can we implement this for f16 when WGSL doesn't support f16 yet?
 // #[cfg(all(feature = "webgpu", feature = "f16"))]
@@ -140,7 +164,11 @@ impl Device<f64> for crate::tensor::Cuda {}
 // #[cfg(all(feature = "webgpu", feature = "f16"))]
 // impl Device<AMP<f16>> for crate::tensor::Webgpu {}
 #[cfg(feature = "webgpu")]
-impl Device<f32> for crate::tensor::Webgpu {}
+mod webgpu {
+    use super::*;
+    impl Device<f32> for crate::tensor::Webgpu {}
+    impl NonCudnnCuda<f32> for crate::tensor::Webgpu {}
+}
 
 // TODO: How can we implement this for f64 when WGSL doesn't support f64 yet?
 // #[cfg(feature = "webgpu")]

--- a/dfdx/examples/12-mnist.rs
+++ b/dfdx/examples/12-mnist.rs
@@ -62,9 +62,6 @@ type Mlp = (
 const BATCH_SIZE: usize = 32;
 
 fn main() {
-    // ftz substantially improves performance
-    dfdx::flush_denormals_to_zero();
-
     let mnist_path = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "./datasets/MNIST/raw".to_string());


### PR DESCRIPTION
- Adds the `try_/unstack` method for tensors.
- Also added `from_fn` for Arrays.
- This is similar to https://github.com/coreylowman/dfdx/pull/831 by @emchristiansen - thanks! I used your code for reference - but the difference is that this one also allows for unstacking into arrays instead of only unstacking into Vecs, which is closer to how the interface for `stack` currently works.
  - But note that this is only useful for "shape certainty" purposes, there shouldn't be much difference in performance.
  - Also, in this implementation, a two-pass array/vec construction is necessary, which does have a performance hit even for the Vec case.
    - This should be avoidable by having a method allowing to merge a tape into a tensor that already had a OwnedTape (instead of moving the tensor - which is necessary since the type is going to change - and splitting it), but in order to avoid adding such functionality I opted for a two-pass array/vec construction. 
- Together with https://github.com/coreylowman/dfdx/pull/917, may close https://github.com/coreylowman/dfdx/issues/825.

#### Remaining Tasks
- [ ] Decide on how to manage non-contiguous data - it's mandatory. Possibly panic at runtime.
- [ ] Add Cuda kernel.
- [ ] Consider adding function to merge a OwnedTape into a tensor which already has a OwnedTape, with a &mut to the tensor.
- [ ] Consider adding a layer, even though TryStack doesn't have one yet.
- [ ] Consider adding a `_vec` method that always realizes the first dimension into a usize before unstacking.
- [ ] Consider allowing the unstack for an arbitrary axis, similar to the concat interface.
  - Note: This is not present on the stack interface; Maybe this can be possible with a helper function that always transmutes that axis as the first one and then calls the unstack; Also this could be made by a future pr.